### PR TITLE
Add `PassManager.enable_verifier/2`

### DIFF
--- a/lib/beaver/composer.ex
+++ b/lib/beaver/composer.ex
@@ -129,9 +129,13 @@ defmodule Beaver.Composer do
     txt
   end
 
-  @run_default_opts [debug: false, print: false, timing: false]
+  @run_default_opts [debug: false, print: false, timing: false, verifier: true]
 
-  @type run_option :: {:debug, boolean()} | {:print, boolean()} | {:timing, boolean()}
+  @type run_option ::
+          {:debug, boolean()}
+          | {:print, boolean()}
+          | {:timing, boolean()}
+          | {:verifier, boolean()}
   @type run_result :: {:ok, any()} | {:error, String.t()}
   @type composer :: __MODULE__.t()
   @spec run!(composer) :: operation
@@ -194,13 +198,14 @@ defmodule Beaver.Composer do
       ) do
     timing = Keyword.get(opts, :timing)
     debug = Keyword.get(opts, :debug)
+    verifier = !!Keyword.get(opts, :verifier)
     pm = to_pm(composer)
 
     if timing do
       pm |> beaverPassManagerEnableTiming()
     end
 
-    mlirPassManagerEnableVerifier(pm, true)
+    :ok = MLIR.PassManager.enable_verifier(pm, verifier)
 
     if debug do
       txt = pm |> MLIR.to_string()

--- a/lib/beaver/mlir/pass_manager.ex
+++ b/lib/beaver/mlir/pass_manager.ex
@@ -76,4 +76,6 @@ defmodule Beaver.MLIR.PassManager do
         Beaver.Native.check!(ret)
     end
   end
+
+  defdelegate enable_verifier(pm, enable), to: MLIR.CAPI, as: :mlirPassManagerEnableVerifier
 end

--- a/test/pass_test.exs
+++ b/test/pass_test.exs
@@ -223,7 +223,7 @@ defmodule PassTest do
       |> Beaver.Composer.nested("func.func", ErrInit)
       |> canonicalize()
 
-    pm = Beaver.Composer.init(composer)
+    pm = Beaver.Composer.init(composer, verifier: true)
     {:error, diagnostics} = MLIR.PassManager.run(pm, op)
 
     assert MLIR.Diagnostic.format(diagnostics) =~

--- a/test/support/toy_pass.ex
+++ b/test/support/toy_pass.ex
@@ -32,8 +32,6 @@ end
 defmodule ToyPassWithInit do
   @moduledoc false
   use Beaver
-  alias MLIR.Dialect.{Func, TOSA}
-  require Func
   use MLIR.Pass, on: "builtin.module"
 
   def initialize(ctx, nil) do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added configurable verifier option for pass manager initialization
  - Introduced ability to enable/disable verifier during pass execution

- **Improvements**
  - Enhanced flexibility in pass manager configuration
  - Updated default behavior to enable verifier by default

- **Code Cleanup**
  - Removed unnecessary module dependencies in test support module

The changes provide more control over verification processes during pass management, with a focus on improving initialization and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->