### PR TITLE
POC defm

### DIFF
--- a/lib/beaver/mlir/block.ex
+++ b/lib/beaver/mlir/block.ex
@@ -22,6 +22,11 @@ defmodule Beaver.MLIR.Block do
     MLIR.CAPI.mlirBlockAddArgument(block, t, loc)
   end
 
+  defp do_add_arg!(block, ctx, t = %Beaver.MLIR.Type{}) do
+    loc = MLIR.CAPI.mlirLocationUnknownGet(ctx)
+    do_add_arg!(block, ctx, {t, loc})
+  end
+
   defp do_add_arg!(block, ctx, {t, loc}) do
     t = MLIR.CAPI.mlirTypeParseGet(ctx, MLIR.StringRef.create(t))
     MLIR.CAPI.mlirBlockAddArgument(block, t, loc)

--- a/test/cf_test.exs
+++ b/test/cf_test.exs
@@ -1,5 +1,5 @@
 defmodule CfTest do
-  use Beaver.Case
+  use Beaver.Case, async: true
   use Beaver
   alias Beaver.MLIR
   alias Beaver.MLIR.Type

--- a/test/defm_test.exs
+++ b/test/defm_test.exs
@@ -1,5 +1,5 @@
 defmodule DefineMLIRTest do
-  use Beaver.Case
+  use Beaver.Case, async: true
 
   @moduletag :smoke
   test "cf with mutation", test_context do

--- a/test/defm_test.exs
+++ b/test/defm_test.exs
@@ -2,7 +2,7 @@ defmodule DefineMLIRTest do
   use Beaver.Case, async: true
 
   @moduletag :smoke
-  test "cf with mutation", test_context do
+  test "add two integers", test_context do
     defmodule AddTwoInt do
       use TranslateMLIR
 

--- a/test/defm_test.exs
+++ b/test/defm_test.exs
@@ -1,0 +1,14 @@
+defmodule DefineMLIRTest do
+  use Beaver.Case
+
+  @moduletag :smoke
+  test "cf with mutation", test_context do
+    defmodule AddTwoInt do
+      use TranslateMLIR
+
+      defm llvm_add(a :: i64, b :: i64) do
+        some_llvm_add_mlir_operation(a, b)
+      end
+    end
+  end
+end

--- a/test/defm_test.exs
+++ b/test/defm_test.exs
@@ -11,6 +11,6 @@ defmodule DefineMLIRTest do
       end
     end
 
-    AddTwoInt.llvm_add(1, 2)
+    assert 3 == AddTwoInt.llvm_add(1, 2)
   end
 end

--- a/test/defm_test.exs
+++ b/test/defm_test.exs
@@ -10,5 +10,7 @@ defmodule DefineMLIRTest do
         some_llvm_add_mlir_operation(a, b)
       end
     end
+
+    AddTwoInt.llvm_add(1, 2)
   end
 end

--- a/test/elixir_ast_dialect_test.exs
+++ b/test/elixir_ast_dialect_test.exs
@@ -4,40 +4,51 @@ defmodule ELXDialectTest do
   @moduletag :smoke
 
   test "gen elx from ast", test_context do
-    quote do
-      defmodule TwoFuncMod do
-        def add_two_literal() do
-          a = 1 + 2
-          b = a + 3
-          b
+    ast =
+      quote do
+        defmodule TwoFuncMod do
+          def add_two_literal() do
+            a = 1 + 2
+            b = a + 3
+            b
+          end
+
+          def main() do
+            add_two_literal()
+          end
         end
 
-        def main() do
-          add_two_literal()
+        defmodule OneFuncMod do
+          def add_two_literal() do
+            a = 1 + 2
+            b = a + 3
+            b
+          end
         end
       end
 
