### PR TITLE
Support typed IRDL region descriptors in Beaver.Slang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ beaver-*.tar.gz.sha256
 
 .elixir_ls
 .dialyzer/
+.restraint/
 
 .zig-cache
 zig-out

--- a/.restraint.exs
+++ b/.restraint.exs
@@ -40,6 +40,7 @@
     mode: :project,
     frontend: :source,
     paths: ["lib/**/*.ex"],
+    cache_path: ".restraint/reach",
     contract_center_limit: 5,
     locality_limit: 6,
     satellite_limit: 7

--- a/lib/beaver/slang.ex
+++ b/lib/beaver/slang.ex
@@ -171,7 +171,7 @@ defmodule Beaver.Slang do
           op_applier slang_target_op: op, sym_name: "\"#{name}\"" do
             region do
               block _op() do
-                {args, ret} = constrain_f.(ip: Beaver.Env.block(), ctx: ctx)
+                {args, ret} = constrain_f.(Beaver.Env.block(), ctx)
 
                 case strip_variadicity(args) do
                   [] ->
@@ -254,6 +254,34 @@ defmodule Beaver.Slang do
     for {v, i} <- Enum.with_index(args), do: transform_variable(v, i)
   end
 
+  defp build_extra_constraints(extra_constraints) do
+    for {ast, {mod, func}} <- extra_constraints || [] do
+      quote do
+        apply(unquote(mod), unquote(func), [unquote(ast), block, ctx])
+      end
+    end
+  end
+
+  defp do_gen_region(:any, block, ctx) do
+    mlir ip: block, ctx: ctx do
+      IRDL.region() >>> ~t{!irdl.region}
+    end
+  end
+
+  defp do_gen_region({:sized, size}, block, ctx) when is_integer(size) do
+    mlir ip: block, ctx: ctx do
+      IRDL.region(numberOfBlocks: MLIR.Attribute.integer(MLIR.Type.i32(), size)) >>>
+        ~t{!irdl.region}
+    end
+  end
+
+  @doc false
+  def gen_region(regions, block, ctx) do
+    regions
+    |> List.wrap()
+    |> Enum.map(&do_gen_region(&1, block, ctx))
+  end
+
   # This function generates the AST for a creator function for an IRDL operation (like `irdl.operation`, `irdl.type`). It uses the transform_defop_pins/1 function to transform the pins, generates the MLIR code for the operation and its arguments, and applies the operation using op_applier/1.
   defp gen_creator(op, args_op, call, do_block, opts) do
     {name, args} = call |> Macro.decompose_call()
@@ -270,6 +298,8 @@ defmodule Beaver.Slang do
         transform_constraint(ast, i)
       end)
 
+    extra_constraints = build_extra_constraints(opts[:extra_constraints])
+
     quote do
       Module.put_attribute(__MODULE__, unquote(attr_name), unquote(name))
       @__slang__creator__ {unquote(op), __MODULE__, unquote(creator)}
@@ -278,11 +308,12 @@ defmodule Beaver.Slang do
           unquote(name),
           unquote(op),
           unquote(args_op),
-          fn opts ->
+          fn block, ctx ->
             use Beaver
 
-            mlir ip: Beaver.Deferred.fetch_insertion_point(opts), ctx: opts[:ctx] do
+            mlir ip: block, ctx: ctx do
               unquote_splicing(input_constrains)
+              unquote_splicing(extra_constraints)
               {[unquote_splicing(args_var_ast)], unquote(do_block)}
             end
           end,
@@ -362,7 +393,10 @@ defmodule Beaver.Slang do
   defmacro defop(call, block \\ nil) do
     gen_creator(:operation, :operands, call, block[:do],
       return_op: :results,
-      need_variadicity: true
+      need_variadicity: true,
+      extra_constraints: [
+        {block[:regions], {Beaver.Slang, :gen_region}}
+      ]
     )
   end
 

--- a/lib/beaver/slang.ex
+++ b/lib/beaver/slang.ex
@@ -262,17 +262,91 @@ defmodule Beaver.Slang do
     end
   end
 
-  defp do_gen_region(:any, block, ctx) do
-    mlir ip: block, ctx: ctx do
-      IRDL.region() >>> ~t{!irdl.region}
-    end
+  defp normalize_region_descriptor(:any) do
+    %{args: nil, size: nil}
   end
 
