### PR TITLE
Remove leftover descriptor codegen

### DIFF
--- a/bench/enif_support.ex
+++ b/bench/enif_support.ex
@@ -36,7 +36,14 @@ defmodule ENIFSupport do
     |> reconcile_unrealized_casts
     |> Beaver.Composer.run!()
     |> then(fn m ->
-      e = MLIR.ExecutionEngine.create!(m, opt_level: 3) |> Beaver.ENIF.register_symbols()
+      libs =
+        MLIR.ExecutionEngine.runtime_libs()
+        |> Enum.filter(&String.contains?(&1, "libmlir_c_runner_utils"))
+
+      e =
+        MLIR.ExecutionEngine.create!(m, opt_level: 3, shared_lib_paths: libs)
+        |> Beaver.ENIF.register_symbols()
+
       %ENIFSupport{mod: m, engine: e}
     end)
   end

--- a/lib/beaver/mlir/capi_codegen.ex
+++ b/lib/beaver/mlir/capi_codegen.ex
@@ -2,53 +2,11 @@ defmodule Beaver.MLIR.CAPI.CodeGen do
   @moduledoc false
   alias Kinda.CodeGen.{KindDecl}
   @behaviour Kinda.CodeGen
-  defp memref_kind_functions(DescriptorUnranked) do
-    [
-      make: 5,
-      aligned: 1,
-      allocated: 1,
-      offset: 1
-    ]
-  end
-
-  defp memref_kind_functions(_) do
-    [
-      make: 5,
-      aligned: 1,
-      allocated: 1,
-      offset: 1,
-      sizes: 1,
-      strides: 1
-    ]
-  end
 
   @impl Kinda.CodeGen
   def kinds() do
-    for rank <- [
-          DescriptorUnranked,
-          Descriptor1D,
-          Descriptor2D,
-          Descriptor3D,
-          Descriptor4D,
-          Descriptor5D,
-          Descriptor6D,
-          Descriptor7D,
-          Descriptor8D,
-          Descriptor9D
-        ],
-        t <- [Complex.F32, U8, U16, U32, I8, I16, I32, I64, F32, F64] do
-      %KindDecl{
-        module_name: Module.concat([Beaver.Native, t, MemRef, rank]),
-        kind_functions: memref_kind_functions(rank)
-      }
-    end ++
-      [
-        %KindDecl{
-          module_name: Beaver.Native.Complex.F32
-        }
-      ] ++
-      Enum.map(
-        ~w[
+    Enum.map(
+      ~w[
           Type
           Pass
           LogicalResult
@@ -114,28 +72,28 @@ defmodule Beaver.MLIR.CAPI.CodeGen do
           PatternRewriter
           UnrankedMemRefDescriptor
         ],
-        &%KindDecl{module_name: Module.concat(Beaver.MLIR, &1)}
-      ) ++
+      &%KindDecl{module_name: Module.concat(Beaver.MLIR, &1)}
+    ) ++
       Enum.map(
-        [
-          :ISize,
-          :OpaquePtr,
-          :Bool,
-          :CInt,
-          :F64,
-          :I32,
-          :I64,
-          :CUInt,
-          :F32,
-          :U64,
-          :U32,
-          :U16,
-          :I8,
-          :I16,
-          :U8,
-          :USize,
-          :OpaqueArray,
-          :StringArray
+        ~w[
+          ISize
+          OpaquePtr
+          Bool
+          CInt
+          F64
+          I32
+          I64
+          CUInt
+          F32
+          U64
+          U32
+          U16
+          I8
+          I16
+          U8
+          USize
+          OpaqueArray
+          StringArray
         ],
         &%KindDecl{module_name: Module.concat(Beaver.Native, &1)}
       ) ++ [%KindDecl{module_name: Beaver.Printer, kind_functions: [make: 0]}]

--- a/lib/beaver/mlir/execution_engine.ex
+++ b/lib/beaver/mlir/execution_engine.ex
@@ -97,4 +97,8 @@ defmodule Beaver.MLIR.ExecutionEngine do
   end
 
   defdelegate destroy(jit), to: MLIR.CAPI, as: :mlirExecutionEngineDestroy
+
+  def runtime_libs do
+    Path.join([:code.priv_dir(:beaver), "lib", "*"]) |> Path.wildcard()
+  end
 end

--- a/lib/beaver/mlir/execution_engine.ex
+++ b/lib/beaver/mlir/execution_engine.ex
@@ -92,6 +92,11 @@ defmodule Beaver.MLIR.ExecutionEngine do
     )
   end
 
+  @doc """
+  Initialize the JIT runtime.
+
+  If not already initialized, this will be called implicitly when first invocation happens.
+  """
   def init(jit) do
     tap(jit, &MLIR.CAPI.mlirExecutionEngineInitialize/1)
   end

--- a/lib/beaver/mlir/execution_engine.ex
+++ b/lib/beaver/mlir/execution_engine.ex
@@ -98,6 +98,9 @@ defmodule Beaver.MLIR.ExecutionEngine do
 
   defdelegate destroy(jit), to: MLIR.CAPI, as: :mlirExecutionEngineDestroy
 
+  @doc """
+  Get the paths to the runtime libraries provided by MLIR.
+  """
   def runtime_libs do
     Path.join([:code.priv_dir(:beaver), "lib", "*"]) |> Path.wildcard()
   end

--- a/native/src/enif_support.zig
+++ b/native/src/enif_support.zig
@@ -109,7 +109,7 @@ fn enif_mlir_type(env: beam.env, ctx: mlir_capi.Context.T, comptime t: type) !be
             if (t == rt.BinaryMemRefDescriptor) {
                 return try binary_memref_type(env, ctx);
             } else if (t == beam.binary) {
-                return try parse_mlir_type(env, ctx, "!llvm.struct<(i64, ptr)>");
+                return try parse_mlir_type(env, ctx, rt.BinaryStructLLVMType);
             }
             return try mlir_i_type_of_size(env, ctx, t);
         },

--- a/native/src/runtime.zig
+++ b/native/src/runtime.zig
@@ -37,6 +37,7 @@ pub fn print_newline() callconv(.c) void {
 
 pub const BinaryMemRefDescriptor = @import("memref.zig").RankedMemRefDescriptor(1);
 pub const BinaryMemRefType = "memref<?xi8>";
+pub const BinaryStructLLVMType = "!llvm.struct<(i64, ptr)>";
 // Due to the change of function signature when MemRef is converted to LLVM, we can't implement this function with MLIR CAPI only.
 // One other way is to implement a conversion pass for LLVMConversionTarget in C++.
 const Ptr = *u8;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a public constant exposing the LLVM binary struct type for easier integration.

- Refactor
  - Streamlined generation of supported kinds and consolidated symbol lists to reduce redundancy and complexity.

- Chores
  - Updated struct binary type handling to reference the runtime-defined constant for consistency across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->