-      defmodule OneFuncMod do
-        def add_two_literal() do
-          a = 1 + 2
-          b = a + 3
-          b
-        end
-      end
-    end
-    |> ElixirAST.from_ast(ctx: test_context[:ctx])
-    |> MLIR.dump!()
-    |> MLIR.Pass.Composer.nested(
-      "builtin.module",
-      [
-        {:nested, "func.func",
-         [
-           ElixirAST.MaterializeBoundVariables
-         ]}
-      ]
-    )
-    |> MLIR.Pass.Composer.run!()
-    |> MLIR.Operation.verify!()
-    |> MLIR.dump!()
+    mlir_module =
+      ast
+      |> ElixirAST.from_ast(ctx: test_context[:ctx])
+      |> MLIR.Pass.Composer.nested(
+        "builtin.module",
+        [
+          {:nested, "func.func",
+           [
+             ElixirAST.MaterializeBoundVariables
+           ]}
+        ]
+      )
+      |> MLIR.Pass.Composer.run!()
+      |> MLIR.Operation.verify!()
+
+    {_, op_names} =
+      mlir_module
+      |> Beaver.Walker.postwalk([], fn
+        %MLIR.Operation{} = op, acc -> {op, [MLIR.Operation.name(op) | acc]}
+        mlir, acc -> {mlir, acc}
+      end)
+
+    op_names |> Enum.map(fn n -> assert n not in ["ex.bind", "ex.var"] end)
   end
 end

--- a/test/elixir_ast_dialect_test.exs
+++ b/test/elixir_ast_dialect_test.exs
@@ -4,51 +4,40 @@ defmodule ELXDialectTest do
   @moduletag :smoke
 
   test "gen elx from ast", test_context do
-    ast =
-      quote do
-        defmodule TwoFuncMod do
-          def add_two_literal() do
-            a = 1 + 2
-            b = a + 3
-            b
-          end
-
-          def main() do
-            add_two_literal()
-          end
+    quote do
+      defmodule TwoFuncMod do
+        def add_two_literal() do
+          a = 1 + 2
+          b = a + 3
+          b
         end
 
-        defmodule OneFuncMod do
-          def add_two_literal() do
-            a = 1 + 2
-            b = a + 3
-            b
-          end
+        def main() do
+          add_two_literal()
         end
       end
 
-    mlir_module =
-      ast
-      |> ElixirAST.from_ast(ctx: test_context[:ctx])
-      |> MLIR.Pass.Composer.nested(
-        "builtin.module",
-        [
-          {:nested, "func.func",
-           [
-             ElixirAST.MaterializeBoundVariables
-           ]}
-        ]
-      )
-      |> MLIR.Pass.Composer.run!()
-      |> MLIR.Operation.verify!()
-
-    {_, op_names} =
-      mlir_module
-      |> Beaver.Walker.postwalk([], fn
-        %MLIR.Operation{} = op, acc -> {op, [MLIR.Operation.name(op) | acc]}
-        mlir, acc -> {mlir, acc}
-      end)
-
-    op_names |> Enum.map(fn n -> assert n not in ["ex.bind", "ex.var"] end)
+      defmodule OneFuncMod do
+        def add_two_literal() do
+          a = 1 + 2
+          b = a + 3
+          b
+        end
+      end
+    end
+    |> ElixirAST.from_ast(ctx: test_context[:ctx])
+    |> MLIR.dump!()
+    |> MLIR.Pass.Composer.nested(
+      "builtin.module",
+      [
+        {:nested, "func.func",
+         [
+           ElixirAST.MaterializeBoundVariables
+         ]}
+      ]
+    )
+    |> MLIR.Pass.Composer.run!()
+    |> MLIR.Operation.verify!()
+    |> MLIR.dump!()
   end
 end

--- a/test/support/defm.ex
+++ b/test/support/defm.ex
@@ -5,6 +5,137 @@ defmodule TranslateMLIR do
     end
   end
 
