### PR TITLE
Remove GlobalRegistrar agent

### DIFF
--- a/lib/beaver/composer.ex
+++ b/lib/beaver/composer.ex
@@ -196,6 +196,7 @@ defmodule Beaver.Composer do
         %__MODULE__{} = composer,
         opts \\ @run_default_opts
       ) do
+    :ok = MLIR.Pass.ensure_all_registered!()
     timing = Keyword.get(opts, :timing)
     debug = Keyword.get(opts, :debug)
     verifier = !!Keyword.get(opts, :verifier)

--- a/lib/beaver/composer.ex
+++ b/lib/beaver/composer.ex
@@ -196,7 +196,6 @@ defmodule Beaver.Composer do
         %__MODULE__{} = composer,
         opts \\ @run_default_opts
       ) do
-    :ok = MLIR.Pass.ensure_all_registered!()
     timing = Keyword.get(opts, :timing)
     debug = Keyword.get(opts, :debug)
     verifier = !!Keyword.get(opts, :verifier)

--- a/lib/beaver/mlir/pass.ex
+++ b/lib/beaver/mlir/pass.ex
@@ -26,23 +26,17 @@ defmodule Beaver.MLIR.Pass do
     end
   end
 
-  @registrar __MODULE__.GlobalRegistrar
   @doc """
   Ensure all passes are registered with the global registry.
   """
   def ensure_all_registered!() do
-    :ok = Agent.get(@registrar, & &1, :infinity)
+    :ok = Beaver.MLIR.CAPI.beaver_raw_register_all_passes()
   end
 
   @registry __MODULE__.Registry
   @doc false
   def global_registrar_child_specs() do
     [
-      Supervisor.child_spec(Agent,
-        start:
-          {Agent, :start_link,
-           [&Beaver.MLIR.CAPI.beaver_raw_register_all_passes/0, [name: @registrar]]}
-      ),
       {Registry, keys: :unique, name: @registry}
     ]
   end

--- a/lib/beaver/mlir/pass.ex
+++ b/lib/beaver/mlir/pass.ex
@@ -36,9 +36,7 @@ defmodule Beaver.MLIR.Pass do
   @registry __MODULE__.Registry
   @doc false
   def global_registrar_child_specs() do
-    [
-      {Registry, keys: :unique, name: @registry}
-    ]
+    [Task.child_spec(&ensure_all_registered!/0), {Registry, keys: :unique, name: @registry}]
   end
 
   defp start_worker(name) do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,4 +6,5 @@ ExUnit.configure(
   ]
 )
 
+IO.puts("OS PID: #{System.pid()}")
 ExUnit.start()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Simplified MLIR pass registration process by removing agent-based state management
	- Streamlined global registrar initialization with direct method calls

- **Chores**
	- Added process ID logging in test helper for diagnostic purposes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->