### PR TITLE
Mesh->Shard

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
-mlir==21.0.0.2025070701+cuda.dc5d353f; sys_platform == "linux" and platform_machine == "x86_64"
-mlir==21.0.0.2025070701+dc5d353f; sys_platform != "linux" or platform_machine != "x86_64"
+mlir==22.0.0.2025072601+cuda.1a4f0d61; sys_platform == "linux" and platform_machine == "x86_64"
+mlir==22.0.0.2025072601+1a4f0d61; sys_platform != "linux" or platform_machine != "x86_64"
 --find-links https://makslevental.github.io/wheels

--- a/test/dialect_registry_test.exs
+++ b/test/dialect_registry_test.exs
@@ -39,7 +39,6 @@ defmodule DialectRegistryTest do
         {"llvm", "LLVM"},
         {"math", "Math"},
         {"memref", "MemRef"},
-        {"mesh", "Mesh"},
         {"ml_program", "MLProgram"},
         {"mpi", "MPI"},
         {"nvgpu", "NVGPU"},
@@ -62,7 +61,8 @@ defmodule DialectRegistryTest do
         {"x86vector", "X86Vector"},
         {"xegpu", "XeGPU"},
         {"smt", "SMT"},
-        {"xevm", "XeVM"}
+        {"xevm", "XeVM"},
+        {"shard", "Shard"}
       ]
       |> MapSet.new()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the version of the `mlir` package used for development.

* **Tests**
  * Updated dialect registry tests to expect "shard" instead of "mesh" in the set of registered dialects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->