### PR TITLE
Register all passes when loading NIF lib

### DIFF
--- a/lib/beaver/mlir/capi.ex
+++ b/lib/beaver/mlir/capi.ex
@@ -99,5 +99,4 @@ defmodule Beaver.MLIR.CAPI do
   def beaver_raw_mlir_type_of_enif_obj(_ctx, _obj), do: :erlang.nif_error(:not_loaded)
   def beaver_raw_string_printer_callback(), do: :erlang.nif_error(:not_loaded)
   def beaver_raw_string_printer_flush(_sp), do: :erlang.nif_error(:not_loaded)
-  def beaver_raw_register_all_passes(), do: :erlang.nif_error(:not_loaded)
 end

--- a/lib/beaver/mlir/pass.ex
+++ b/lib/beaver/mlir/pass.ex
@@ -26,17 +26,10 @@ defmodule Beaver.MLIR.Pass do
     end
   end
 
-  @doc """
-  Ensure all passes are registered with the global registry.
-  """
-  def ensure_all_registered!() do
-    :ok = Beaver.MLIR.CAPI.beaver_raw_register_all_passes()
-  end
-
   @registry __MODULE__.Registry
   @doc false
   def global_registrar_child_specs() do
-    [Task.child_spec(&ensure_all_registered!/0), {Registry, keys: :unique, name: @registry}]
+    [{Registry, keys: :unique, name: @registry}]
   end
 
   defp start_worker(name) do

--- a/native/src/main.zig
+++ b/native/src/main.zig
@@ -20,6 +20,7 @@ const num_nifs = handwritten_nifs.len;
 export var nifs: [num_nifs]e.ErlNifFunc = handwritten_nifs;
 
 export fn nif_load(env: beam.env, _: [*c]?*anyopaque, _: beam.term) c_int {
+    pass.register_all_passes();
     kinda.open_internal_resource_types(env);
     kinda.Internal.OpaqueStruct.open_all(env);
     mlir_capi.open_all(env);

--- a/native/src/pass.zig
+++ b/native/src/pass.zig
@@ -196,19 +196,17 @@ const ManagerRunner = struct {
 
 var mutex: std.Thread.Mutex = .{};
 var all_passes_registered = false;
-fn register_all_passes(env: beam.env, _: c_int, _: [*c]const beam.term) !beam.term {
+pub fn register_all_passes() void {
     mutex.lock();
     defer mutex.unlock();
     if (!all_passes_registered) {
         all_passes_registered = true;
         c.mlirRegisterAllPasses();
     }
-    return beam.make_ok(env);
 }
 
 pub const nifs = .{
     result.nif("beaver_raw_create_mlir_pass", 8, CallbackDispatcher.create_mlir_pass).entry,
     result.nif("beaver_raw_run_pm_on_op_async", 2, ManagerRunner.run_pm_on_op).entry,
     result.nif("beaver_raw_destroy_pm_async", 1, ManagerRunner.destroy).entry,
-    result.nif("beaver_raw_register_all_passes", 0, register_all_passes).entry,
 };

--- a/test/support/beaver_case.ex
+++ b/test/support/beaver_case.ex
@@ -10,7 +10,6 @@ defmodule Beaver.Case do
       alias Beaver.MLIR
 
       setup do
-        Beaver.MLIR.Pass.ensure_all_registered!()
         ctx = MLIR.Context.create(unquote(options))
 
         on_exit(fn ->


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified pass registration process by removing `beaver_raw_register_all_passes()` function
	- Removed automatic pass registration step in test setup
	- Updated NIF loading to directly register passes

- **Changes**
	- Modified how passes are registered during NIF initialization
	- Streamlined module interfaces related to pass registration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->