### PR TITLE
Fix lowering of `cf` and `arith` after upgrading MLIR

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Install MLIR (latest), via ${{ github.event_name }}
         if: inputs.mlir_wheel_version == 'latest' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'use-latest-mlir'))
         run: |
-          latest_version=$(curl -Ls https://makslevental.github.io/wheels | grep -oh '[0-9.]*+cuda.[a-z0-9]*' | tail -n 1)
+          latest_version=$(curl -Ls https://makslevental.github.io/wheels | grep -oh '[0-9.]*+cuda.[a-z0-9]*' | sort | tail -n 1)
           python3 -m pip install "mlir==${latest_version}" -f https://makslevental.github.io/wheels -U
           echo "LLVM_CONFIG_PATH=$(python3 -c 'import mlir;print(mlir.__path__[0])')/bin/llvm-config" >> "$GITHUB_ENV"
       - name: Install MLIR (fixed version), via ${{ github.event_name }}

--- a/bench/enif_support.ex
+++ b/bench/enif_support.ex
@@ -29,6 +29,7 @@ defmodule ENIFSupport do
     |> Beaver.Composer.nested("func.func", "llvm-request-c-wrappers")
     |> convert_scf_to_cf
     |> convert_arith_to_llvm()
+    |> convert_cf_to_llvm()
     |> convert_index_to_llvm()
     |> convert_func_to_llvm()
     |> Beaver.Composer.append("convert-vector-to-llvm{reassociate-fp-reductions}")

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
-mlir==20.0.0.2024120617+cuda.39451e45; sys_platform == "linux" and platform_machine == "x86_64"
-mlir==20.0.0.2024120617+39451e45; sys_platform != "linux" or platform_machine != "x86_64"
+mlir==20.0.0.2024122701+cuda.5d529c32; sys_platform == "linux" and platform_machine == "x86_64"
+mlir==20.0.0.2024122701+5d529c32; sys_platform != "linux" or platform_machine != "x86_64"
 --find-links https://github.com/makslevental/mlir-wheels/releases/expanded_assets/latest

--- a/test/capi_test.exs
+++ b/test/capi_test.exs
@@ -238,6 +238,7 @@ defmodule MlirTest do
   def lower_to_llvm(ctx, module) do
     pm = mlirPassManagerCreate(ctx)
     mlirPassManagerAddOwnedPass(pm, mlirCreateConversionConvertFuncToLLVMPass())
+    mlirPassManagerAddOwnedPass(pm, mlirCreateConversionArithToLLVMConversionPass())
     status = mlirPassManagerRunOnOp(pm, module)
 
     if not MLIR.LogicalResult.success?(status) do

--- a/test/cf_test.exs
+++ b/test/cf_test.exs
@@ -219,6 +219,7 @@ defmodule CfTest do
       import MLIR.{Transform, Conversion}
 
       ir
+      |> convert_cf_to_llvm()
       |> convert_arith_to_llvm
       |> Beaver.Composer.nested("func.func", "llvm-request-c-wrappers")
       |> Beaver.Composer.nested("func.func", {"DoNothing0", "func.func", fn _ -> :ok end})

--- a/test/e2e_test.exs
+++ b/test/e2e_test.exs
@@ -18,6 +18,7 @@ defmodule E2ETest do
       """.(ctx)
       |> canonicalize
       |> cse
+      |> convert_arith_to_llvm()
       |> convert_func_to_llvm
       |> convert_arith_to_llvm
       |> Beaver.Composer.run!()

--- a/test/memref_test.exs
+++ b/test/memref_test.exs
@@ -43,6 +43,8 @@ defmodule MemRefTest do
       )
       |> convert_scf_to_cf
       |> Beaver.Composer.append("finalize-memref-to-llvm")
+      |> convert_cf_to_llvm()
+      |> convert_arith_to_llvm()
       |> convert_func_to_llvm
       |> reconcile_unrealized_casts
       |> Beaver.Composer.run!()

--- a/test/support/translate.ex
+++ b/test/support/translate.ex
@@ -304,6 +304,7 @@ defmodule TranslateMLIR do
       |> Beaver.Composer.nested("func.func", "llvm-request-c-wrappers")
       |> convert_scf_to_cf
       |> convert_arith_to_llvm()
+      |> convert_cf_to_llvm()
       |> convert_index_to_llvm()
       |> convert_func_to_llvm()
       |> Beaver.Composer.append("finalize-memref-to-llvm")

--- a/test/tosa_test.exs
+++ b/test/tosa_test.exs
@@ -20,6 +20,8 @@ defmodule TosaTest do
     |> Beaver.Composer.nested("func.func", convert_math_to_llvm())
     |> Beaver.Composer.append("expand-strided-metadata")
     |> lower_affine()
+    |> convert_cf_to_llvm()
+    |> convert_arith_to_llvm()
     |> Beaver.Composer.append("finalize-memref-to-llvm")
     |> convert_func_to_llvm
     |> convert_index_to_llvm


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced MLIR transformation pipeline with new conversions for control flow and arithmetic operations to LLVM representation.
	- Updated JIT compilation process to include early conversion of arithmetic operations.
  
- **Bug Fixes**
	- Improved version selection logic for MLIR package installation to ensure the latest version is fetched accurately.

- **Documentation**
	- Updated tests to reflect new transformation steps in the MLIR pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->