### PR TITLE
Stop using `crypto` module

### DIFF
--- a/lib/beaver/mlir/dialect/memref.ex
+++ b/lib/beaver/mlir/dialect/memref.ex
@@ -22,10 +22,11 @@ defmodule Beaver.MLIR.Dialect.MemRef do
       when is_binary(txt) do
     {t, width} = {:i, 8}
     value = Attribute.dense_elements(txt, {t, width})
+    sym_name = :erlang.md5(txt) |> Base.encode16(case: :lower)
 
     arguments =
       arguments
-      |> Keyword.put_new(:sym_name, Attribute.string(:crypto.hash(:sha256, txt)))
+      |> Keyword.put_new(:sym_name, Attribute.string(sym_name))
       |> Keyword.put_new(:initial_value, value)
       |> Keyword.put_new(:type, ~t{memref<#{byte_size(txt)}x#{t}#{width}>})
 


### PR DESCRIPTION
- **New Features**
	- Updated the method for generating the `:sym_name` attribute, now using an MD5 hash.
  
- **Impact**
	- `mix test --no-compile` now runs without raising `(UndefinedFunctionError) function :crypto.hash/2 is undefined (module :crypto is not available)`