### PR TITLE
Compile for loop of literal integer list in `defm`

### DIFF
--- a/lib/beaver/mlir/execution_engine.ex
+++ b/lib/beaver/mlir/execution_engine.ex
@@ -58,27 +58,21 @@ defmodule Beaver.MLIR.ExecutionEngine do
   @doc """
   invoke a function by symbol name.
   """
-  def invoke!(jit, symbol, args, return) when is_list(args) do
+  def invoke!(jit, symbol, args, return \\ nil) when is_list(args) do
     arg_ptr_list = args |> Enum.map(&Beaver.Native.opaque_ptr/1)
-    return_ptr = return |> Beaver.Native.opaque_ptr()
-    result = do_invoke!(jit, symbol, arg_ptr_list ++ [return_ptr])
+
+    return_ptr =
+      if return do
+        return |> Beaver.Native.opaque_ptr()
+      else
+        []
+      end
+      |> List.wrap()
+
+    result = do_invoke!(jit, symbol, arg_ptr_list ++ return_ptr)
 
     if MLIR.LogicalResult.success?(result) do
-      return
-    else
-      raise "Execution engine invoke failed"
-    end
-  end
-
-  @doc """
-  invoke a void function by symbol name.
-  """
-  def invoke!(jit, symbol, args) when is_list(args) do
-    arg_ptr_list = args |> Enum.map(&Beaver.Native.opaque_ptr/1)
-    result = do_invoke!(jit, symbol, arg_ptr_list)
-
-    if MLIR.LogicalResult.success?(result) do
-      :ok
+      return || :ok
     else
       raise "Execution engine invoke failed"
     end

--- a/lib/beaver/mlir/type.ex
+++ b/lib/beaver/mlir/type.ex
@@ -111,7 +111,7 @@ defmodule Beaver.MLIR.Type do
       when is_list(shape) do
     rank = length(shape)
 
-    shape = shape |> Beaver.Native.array(Beaver.Native.I64)
+    shape = shape |> Enum.map(&escape_dynamic/1) |> Beaver.Native.array(Beaver.Native.I64)
 
     default_null = CAPI.mlirAttributeGetNull()
     layout = Keyword.get(opts, :layout) || default_null

--- a/test/defm_test.exs
+++ b/test/defm_test.exs
@@ -20,6 +20,12 @@ defmodule DefineMLIRTest do
         a = 2 + c + b + 1
         a
       end
+
+      defm llvm_for_loop(a :: i64, b :: i64) do
+        for i <- [1, 2, 3] do
+          i + a + b
+        end
+      end
     end
 
     assert 3 == AddTwoInt.llvm_add(1, 2)

--- a/test/defm_test.exs
+++ b/test/defm_test.exs
@@ -22,7 +22,7 @@ defmodule DefineMLIRTest do
       end
 
       defm llvm_for_loop(a :: i64, b :: i64) do
-        for i <- [1, 2, 3] do
+        for i <- [1, 2, 3, 4, 5] do
           i + a + b
         end
       end
@@ -31,5 +31,6 @@ defmodule DefineMLIRTest do
     assert 3 == AddTwoInt.llvm_add(1, 2)
     assert 5 == AddTwoInt.llvm_add1(2, 2)
     assert 7 == AddTwoInt.llvm_add_multi_lines(1, 1)
+    assert [0, 1, 2, 3, 4] == AddTwoInt.llvm_for_loop(-2, 1)
   end
 end

--- a/test/defm_test.exs
+++ b/test/defm_test.exs
@@ -26,6 +26,17 @@ defmodule DefineMLIRTest do
           i + a + b
         end
       end
+
+      defm llvm_for_loop2(a :: i64, b :: i64) do
+        l =
+          for i <- [1, 2, 3, 4, 5] do
+            i + a + b
+          end
+
+        for i <- l do
+          i + a + b
+        end
+      end
     end
 
     assert 3 == AddTwoInt.llvm_add(1, 2)

--- a/test/defm_test.exs
+++ b/test/defm_test.exs
@@ -29,12 +29,17 @@ defmodule DefineMLIRTest do
 
       defm llvm_for_loop2(a :: i64, b :: i64) do
         l =
-          for i <- [1, 2, 3, 4, 5] do
+          for i <- [1, 2, 3] do
             i + a + b
           end
 
-        for i <- l do
-          i + a + b
+        m =
+          for i <- [1, 2, 3, 4] do
+            i + a + b
+          end
+
+        for i <- l, j <- m, k <- m do
+          i + j + k + a + b
         end
       end
     end
@@ -42,6 +47,11 @@ defmodule DefineMLIRTest do
     assert 3 == AddTwoInt.llvm_add(1, 2)
     assert 5 == AddTwoInt.llvm_add1(2, 2)
     assert 7 == AddTwoInt.llvm_add_multi_lines(1, 1)
