### PR TITLE
Correctly mapping float type in native/src/enif_support.zig

### DIFF
--- a/bench/enif_add.ex
+++ b/bench/enif_add.ex
@@ -53,7 +53,7 @@ defmodule AddENIF do
           end
         end
 
-        Func.func point_one(function_type: Type.function([env_t], [term_t])) do
+        Func.func add_point_one(function_type: Type.function([env_t], [term_t])) do
           region do
             block _(env >>> env_t) do
               f = Attribute.float(Type.f64(), 0.1)

--- a/bench/enif_add.ex
+++ b/bench/enif_add.ex
@@ -48,6 +48,9 @@ defmodule AddENIF do
               right = LLVM.load(right_ptr) >>> Type.i64()
               sum = Arith.addi(left, right) >>> Type.i64()
               sum = ENIF.make_int64(env, sum) >>> :infer
+              f = Attribute.float(Type.f64(), 0.1)
+              f = Arith.constant(value: f) >>> ~t<f64>
+              ENIF.make_double(env, f) >>> :infer
               Func.return(sum) >>> []
             end
           end

--- a/bench/enif_add.ex
+++ b/bench/enif_add.ex
@@ -48,10 +48,18 @@ defmodule AddENIF do
               right = LLVM.load(right_ptr) >>> Type.i64()
               sum = Arith.addi(left, right) >>> Type.i64()
               sum = ENIF.make_int64(env, sum) >>> :infer
+              Func.return(sum) >>> []
+            end
+          end
+        end
+
+        Func.func point_one(function_type: Type.function([env_t], [term_t])) do
+          region do
+            block _(env >>> env_t) do
               f = Attribute.float(Type.f64(), 0.1)
               f = Arith.constant(value: f) >>> ~t<f64>
-              ENIF.make_double(env, f) >>> :infer
-              Func.return(sum) >>> []
+              f = ENIF.make_double(env, f) >>> :infer
+              Func.return(f) >>> []
             end
           end
         end

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
-mlir==21.0.0.2025031601+2091547d; sys_platform == "linux" and platform_machine == "x86_64"
-mlir==21.0.0.2025031601+2091547d; sys_platform != "linux" or platform_machine != "x86_64"
+mlir==21.0.0.2025042301+85b35a90; sys_platform == "linux" and platform_machine == "x86_64"
+mlir==21.0.0.2025042301+85b35a90; sys_platform != "linux" or platform_machine != "x86_64"
 --find-links https://github.com/makslevental/mlir-wheels/releases/expanded_assets/latest

--- a/lib/beaver/mlir/capi_codegen.ex
+++ b/lib/beaver/mlir/capi_codegen.ex
@@ -105,7 +105,9 @@ defmodule Beaver.MLIR.CAPI.CodeGen do
           :FrozenRewritePatternSet,
           :PDLPatternModule,
           :GreedyRewriteDriverConfig,
-          :TransformOptions
+          :TransformOptions,
+          :LinalgContractionDimensions,
+          :LinalgConvolutionDimensions
         ],
         &%KindDecl{module_name: Module.concat(Beaver.MLIR, &1)}
       ) ++

--- a/lib/beaver/mlir/dialect/registry.ex
+++ b/lib/beaver/mlir/dialect/registry.ex
@@ -24,7 +24,7 @@ defmodule Beaver.MLIR.Dialect.Registry do
   end
 
   def normalize_dialect_name(to_upcase)
-      when to_upcase in ~w{tosa gpu nvgpu omp nvvm llvm cf pdl rocdl spirv amx amdgpu scf acc dlti},
+      when to_upcase in ~w{tosa gpu nvgpu omp nvvm llvm cf pdl rocdl spirv amx amdgpu scf acc dlti smt},
       do: String.upcase(to_upcase)
 
   def normalize_dialect_name("memref"), do: "MemRef"

--- a/native/Makefile
+++ b/native/Makefile
@@ -11,7 +11,7 @@ all: zig_build
 
 zig_translate:
 	mkdir -p ${NATIVE_INSTALL_DIR}
-	clang -Xclang -ast-dump=json -fsyntax-only include/mlir-c/Beaver/wrapper.h -I include -I ${MLIR_INCLUDE_DIR} | tee ${MIX_APP_PATH}/wrapper.h.clang.ast.json | elixir gen_wrapper.exs --elixir ${NATIVE_INSTALL_DIR}/capi_functions.ex --zig src/wrapper.zig
+	zig cc -Xclang -ast-dump=json -fsyntax-only include/mlir-c/Beaver/wrapper.h -I include -I ${MLIR_INCLUDE_DIR} -o ${MIX_APP_PATH}/wrapper.h.clang.ast.out | tee ${MIX_APP_PATH}/wrapper.h.clang.ast.json | elixir gen_wrapper.exs --elixir ${NATIVE_INSTALL_DIR}/capi_functions.ex --zig src/wrapper.zig
 
 ${BUILD_STAMP}:
 	cmake -G Ninja -B ${CMAKE_BUILD_DIR} -DLLVM_DIR=${LLVM_CMAKE_DIR} -DMLIR_DIR=${MLIR_CMAKE_DIR} -DCMAKE_INSTALL_PREFIX=${NATIVE_INSTALL_DIR}

