### PR TITLE
Upcased normalized name for UB dialect

### DIFF
--- a/lib/beaver/mlir/dialect/registry.ex
+++ b/lib/beaver/mlir/dialect/registry.ex
@@ -37,6 +37,7 @@ defmodule Beaver.MLIR.Dialect.Registry do
   def normalize_dialect_name("irdl"), do: "IRDL"
   def normalize_dialect_name("mpi"), do: "MPI"
   def normalize_dialect_name("xegpu"), do: "XeGPU"
+  def normalize_dialect_name("ub"), do: "UB"
   def normalize_dialect_name(other), do: other |> Macro.camelize()
 
   defp unwrap_ctx_then(opts, cb) do

--- a/test/dialect_registry_test.exs
+++ b/test/dialect_registry_test.exs
@@ -57,7 +57,7 @@ defmodule DialectRegistryTest do
         {"tensor", "Tensor"},
         {"tosa", "TOSA"},
         {"transform", "Transform"},
-        {"ub", "Ub"},
+        {"ub", "UB"},
         {"vector", "Vector"},
         {"x86vector", "X86Vector"},
         {"xegpu", "XeGPU"},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced dialect name normalization to include "ub," which now returns "UB."
  
- **Bug Fixes**
	- Updated test cases to reflect the new expected output for the dialect name "ub," ensuring accurate capitalization in assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->