+
+    assert AddTwoInt.__original__llvm_add_multi_lines(111, 111) ==
+             AddTwoInt.llvm_add_multi_lines(111, 111)
+
     assert [0, 1, 2, 3, 4] == AddTwoInt.llvm_for_loop(-2, 1)
+    assert AddTwoInt.__original__llvm_for_loop2(2, 3) == AddTwoInt.llvm_for_loop2(2, 3)
   end
 end

--- a/test/support/defm.ex
+++ b/test/support/defm.ex
@@ -294,7 +294,7 @@ defmodule TranslateMLIR do
     {ir, return_convention}
   end
 
-  def compile_and_invoke(ir, function, arguments, return_config) when is_bitstring(ir) do
+  def compile_and_invoke(ir, function, arguments, return_convention) when is_bitstring(ir) do
     ctx = MLIR.Context.create()
     import MLIR.Conversion
 
@@ -311,12 +311,12 @@ defmodule TranslateMLIR do
       |> MLIR.ExecutionEngine.create!()
 
     %{mode: return_mode, maker: {mod, func, args}} =
-      return_config
+      return_convention
 
     return = apply(mod, func, args)
 
     return_arg =
-      if preparer = return_config[:preparer] do
+      if preparer = return_convention[:preparer] do
         {mod, func} = preparer
         apply(mod, func, [return])
       else
@@ -332,7 +332,7 @@ defmodule TranslateMLIR do
     end
 
     ret =
-      if postprocesser = return_config[:postprocesser] do
+      if postprocesser = return_convention[:postprocesser] do
         {mod, func} = postprocesser
         apply(mod, func, [return])
       else
@@ -349,7 +349,7 @@ defmodule TranslateMLIR do
     args = for {:"::", _, [arg, _type]} <- args, do: arg
     ctx = MLIR.Context.create()
 
-    {ir, return_config} =
+    {ir, return_convention} =
       compile_defm(call, expr, ctx)
 
     ir = ir |> MLIR.Operation.verify!() |> MLIR.to_string()
@@ -369,7 +369,7 @@ defmodule TranslateMLIR do
           @ir,
           unquote(name),
           arguments,
-          unquote(Macro.escape(return_config))
+          unquote(Macro.escape(return_convention))
         )
       end
     end

--- a/test/support/defm.ex
+++ b/test/support/defm.ex
@@ -80,7 +80,6 @@ defmodule TranslateMLIR do
             sum
         end)
 
-      # generate result to write to
       result =
         MemRef.alloc(size, operand_segment_sizes: Beaver.MLIR.ODS.operand_segment_sizes([1, 0])) >>>
           MLIR.Type.memref([:dynamic], MLIR.Type.i64())

--- a/test/support/defm.ex
+++ b/test/support/defm.ex
@@ -251,7 +251,7 @@ defmodule TranslateMLIR do
 
     ret_t = MLIR.CAPI.mlirValueGetType(ret_val)
 
-    return_maker =
+    return_convention =
       if MLIR.CAPI.mlirTypeIsAInteger(ret_t) |> Beaver.Native.to_term() do
         %{
           mode: :value,
@@ -291,7 +291,7 @@ defmodule TranslateMLIR do
         end)
       end
 
-    {ir, return_maker}
+    {ir, return_convention}
   end
 
   def compile_and_invoke(ir, function, arguments, return_config) when is_bitstring(ir) do

--- a/test/support/defm.ex
+++ b/test/support/defm.ex
@@ -256,7 +256,7 @@ defmodule TranslateMLIR do
         %{
           mode: :value,
           maker: {Beaver.Native.I64, :make, [0]},
-          postprocesser: {Beaver.Native, :to_term}
+          post_processor: {Beaver.Native, :to_term}
         }
       else
         if MLIR.CAPI.mlirTypeIsAMemRef(ret_t) |> Beaver.Native.to_term() do
@@ -264,7 +264,7 @@ defmodule TranslateMLIR do
             mode: :mutation,
             maker: {__MODULE__, :memref_descriptor_ptr, []},
             preparer: {Beaver.Native.Memory, :descriptor_ptr},
-            postprocesser: {__MODULE__, :parse_integers}
+            post_processor: {__MODULE__, :parse_integers}
           }
         else
           raise "ret type not supported"
@@ -332,8 +332,8 @@ defmodule TranslateMLIR do
     end
 
     ret =
-      if postprocesser = return_convention[:postprocesser] do
-        {mod, func} = postprocesser
+      if post_processor = return_convention[:post_processor] do
+        {mod, func} = post_processor
         apply(mod, func, [return])
       else
         return

--- a/test/support/defm.ex
+++ b/test/support/defm.ex
@@ -281,7 +281,11 @@ defmodule TranslateMLIR do
             end
           end
         end
-        |> MLIR.dump!()
+        |> tap(fn ir ->
+          if System.get_env("DEFM_DUMP_IR") == "1" do
+            MLIR.dump!(ir)
+          end
+        end)
       end
 
     {ir, return_maker}
