### PR TITLE
Use `Supervisor.child_spec/2` to override pass registrar spec

### DIFF
--- a/lib/beaver/mlir/pass.ex
+++ b/lib/beaver/mlir/pass.ex
@@ -30,9 +30,9 @@ defmodule Beaver.MLIR.Pass do
   @doc false
   def global_registrar_child_specs() do
     [
-      update_in(Agent.child_spec(fn -> nil end).start, fn {m, f, a} ->
-        {m, f, a ++ [[name: @registrar]]}
-      end),
+      Supervisor.child_spec(Agent,
+        start: {Agent, :start_link, [fn -> nil end, [name: @registrar]]}
+      ),
       Task.child_spec(fn ->
         Agent.update(@registrar, fn _ -> Beaver.MLIR.CAPI.mlirRegisterAllPasses() end, :infinity)
       end)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved initialization of agents with updated specifications for better performance and reliability.

- **Bug Fixes**
	- Enhanced functionality for managing child specifications of agents, ensuring more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->