--- a/native/src/enif_support.zig
+++ b/native/src/enif_support.zig
@@ -86,7 +86,12 @@ fn mlir_i_type_of_size(env: beam.env, ctx: mlir_capi.Context.T, comptime t: type
 }
 
 fn mlir_f_type_of_size(env: beam.env, ctx: mlir_capi.Context.T, comptime t: type) !beam.term {
-    return mlir_capi.Type.resource.make(env, c.mlirFloatTypeGet(ctx, @bitSizeOf(t)));
+    const mlir_t = switch (@bitSizeOf(t)) {
+        32 => c.mlirF32TypeGet(ctx),
+        64 => c.mlirF64TypeGet(ctx),
+        else => @compileError("unsupported float type"),
+    };
+    return mlir_capi.Type.resource.make(env, mlir_t);
 }
 
 fn enif_mlir_type(env: beam.env, ctx: mlir_capi.Context.T, comptime t: type) !beam.term {
@@ -110,12 +115,12 @@ fn enif_mlir_type(env: beam.env, ctx: mlir_capi.Context.T, comptime t: type) !be
         },
         else => {
             const is_int = t == c_int or t == c_ulong or t == c_long or t == beam.env or t == usize or t == c_uint or t == i32 or t == u32 or t == i64 or t == u64;
-            const is_float = t == f32 or t == f64;
+            const is_float = t == f16 or t == f32 or t == f64;
             const is_struct = t == beam.resource_type or t == e.ErlNifCond;
             if (is_int or is_struct) {
                 return try mlir_i_type_of_size(env, ctx, t);
             } else if (is_float) {
-                return try mlir_i_type_of_size(env, ctx, t);
+                return try mlir_f_type_of_size(env, ctx, t);
             } else if (t == void) {
                 return beam.make_atom(env, "void");
             } else if (t == ?*anyopaque) {

--- a/native/src/enif_support.zig
+++ b/native/src/enif_support.zig
@@ -115,7 +115,7 @@ fn enif_mlir_type(env: beam.env, ctx: mlir_capi.Context.T, comptime t: type) !be
         },
         else => {
             const is_int = t == c_int or t == c_ulong or t == c_long or t == beam.env or t == usize or t == c_uint or t == i32 or t == u32 or t == i64 or t == u64;
-            const is_float = t == f16 or t == f32 or t == f64;
+            const is_float = t == f32 or t == f64;
             const is_struct = t == beam.resource_type or t == e.ErlNifCond;
             if (is_int or is_struct) {
                 return try mlir_i_type_of_size(env, ctx, t);

--- a/native/src/mlir_capi.zig
+++ b/native/src/mlir_capi.zig
@@ -80,6 +80,8 @@ pub const RewriterBase = MLIRKind("RewriterBase");
 pub const FrozenRewritePatternSet = MLIRKind("FrozenRewritePatternSet");
 pub const PDLPatternModule = MLIRKind("PDLPatternModule");
 pub const GreedyRewriteDriverConfig = MLIRKind("GreedyRewriteDriverConfig");
+pub const LinalgContractionDimensions = MLIRKind("LinalgContractionDimensions");
+pub const LinalgConvolutionDimensions = MLIRKind("LinalgConvolutionDimensions");
 
 pub const ExternalPass = MLIRKind("ExternalPass");
 pub const ExternalPassCallbacks = MLIRKind("ExternalPassCallbacks");
@@ -93,7 +95,7 @@ pub const TypeIDAllocator = MLIRKind("TypeIDAllocator");
 pub const TransformOptions = MLIRKind("TransformOptions");
 pub const LLVMThreadPool = MLIRKind2("MlirLlvmThreadPool", "LLVMThreadPool");
 pub const OperationState = MLIRKind2("MlirOperationState", "Operation.State");
-pub const allKinds = .{ Pass, LogicalResult, StringRef, Context, Location, ISize, Attribute, OpaquePtr, ShapedTypeComponentsCallback, TypeID, TypesCallback, Bool, Operation, IntegerSet, AffineExpr, StringCallback, DialectHandle, CInt, AffineMap, SparseTensorLevelType, F64, Type, I32, I64, CUInt, DialectRegistry, DiagnosticHandlerID, DiagnosticHandler, DiagnosticHandlerDeleteUserData, Diagnostic, DiagnosticSeverity, F32, U64, U32, U16, I16, U8, I8, USize, UnmanagedDenseResourceElementsAttrGetDeleteCallback, OpaqueArray, StringArray, NamedAttribute, PassManager, RewritePatternSet, Region, Module, ExecutionEngine, GenericCallback, ExternalPassConstruct, ExternalPassRun, Identifier, OperationState, SymbolTable, Value, Block, Dialect, ExternalPass, ExternalPassCallbacks, OpPassManager, AffineMapCompressUnusedSymbolsPopulateResult, SymbolTableWalkSymbolTablesCallback, OpOperand, AsmState, OperationWalkCallback, WalkOrder, BytecodeWriterConfig, OpPrintingFlags, LLVMThreadPool, TypeIDAllocator, TransformOptions, RewriterBase, FrozenRewritePatternSet, PDLPatternModule, GreedyRewriteDriverConfig, string_ref.Printer.ResourceKind };
+pub const allKinds = .{ Pass, LogicalResult, StringRef, Context, Location, ISize, Attribute, OpaquePtr, ShapedTypeComponentsCallback, TypeID, TypesCallback, Bool, Operation, IntegerSet, AffineExpr, StringCallback, DialectHandle, CInt, AffineMap, SparseTensorLevelType, F64, Type, I32, I64, CUInt, DialectRegistry, DiagnosticHandlerID, DiagnosticHandler, DiagnosticHandlerDeleteUserData, Diagnostic, DiagnosticSeverity, F32, U64, U32, U16, I16, U8, I8, USize, UnmanagedDenseResourceElementsAttrGetDeleteCallback, OpaqueArray, StringArray, NamedAttribute, PassManager, RewritePatternSet, Region, Module, ExecutionEngine, GenericCallback, ExternalPassConstruct, ExternalPassRun, Identifier, OperationState, SymbolTable, Value, Block, Dialect, ExternalPass, ExternalPassCallbacks, OpPassManager, AffineMapCompressUnusedSymbolsPopulateResult, SymbolTableWalkSymbolTablesCallback, OpOperand, AsmState, OperationWalkCallback, WalkOrder, BytecodeWriterConfig, OpPrintingFlags, LLVMThreadPool, TypeIDAllocator, TransformOptions, RewriterBase, FrozenRewritePatternSet, PDLPatternModule, GreedyRewriteDriverConfig, string_ref.Printer.ResourceKind, LinalgContractionDimensions, LinalgConvolutionDimensions };
 pub fn open_all(env: beam.env) void {
     inline for (allKinds) |k| {
         k.open_all(env);

--- a/test/dialect_registry_test.exs
+++ b/test/dialect_registry_test.exs
@@ -61,7 +61,8 @@ defmodule DialectRegistryTest do
         {"vector", "Vector"},
         {"x86vector", "X86Vector"},
         {"xegpu", "XeGPU"},
-        {"polynomial", "Polynomial"}
+        {"polynomial", "Polynomial"},
+        {"smt", "SMT"}
       ]
       |> MapSet.new()
 

--- a/test/enif_test.exs
+++ b/test/enif_test.exs
@@ -13,7 +13,7 @@ defmodule EnifTest do
 
   test "enif float api", %{ctx: ctx} do
     %ENIFSupport{engine: e} = s = AddENIF.init(ctx)
-    assert 0.1 == Beaver.ENIF.invoke(e, "point_one", [])
+    assert 0.1 == Beaver.ENIF.invoke(e, "add_point_one", [])
     ENIFSupport.destroy(s)
   end
 

--- a/test/enif_test.exs
+++ b/test/enif_test.exs
@@ -11,6 +11,12 @@ defmodule EnifTest do
     ENIFSupport.destroy(s)
   end
 
+  test "enif float api", %{ctx: ctx} do
+    %ENIFSupport{engine: e} = s = AddENIF.init(ctx)
+    assert 0.1 == Beaver.ENIF.invoke(e, "point_one", [])
+    ENIFSupport.destroy(s)
+  end
+
   test "query enif functions" do
     assert :enif_binary_to_term in Beaver.ENIF.functions()
   end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new function that returns the floating-point value 0.1.
  - Extended support for new MLIR resource kinds related to Linalg operations.
  - Included the "smt" dialect in the recognized dialects list.
- **Bug Fixes**
  - Corrected handling of floating-point types to ensure proper mapping to MLIR float types.
- **Tests**
  - Introduced a new test to verify the correct return of the floating-point value 0.1.
  - Updated dialect registry tests to include the new "smt" dialect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->