### PR TITLE
Move wrapper.h.zig to prevent race conditions

### DIFF
--- a/native/Makefile
+++ b/native/Makefile
@@ -11,7 +11,8 @@ all: zig_build
 
 zig_translate:
 	mkdir -p ${NATIVE_INSTALL_DIR}
-	zig translate-c include/mlir-c/Beaver/wrapper.h -I include -I ${MLIR_INCLUDE_DIR} | tee src/wrapper.h.zig | elixir gen_wrapper.exs --elixir ${NATIVE_INSTALL_DIR}/capi_functions.ex --zig src/wrapper.zig
+	zig translate-c include/mlir-c/Beaver/wrapper.h -I include -I ${MLIR_INCLUDE_DIR} | tee ${MIX_APP_PATH}/wrapper.h.zig | elixir gen_wrapper.exs --elixir ${NATIVE_INSTALL_DIR}/capi_functions.ex --zig src/wrapper.zig
+	mv ${MIX_APP_PATH}/wrapper.h.zig src/wrapper.h.zig
 
 ${BUILD_STAMP}:
 	cmake -G Ninja -B ${CMAKE_BUILD_DIR} -DLLVM_DIR=${LLVM_CMAKE_DIR} -DMLIR_DIR=${MLIR_CMAKE_DIR} -DCMAKE_INSTALL_PREFIX=${NATIVE_INSTALL_DIR}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Makefile build process to modify the intermediate file location for Zig wrapper generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->