+  use Beaver
+  alias Beaver.MLIR.Dialect.{Func, Arith}
+  alias Beaver.MLIR.Type
+  require Func
+
+  defp gen_mlir(
+         {:some_llvm_add_mlir_operation, _, [left, right]} = ast,
+         acc,
+         ctx,
+         block
+       ) do
+    value =
+      mlir ctx: ctx, block: block do
+        {[left, right], acc} =
+          Enum.reduce([left, right], {[], acc}, fn i, {ops, acc} ->
+            {r, acc} = Macro.prewalk(i, acc, &gen_mlir(&1, &2, ctx, Beaver.Env.block()))
+            {ops ++ [r], acc}
+          end)
+
+        Arith.addi(left, right) >>> Type.i64()
+      end
+
+    {value, acc}
+  end
+
+  defp gen_mlir(
+         {name, [line: _], nil},
+         acc,
+         ctx,
+         block
+       ) do
+    {acc.variables[name], acc}
+  end
+
+  defp gen_mlir(
+         ast,
+         acc,
+         ctx,
+         block
+       ) do
+    {ast, acc}
+  end
+
+  def compile_defm(call, expr, ctx) do
+    {name, args} = Macro.decompose_call(call)
+
+    mlir ctx: ctx do
+      arg_type_pairs =
+        for {:"::", _, [{a, _, nil}, type]} <- args do
+          t =
+            case type do
+              {:i64, _line, nil} ->
+                Type.i64(ctx: ctx)
+            end
+
+          {a, t}
+        end
+
+      arg_types = Enum.map(arg_type_pairs, &elem(&1, 1))
+
+      body_block = MLIR.Block.create([])
+
+      ret_type =
+        mlir ctx: ctx, block: body_block do
+          Beaver.MLIR.Block.add_arg!(
+            Beaver.Env.block(),
+            Beaver.Env.context(),
+            arg_types
+          )
+
+          variables =
+            for {{k, _}, i} <- Enum.with_index(arg_type_pairs) do
+              {k, Beaver.MLIR.Block.get_arg!(Beaver.Env.block(), i)}
+            end
+
+          acc_init = %{variables: Map.new(variables)}
+
+          {ret, _acc} =
+            Macro.prewalk(expr, acc_init, &gen_mlir(&1, &2, ctx, Beaver.Env.block()))
+
+          ret_val = ret[:do]
+          Func.return(ret_val) >>> []
+          MLIR.CAPI.mlirValueGetType(ret_val)
+        end
+
+      module do
+        Func.func main(
+                    sym_name: "\"#{name}\"",
+                    function_type: Type.function(arg_types, [ret_type])
+                  ) do
+          region do
+            MLIR.CAPI.mlirRegionAppendOwnedBlock(Beaver.Env.region(), body_block)
+          end
+        end
+      end
+    end
+  end
+
   defmacro defm(call, expr \\ nil) do
