### PR TITLE
Pin default LLVM prebuilt snapshot

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,22 +45,13 @@ Zig as a local package override, so both dependency graphs use the same source.
 
 - Option 1: Install a prebuilt `llvm/eudsl` tarball
 
-  The helper script resolves the matching `mlir_<os>_<arch>_*.tar.gz` asset for
+  The helper script selects the matching `mlir_<os>_<arch>_*.tar.gz` asset for
   the current machine, downloads it, and extracts the compiled binaries into a
   local prefix. This replaces the old Python wheel-based setup and only needs a
   local `python3` runtime.
 
   ```bash
   bash scripts/install-prebuilt-llvm.sh priv/llvm-prebuilt
-  export LLVM_CONFIG_PATH=$PWD/priv/llvm-prebuilt/bin/llvm-config
-  ```
-
-  To pin the latest snapshot verified by Beaver instead of auto-detecting by OS
-  and architecture:
-
-  ```bash
-  LLVM_EUDSL_ASSET_NAME=mlir_macos_arm64_20260804+eb50d8775.tar.gz \
-    bash scripts/install-prebuilt-llvm.sh priv/llvm-prebuilt
   export LLVM_CONFIG_PATH=$PWD/priv/llvm-prebuilt/bin/llvm-config
   ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,10 +55,11 @@ Zig as a local package override, so both dependency graphs use the same source.
   export LLVM_CONFIG_PATH=$PWD/priv/llvm-prebuilt/bin/llvm-config
   ```
 
-  To pin a specific asset instead of auto-detecting by OS and architecture:
+  To pin the latest snapshot verified by Beaver instead of auto-detecting by OS
+  and architecture:
 
   ```bash
-  LLVM_EUDSL_ASSET_NAME=mlir_macos_arm64_20260416+47b5ad2bd.tar.gz \
+  LLVM_EUDSL_ASSET_NAME=mlir_macos_arm64_20260804+eb50d8775.tar.gz \
     bash scripts/install-prebuilt-llvm.sh priv/llvm-prebuilt
   export LLVM_CONFIG_PATH=$PWD/priv/llvm-prebuilt/bin/llvm-config
   ```

--- a/scripts/install-prebuilt-llvm.sh
+++ b/scripts/install-prebuilt-llvm.sh
@@ -9,6 +9,8 @@ fi
 install_dir="${1:-${LLVM_PREBUILT_DIR:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/llvm-prebuilt}}"
 repo="${LLVM_EUDSL_REPO:-llvm/eudsl}"
 tag="${LLVM_EUDSL_TAG:-llvm}"
+default_asset_revision="20260804+eb50d8775"
+asset_revision="${LLVM_EUDSL_ASSET_REVISION:-${default_asset_revision}}"
 asset_name="${LLVM_EUDSL_ASSET_NAME:-}"
 asset_url="${LLVM_EUDSL_ASSET_URL:-}"
 resolve_only="${LLVM_EUDSL_RESOLVE_ONLY:-0}"
@@ -68,13 +70,15 @@ if [[ -z "${asset_name}" ]]; then
   read -r detected_asset_os detected_asset_arch < <(detect_platform)
   asset_os="${LLVM_EUDSL_ASSET_OS:-${detected_asset_os}}"
   asset_arch="${LLVM_EUDSL_ASSET_ARCH:-${detected_asset_arch}}"
-  asset_name="$(
-    REPO="${repo}" \
-    TAG="${tag}" \
-    ASSET_OS="${asset_os}" \
-    ASSET_ARCH="${asset_arch}" \
-    GITHUB_TOKEN="${token}" \
-    python3 - <<'PY'
+
+  if [[ "${asset_revision}" == "latest" ]]; then
+    asset_name="$(
+      REPO="${repo}" \
+      TAG="${tag}" \
+      ASSET_OS="${asset_os}" \
+      ASSET_ARCH="${asset_arch}" \
+      GITHUB_TOKEN="${token}" \
+      python3 - <<'PY'
 import json
 import os
 import sys
@@ -128,7 +132,10 @@ if not matches:
 matches.sort(key=lambda asset: (asset.get("updated_at", ""), asset["name"]))
 print(matches[-1]["name"])
 PY
-  )"
+    )"
+  else
+    asset_name="mlir_${asset_os}_${asset_arch}_${asset_revision}.tar.gz"
+  fi
 fi
 
 if [[ -z "${asset_url}" ]]; then


### PR DESCRIPTION
## Summary

- pin the default llvm/eudsl revision to `20260804+eb50d8775` in the installer
- derive the matching asset name for macOS ARM64, Linux x86_64/AArch64, and Windows AMD64
- preserve exact asset overrides and provide `LLVM_EUDSL_ASSET_REVISION=latest` for explicit floating resolution
- remove the fixed artifact example from the contributor guide

## Why

Selecting the newest release asset implicitly made otherwise identical CI and local builds depend on when they ran. Keeping the verified revision in the installer makes the default reproducible across platforms while retaining an explicit path for testing newer snapshots.

## Impact

Default local, CI, release, and Docker resolution now use the same verified LLVM 24.0.0 snapshot. Existing `LLVM_EUDSL_ASSET_NAME` overrides continue to take precedence.

## Validation

- resolved the pinned default for macOS ARM64, manylinux x86_64, manylinux AArch64, and Windows AMD64
- verified explicit latest-revision and exact-asset override paths
- compiled Beaver native CMake, TableGen, C++ CAPI, Zig NIF, and Elixir sources against the snapshot
- `mix test --warnings-as-errors --exclude vulkan --exclude todo`: 176 passed, 8 excluded
- `bash -n scripts/install-prebuilt-llvm.sh`
- `git diff --check`