-  defp do_gen_region({:sized, size}, block, ctx) when is_integer(size) do
-    mlir ip: block, ctx: ctx do
-      IRDL.region(numberOfBlocks: MLIR.Attribute.integer(MLIR.Type.i32(), size)) >>>
-        ~t{!irdl.region}
-    end
+  defp normalize_region_descriptor({:sized, size}) when is_integer(size) and size > 0 do
+    %{args: nil, size: size}
+  end
+
+  defp normalize_region_descriptor({:region, opts}) when is_list(opts) do
+    opts = Keyword.validate!(opts, [:args, :size])
+
+    args =
+      case Keyword.get(opts, :args) do
+        nil -> nil
+        args -> List.wrap(args)
+      end
+
+    size =
+      case Keyword.get(opts, :size) do
+        nil ->
+          nil
+
+        size when is_integer(size) and size > 0 ->
+          size
+
+        size ->
+          raise ArgumentError,
+                "expected region size to be a positive integer, got: #{inspect(size)}"
+      end
+
+    %{args: args, size: size}
+  end
+
+  defp build_region_arguments(%{args: args, size: size}, block, ctx) do
+    constrained_args? = not is_nil(args)
+
+    args =
+      for arg <- args || [] do
+        create_constraint(arg, ip: block, ctx: ctx)
+      end
+
+    attrs =
+      []
+      |> then(fn attrs ->
+        if is_nil(size) do
+          attrs
+        else
+          attrs ++
+            [
+              numberOfBlocks:
+                Beaver.Deferred.create(
+                  MLIR.Attribute.integer(MLIR.Type.i32(), size),
+                  ctx
+                )
+            ]
+        end
+      end)
+      |> then(fn attrs ->
+        if constrained_args? do
+          attrs ++ [constrainedArguments: Beaver.Deferred.create(MLIR.Attribute.unit(), ctx)]
+        else
+          attrs
+        end
+      end)
+
+    args ++ attrs
+  end
+
+  defp do_gen_region(region, block, ctx) do
+    use Beaver
+
+    region_args =
+      region
+      |> normalize_region_descriptor()
+      |> build_region_arguments(block, ctx)
+
+    %Beaver.SSA{
+      arguments: region_args,
+      results: [Beaver.Deferred.create(~t{!irdl.region}, ctx)],
+      ip: block,
+      ctx: ctx,
+      loc: Beaver.Deferred.create(MLIR.Location.unknown(), ctx),
+      evaluator: &MLIR.Operation.eval_ssa/1
+    }
+    |> IRDL.region()
   end
 
   @doc false
@@ -282,6 +356,7 @@ defmodule Beaver.Slang do
     |> Enum.map(&do_gen_region(&1, block, ctx))
   end
 
+  @doc false
   # This function generates the AST for a creator function for an IRDL operation (like `irdl.operation`, `irdl.type`). It uses the transform_defop_pins/1 function to transform the pins, generates the MLIR code for the operation and its arguments, and applies the operation using op_applier/1.
   defp gen_creator(op, args_op, call, do_block, opts) do
     {name, args} = call |> Macro.decompose_call()

--- a/test/irdl_test.exs
+++ b/test/irdl_test.exs
@@ -69,4 +69,8 @@ defmodule IRDLTest do
     use Beaver
     TestVariadic.__slang_dialect__(ctx) |> MLIR.verify!()
   end
+
+  test "region dialect", %{ctx: ctx} do
+    TestRegion.__slang_dialect__(ctx) |> MLIR.verify!()
+  end
 end

--- a/test/irdl_test.exs
+++ b/test/irdl_test.exs
@@ -71,6 +71,14 @@ defmodule IRDLTest do
   end
 
   test "region dialect", %{ctx: ctx} do
-    TestRegion.__slang_dialect__(ctx) |> MLIR.verify!()
+    dialect =
+      TestRegion.__slang_dialect__(ctx)
+      |> MLIR.verify!()
+
+    rendered = MLIR.to_string(dialect)
+
+    assert rendered =~ "irdl.region()"
+    assert rendered =~ "irdl.region(%"
+    assert rendered =~ "with size 2"
   end
 end

--- a/test/support/region_dialect.ex
+++ b/test/support/region_dialect.ex
@@ -1,0 +1,8 @@
+defmodule TestRegion do
+  @moduledoc "An example to showcase a region dialect in IRDL test."
+  use Beaver.Slang, name: "test_region"
+
+  defop any_region(i = {:single, Type.i32()}), do: [], regions: [:any]
+  defop any_region2(i = {:single, Type.i32()}), do: [], regions: [:any, :any]
+  defop sized_region(), regions: {:sized, 11}
+end

--- a/test/support/region_dialect.ex
+++ b/test/support/region_dialect.ex
@@ -5,4 +5,11 @@ defmodule TestRegion do
   defop any_region(i = {:single, Type.i32()}), do: [], regions: [:any]
   defop any_region2(i = {:single, Type.i32()}), do: [], regions: [:any, :any]
   defop sized_region(), regions: {:sized, 11}
+  defop empty_args_region(), regions: {:region, args: []}
+
+  defop typed_args_region(),
+    regions: {:region, args: [Beaver.MLIR.Type.i32(), Beaver.MLIR.Type.i64()]}
+
+  defop sized_typed_region(),
+    regions: {:region, args: [Beaver.MLIR.Type.i32()], size: 2}
 end


### PR DESCRIPTION
## Summary

This continues the old IRDL region-constraint refactor and lands it on the current codebase.

`Beaver.Slang.defop` now supports IRDL region constraints through `regions:` and can generate region constraints directly in the IRDL dialect definition.

Supported region descriptors now include:

- `:any`
- `{:sized, n}`
- `{:region, args: [...], size: n}`

This means we can now express:

- unconstrained regions
- fixed block-count regions
- regions with explicitly constrained entry block arguments
- regions that constrain both entry args and block cardinality

## Implementation

- wire `defop` extra constraints into the IRDL operation builder
- generate `irdl.region` constraints from normalized region descriptors
- build region constraints through SSA / `IRDL.region()` instead of relying on ad hoc surface DSL forms
- support empty arg lists as a first-class "no entry block args" constraint

## Tests

Added a dedicated region dialect fixture and coverage for:

- `irdl.region()`
- typed entry-block argument constraints
- combined `args + size` region descriptors

## Files

- `lib/beaver/slang.ex`
- `test/support/region_dialect.ex`
- `test/irdl_test.exs`

## Verification

- `mix test`
- `mix dialyzer --quiet --format dialyxir`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for region constraints in operation definitions, enabling declaration of region requirements with optional sizing and typed arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->