+    {name, args} = Macro.decompose_call(call)
+    args = for {:"::", _, [arg, type]} <- args, do: arg
+    ctx = MLIR.Context.create()
+
+    ir =
+      compile_defm(call, expr, ctx)
+      |> MLIR.dump!()
+      |> MLIR.Operation.verify!()
+      |> MLIR.to_string()
+
+    ctx = MLIR.Context.destroy(ctx)
+
+    quote do
+      @ir unquote(ir)
+      def unquote(name)(unquote_splicing(args)) do
+        ctx = MLIR.Context.create()
+
+        arguments = [unquote_splicing(args)] |> Enum.map(&Beaver.Native.I64.make/1)
+        return = Beaver.Native.I64.make(0)
+
+        jit =
+          ~m{#{@ir}}.(ctx)
+          |> MLIR.Pass.Composer.nested("func.func", "llvm-request-c-wrappers")
+          |> MLIR.Conversion.convert_arith_to_llvm()
+          |> MLIR.Conversion.convert_func_to_llvm()
+          |> MLIR.Pass.Composer.run!()
+          |> MLIR.dump!()
+          |> MLIR.ExecutionEngine.create!()
+
+        MLIR.ExecutionEngine.invoke!(jit, "#{unquote(name)}", arguments, return)
+        |> Beaver.Native.to_term()
+      end
+    end
   end
 end

--- a/test/support/defm.ex
+++ b/test/support/defm.ex
@@ -11,7 +11,7 @@ defmodule TranslateMLIR do
   require Func
 
   defp gen_mlir(
-         {:some_llvm_add_mlir_operation, _, [left, right]} = ast,
+         {:some_llvm_add_mlir_operation, _, [left, right]},
          acc,
          ctx,
          block
@@ -33,8 +33,8 @@ defmodule TranslateMLIR do
   defp gen_mlir(
          {name, [line: _], nil},
          acc,
-         ctx,
-         block
+         _ctx,
+         _block
        ) do
     {acc.variables[name], acc}
   end
@@ -42,8 +42,8 @@ defmodule TranslateMLIR do
   defp gen_mlir(
          ast,
          acc,
-         ctx,
-         block
+         _ctx,
+         _block
        ) do
     {ast, acc}
   end
@@ -105,7 +105,7 @@ defmodule TranslateMLIR do
 
   defmacro defm(call, expr \\ nil) do
     {name, args} = Macro.decompose_call(call)
-    args = for {:"::", _, [arg, type]} <- args, do: arg
+    args = for {:"::", _, [arg, _type]} <- args, do: arg
     ctx = MLIR.Context.create()
 
     ir =
@@ -114,7 +114,7 @@ defmodule TranslateMLIR do
       |> MLIR.Operation.verify!()
       |> MLIR.to_string()
 
-    ctx = MLIR.Context.destroy(ctx)
+    MLIR.Context.destroy(ctx)
 
     quote do
       @ir unquote(ir)

--- a/test/support/defm.ex
+++ b/test/support/defm.ex
@@ -1,0 +1,10 @@
+defmodule TranslateMLIR do
+  defmacro __using__(_) do
+    quote do
+      import TranslateMLIR
+    end
+  end
+
+  defmacro defm(call, expr \\ nil) do
+  end
+end

--- a/test/support/defm.ex
+++ b/test/support/defm.ex
@@ -64,24 +64,13 @@ defmodule TranslateMLIR do
         end
 
       arg_types = Enum.map(arg_type_pairs, &elem(&1, 1))
-
       body_block = MLIR.Block.create([])
+      args = Beaver.MLIR.Block.add_arg!(body_block, ctx, arg_types)
+      arg_names = Enum.map(arg_type_pairs, &elem(&1, 0))
+      acc_init = %{variables: Map.new(Enum.zip(arg_names, args))}
 
       ret_type =
         mlir ctx: ctx, block: body_block do
-          Beaver.MLIR.Block.add_arg!(
-            Beaver.Env.block(),
-            Beaver.Env.context(),
-            arg_types
-          )
-
-          variables =
-            for {{k, _}, i} <- Enum.with_index(arg_type_pairs) do
-              {k, Beaver.MLIR.Block.get_arg!(Beaver.Env.block(), i)}
-            end
-
-          acc_init = %{variables: Map.new(variables)}
-
           {ret, _acc} =
             Macro.prewalk(expr, acc_init, &gen_mlir(&1, &2, ctx, Beaver.Env.block()))
 


### PR DESCRIPTION
```elixir
defmodule AddTwoInt do
  use TranslateMLIR

  defm llvm_add(a :: i64, b :: i64) do
    some_llvm_add_mlir_operation(a, b)
  end
end

assert 3 == AddTwoInt.llvm_add(1, 2)
```

```mlir
module {
  // this function is generated from AST
  func.func @llvm_add(%arg0: i64, %arg1: i64) -> i64 {
    %0 = arith.addi %arg0, %arg1 : i64
    return %0 : i64
  }
}
// the module above gets converted to LLVM, and get the module below
module {
  // this is the final LLVM function for @llvm_add
  llvm.func @llvm_add(%arg0: i64, %arg1: i64) -> i64 attributes {llvm.emit_c_interface} {
    %0 = llvm.add %arg0, %arg1  : i64
    llvm.return %0 : i64
  }
  // this is the function C can call, which means we can call this function from JIT
  // in this function, we call @llvm_add
  // we can't call @llvm_add directly
  llvm.func @_mlir_ciface_llvm_add(%arg0: i64, %arg1: i64) -> i64 attributes {llvm.emit_c_interface} {
    %0 = llvm.call @llvm_add(%arg0, %arg1) : (i64, i64) -> i64
    llvm.return %0 : i64
  }
}
```