### PR TITLE
Read the content of external_files.txt as `@external_resource`

### DIFF
--- a/lib/beaver/mlir/capi.ex
+++ b/lib/beaver/mlir/capi.ex
@@ -23,7 +23,9 @@ defmodule Beaver.MLIR.CAPI do
   end
 
   # setting up elixir re-compilation triggered by changes in external files
-  for path <- ~w{#{File.read!("external_files.txt")}} |> Enum.flat_map(&Path.wildcard/1) do
+  for path <-
+        ~w{#{Mix.Project.project_file() |> Path.dirname() |> Path.join("external_files.txt") |> File.read!()}}
+        |> Enum.flat_map(&Path.wildcard/1) do
     @external_resource path
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -83,6 +83,7 @@ defmodule Beaver.MixProject do
     ]
   end
 
+  @external_files __DIR__ |> Path.join("external_files.txt") |> File.read!()
   defp package() do
     [
       licenses: ["Apache-2.0", "MIT"],
@@ -91,7 +92,7 @@ defmodule Beaver.MixProject do
         lib .formatter.exs mix.exs README*
         checksum.exs
         external_files.txt
-        #{File.read!("external_files.txt")}
+        #{@external_files}
       }
     ]
   end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved file path handling for `external_files.txt`, enhancing flexibility and portability across different environments.
	- Introduced a new module attribute `@external_files` for better code clarity and maintainability in the package definition.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->