### PR TITLE
Save translate-c result to file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ all: zig_build
 zig_build: cmake_build
 	zig translate-c ${BEAVER_INCLUDE_DIR}/mlir-c/Beaver/wrapper.h --cache-dir ${ZIG_CACHE_DIR} \
 		-I ${BEAVER_INCLUDE_DIR} \
-		-I ${MLIR_INCLUDE_DIR} | elixir scripts/update_generated.exs \
+		-I ${MLIR_INCLUDE_DIR} | tee native/mlir-zig-proj/src/wrapper.h.zig | elixir scripts/update_generated.exs \
 			--elixir ${NATIVE_INSTALL_DIR}/capi_functions.ex \
 			--zig native/mlir-zig-proj/src/wrapper.zig
 	cd native/mlir-zig-proj && zig build --cache-dir ${ZIG_CACHE_DIR} \

--- a/native/mlir-zig-proj/.gitignore
+++ b/native/mlir-zig-proj/.gitignore
@@ -6,4 +6,4 @@ prod/src
 dev/src
 .cache
 compile_commands.json
-src/wrapper.zig
+src/wrapper.*

--- a/native/mlir-zig-proj/src/prelude.zig
+++ b/native/mlir-zig-proj/src/prelude.zig
@@ -1,8 +1,4 @@
-pub const c = @cImport({
-    @cDefine("_NO_CRT_STDIO_INLINE", "1");
-    @cInclude("mlir-c/Beaver/wrapper.h");
-});
-
+pub const c = @import("wrapper.h.zig");
 pub const MlirDiagnosticHandlerDeleteUserData = ?*const fn (?*anyopaque) callconv(.C) void;
 pub const MlirExternalPassConstruct = ?*const fn (?*anyopaque) callconv(.C) ?*anyopaque;
 pub const MlirExternalPassRun = ?*const fn (c.MlirOperation, c.MlirExternalPass, ?*anyopaque) callconv(.C) void;


### PR DESCRIPTION
- **New Features**
	- Enhanced the build process to generate a separate Zig wrapper file for better modularity and debugging. 
	- Streamlined integration of external C dependencies by simplifying import methods.
	- This should make the C-to-Zig source generation have a single source of truth.
	- Translating only once might reduce time it takes to build Zig project.

- **Chores**
	- Updated `.gitignore` to prevent tracking of all files matching the pattern `src/wrapper.*`, improving version control management.