### PR TITLE
Only run Clang preprocessor with zig cc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,8 @@ jobs:
         with:
           repository: beaver-lodge/kinda
           path: kinda
+      - name: Strip dev suffix
+        run: sed -i 's/-dev//g' mix.exs
       - name: Build ARM
         if: ${{ matrix.image.platform == 'linux/arm64/v8' }}
         run: docker run --platform ${{ matrix.image.platform }} -v $PWD:/src -w /src/beaver ${{ vars.DOCKERHUB_USERNAME }}/beaver-livebook-${{ matrix.image.suffix }}:latest bash scripts/build-for-publish.sh
@@ -191,7 +193,7 @@ jobs:
         if: ${{ github.repository == 'beaver-lodge/beaver' && env.PRE_BUILT_RELEASE_GITHUB_TOKEN != null }}
         with:
           files: |
-            *.tar.gz
+            beaver/*.tar.gz
           repository: beaver-lodge/beaver-prebuilt
           token: ${{ secrets.PRE_BUILT_RELEASE_GITHUB_TOKEN }}
           tag_name: ${{ needs.generate_id.outputs.formatted_date }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,6 +184,7 @@ jobs:
           repository: beaver-lodge/kinda
           path: kinda
       - name: Strip dev suffix
+        working-directory: beaver
         run: sed -i 's/-dev//g' mix.exs
       - name: Build ARM
         if: ${{ matrix.image.platform == 'linux/arm64/v8' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
           mix clean
           mix test --exclude vulkan --exclude todo
       - name: Publish archives and packages
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: ${{ github.repository == 'beaver-lodge/beaver' && env.PRE_BUILT_RELEASE_GITHUB_TOKEN != null }}
         with:
           files: |
@@ -190,7 +190,7 @@ jobs:
         if: ${{ matrix.image.platform == 'linux/arm64/v8' }}
         run: docker run --platform ${{ matrix.image.platform }} -v $PWD:/src -w /src/beaver ${{ vars.DOCKERHUB_USERNAME }}/beaver-livebook-${{ matrix.image.suffix }}:latest bash scripts/build-for-publish.sh
       - name: Publish archives and packages
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: ${{ github.repository == 'beaver-lodge/beaver' && env.PRE_BUILT_RELEASE_GITHUB_TOKEN != null }}
         with:
           files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,9 +184,17 @@ jobs:
           repository: beaver-lodge/kinda
           path: kinda
       - name: Build ARM
-        continue-on-error: true
         if: ${{ matrix.image.platform == 'linux/arm64/v8' }}
         run: docker run --platform ${{ matrix.image.platform }} -v $PWD:/src -w /src/beaver ${{ vars.DOCKERHUB_USERNAME }}/beaver-livebook-${{ matrix.image.suffix }}:latest bash scripts/build-for-publish.sh
+      - name: Publish archives and packages
+        uses: softprops/action-gh-release@v1
+        if: ${{ github.repository == 'beaver-lodge/beaver' && env.PRE_BUILT_RELEASE_GITHUB_TOKEN != null }}
+        with:
+          files: |
+            *.tar.gz
+          repository: beaver-lodge/beaver-prebuilt
+          token: ${{ secrets.PRE_BUILT_RELEASE_GITHUB_TOKEN }}
+          tag_name: ${{ needs.generate_id.outputs.formatted_date }}
       - name: Build x86
         if: ${{ matrix.image.platform == 'linux/amd64' }}
         run: docker run -v $PWD:/src -w /src/beaver ${{ vars.DOCKERHUB_USERNAME }}/beaver-livebook-${{ matrix.image.suffix }}:latest bash scripts/build-for-publish.sh

--- a/native/Makefile
+++ b/native/Makefile
@@ -11,7 +11,7 @@ all: zig_build
 
 zig_translate:
 	mkdir -p ${NATIVE_INSTALL_DIR}
-	zig cc -Xclang -ast-dump=json -fsyntax-only include/mlir-c/Beaver/wrapper.h -I include -I ${MLIR_INCLUDE_DIR} -o ${MIX_APP_PATH}/wrapper.h.clang.ast.out | tee ${MIX_APP_PATH}/wrapper.h.clang.ast.json | elixir gen_wrapper.exs --elixir ${NATIVE_INSTALL_DIR}/capi_functions.ex --zig src/wrapper.zig
+	zig cc -E -Xclang -ast-dump=json include/mlir-c/Beaver/wrapper.h -I include -I ${MLIR_INCLUDE_DIR} | tee ${MIX_APP_PATH}/wrapper.h.clang.ast.json | elixir gen_wrapper.exs --elixir ${NATIVE_INSTALL_DIR}/capi_functions.ex --zig src/wrapper.zig
 
 ${BUILD_STAMP}:
 	cmake -G Ninja -B ${CMAKE_BUILD_DIR} -DLLVM_DIR=${LLVM_CMAKE_DIR} -DMLIR_DIR=${MLIR_CMAKE_DIR} -DCMAKE_INSTALL_PREFIX=${NATIVE_INSTALL_DIR}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the build process for improved handling of AST generation during preprocessing.
  - Enhanced the release workflow to publish ARM build artifacts automatically to a designated repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->