@@ -300,7 +304,7 @@ defmodule TranslateMLIR do
       |> convert_func_to_llvm()
       |> MLIR.Pass.Composer.append("finalize-memref-to-llvm")
       |> reconcile_unrealized_casts
-      |> MLIR.Pass.Composer.run!(print: System.get_env("DEFM_PRINT_IR"))
+      |> MLIR.Pass.Composer.run!(print: System.get_env("DEFM_PRINT_IR") == "1")
       |> MLIR.ExecutionEngine.create!()
 
     ret =

--- a/test/support/defm.ex
+++ b/test/support/defm.ex
@@ -246,7 +246,7 @@ defmodule TranslateMLIR do
       |> convert_func_to_llvm()
       |> MLIR.Pass.Composer.append("finalize-memref-to-llvm")
       |> reconcile_unrealized_casts
-      |> MLIR.Pass.Composer.run!()
+      |> MLIR.Pass.Composer.run!(print: System.get_env("DEFM_PRINT_IR"))
       |> MLIR.ExecutionEngine.create!()
 
     ret =

--- a/test/support/defm.ex
+++ b/test/support/defm.ex
@@ -27,9 +27,10 @@ defmodule TranslateMLIR do
       {values, acc} = Macro.prewalk(list, acc, &gen_mlir(&1, &2, ctx, block))
 
       mlir ctx: ctx, block: block do
+        # generate result to write to
+        result = MemRef.alloc() >>> MLIR.Type.memref([length(list)], MLIR.Type.i64())
         # generate list literal
         memref = MemRef.alloc() >>> MLIR.Type.memref([length(list)], MLIR.Type.i64())
-        result = MemRef.alloc() >>> MLIR.Type.memref([length(list)], MLIR.Type.i64())
 
         for {v, i} <- Enum.with_index(values) do
           indices = Index.constant(value: Attribute.index(i)) >>> Type.index()

--- a/test/support/defm.ex
+++ b/test/support/defm.ex
@@ -14,7 +14,7 @@ defmodule TranslateMLIR do
     mlir ctx: ctx, block: block do
       {ret, acc} = Macro.prewalk(do_block, acc, &gen_mlir(&1, &2, ctx, block))
       MemRef.store(ret, result, write_index) >>> []
-      {ret, acc}
+      {nil, acc}
     end
   end
 

--- a/test/support/defm.ex
+++ b/test/support/defm.ex
@@ -349,7 +349,7 @@ defmodule TranslateMLIR do
     args = for {:"::", _, [arg, _type]} <- args, do: arg
     ctx = MLIR.Context.create()
 
-    {ir, ret_maker} =
+    {ir, return_config} =
       compile_defm(call, expr, ctx)
 
     ir = ir |> MLIR.Operation.verify!() |> MLIR.to_string()
@@ -369,7 +369,7 @@ defmodule TranslateMLIR do
           @ir,
           unquote(name),
           arguments,
-          unquote(Macro.escape(ret_maker))
+          unquote(Macro.escape(return_config))
         )
       end
     end


### PR DESCRIPTION
```elixir
defm llvm_for_loop(a :: i64, b :: i64) do
  for i <- [1, 2, 3, 4, 5] do
    i + a + b
  end
end
assert [0, 1, 2, 3, 4] == AddTwoInt.llvm_for_loop(-2, 1)
```
```mlir
module {
  func.func @llvm_for_loop(%arg0: i64, %arg1: i64) -> memref<5xi64> {
    %c1_i64 = arith.constant 1 : i64
    %c2_i64 = arith.constant 2 : i64
    %c3_i64 = arith.constant 3 : i64
    %c4_i64 = arith.constant 4 : i64
    %c5_i64 = arith.constant 5 : i64
    %alloc = memref.alloc() : memref<5xi64>
    %alloca = memref.alloca() : memref<5xi64>
    %idx0 = index.constant 0
    memref.store %c1_i64, %alloca[%idx0] : memref<5xi64>
    %idx1 = index.constant 1
    memref.store %c2_i64, %alloca[%idx1] : memref<5xi64>
    %idx2 = index.constant 2
    memref.store %c3_i64, %alloca[%idx2] : memref<5xi64>
    %idx3 = index.constant 3
    memref.store %c4_i64, %alloca[%idx3] : memref<5xi64>
    %idx4 = index.constant 4
    memref.store %c5_i64, %alloca[%idx4] : memref<5xi64>
    %idx0_0 = index.constant 0
    %idx5 = index.constant 5
    %idx1_1 = index.constant 1
    scf.for %arg2 = %idx0_0 to %idx5 step %idx1_1 {
      %0 = memref.load %alloca[%arg2] : memref<5xi64>
      %1 = arith.addi %0, %arg0 : i64
      %2 = arith.addi %1, %arg1 : i64
      memref.store %2, %alloc[%arg2] : memref<5xi64>
    }
    return %alloc : memref<5xi64>
  }
}
```