### PR TITLE
Upgrade MLIR to fix `mlirPassManagerEnableIRPrinting/8`

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
-mlir==20.0.0.2024120301+cuda.814ed93e; sys_platform == "linux" and platform_machine == "x86_64"
-mlir==20.0.0.2024120301+814ed93e; sys_platform != "linux" or platform_machine != "x86_64"
+mlir==20.0.0.2024120617+cuda.39451e45; sys_platform == "linux" and platform_machine == "x86_64"
+mlir==20.0.0.2024120617+39451e45; sys_platform != "linux" or platform_machine != "x86_64"
 --find-links https://github.com/makslevental/mlir-wheels/releases/expanded_assets/latest

--- a/lib/beaver/mlir/pass_manager.ex
+++ b/lib/beaver/mlir/pass_manager.ex
@@ -23,6 +23,7 @@ defmodule Beaver.MLIR.PassManager do
       !!Keyword.get(opts, :module_scope, false),
       !!Keyword.get(opts, :after_only_on_change, false),
       !!Keyword.get(opts, :after_only_on_failure, false),
+      MLIR.CAPI.mlirOpPrintingFlagsCreate(),
       MLIR.StringRef.create(Keyword.get(opts, :tree_printing_path, ""))
     )
   end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version of the `mlir` package in the development requirements to ensure compatibility and access to the latest features.
  
- **Bug Fixes**
	- Enhanced the IR printing functionality by adding new printing flags, improving the configuration options for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->