### PR TITLE
Restore upstream LLVM checks

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -10,13 +10,20 @@ on:
   workflow_dispatch:
     inputs:
       llvm_prebuilt_asset_name:
-        description: "exact llvm/eudsl asset name to install; empty means auto-detect by OS/arch"
+        description: "exact llvm/eudsl asset name to install; empty uses the installer default"
+        required: false
+      llvm_prebuilt_asset_revision:
+        description: "llvm/eudsl asset revision, or latest; empty uses the installer default"
         required: false
 
   workflow_call:
     inputs:
       llvm_prebuilt_asset_name:
-        description: "exact llvm/eudsl asset name to install; empty means auto-detect by OS/arch"
+        description: "exact llvm/eudsl asset name to install; empty uses the installer default"
+        type: string
+        required: false
+      llvm_prebuilt_asset_revision:
+        description: "llvm/eudsl asset revision, or latest; empty uses the installer default"
         type: string
         required: false
 
@@ -29,7 +36,7 @@ env:
   KINDA_REF: "a595f26b67fa3e491add0b4008a4cae63d2eb02e"
 
 concurrency:
-  group: build-and-test-${{ github.ref }}-${{ inputs.llvm_prebuilt_asset_name || 'auto' }}
+  group: build-and-test-${{ github.ref }}-${{ inputs.llvm_prebuilt_asset_name || inputs.llvm_prebuilt_asset_revision || 'default' }}
   cancel-in-progress: true
 
 jobs:
@@ -98,6 +105,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           LLVM_EUDSL_ASSET_NAME: ${{ inputs.llvm_prebuilt_asset_name }}
+          LLVM_EUDSL_ASSET_REVISION: ${{ inputs.llvm_prebuilt_asset_revision }}
         run: |
           bash scripts/install-prebuilt-llvm.sh "$RUNNER_TEMP/llvm-prebuilt"
       - name: Build native library

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -6,14 +6,14 @@ on:
   workflow_dispatch:
     inputs:
       llvm_prebuilt_asset_name:
-        description: "exact llvm/eudsl asset name to install; empty means auto-detect by OS/arch"
+        description: "exact llvm/eudsl asset name to install; empty checks the latest revision"
         required: false
   push:
     branches:
       - "upstream/*"
 
 concurrency:
-  group: check-upstream-${{ github.ref }}-${{ inputs.llvm_prebuilt_asset_name || 'auto' }}
+  group: check-upstream-${{ github.ref }}-${{ inputs.llvm_prebuilt_asset_name || 'latest' }}
   cancel-in-progress: true
 
 jobs:
@@ -25,3 +25,4 @@ jobs:
     uses: ./.github/workflows/elixir.yml
     with:
       llvm_prebuilt_asset_name: ${{ inputs.llvm_prebuilt_asset_name }}
+      llvm_prebuilt_asset_revision: latest


### PR DESCRIPTION
## Summary

- add an LLVM asset revision input to the reusable Elixir workflow
- keep ordinary CI on the installer's reproducible default snapshot
- make Check Upstream explicitly request the latest llvm/eudsl revision
- preserve exact asset-name overrides for manual runs
- distinguish default, latest, and exact-asset runs in concurrency groups

## Why

GitHub disabled Check Upstream because of repository inactivity. After the default LLVM snapshot was pinned, simply enabling the workflow would no longer detect upstream LLVM drift because an empty input now selects the pinned default.

## Impact

Normal CI remains deterministic, while scheduled and manually dispatched Check Upstream runs once again exercise the newest platform-matching llvm/eudsl asset.

## Validation

- re-enabled the GitHub workflow from `disabled_inactivity` to `active`
- manually dispatched Check Upstream with the latest resolved Linux asset
- validated workflow YAML
- validated `LLVM_EUDSL_ASSET_REVISION=latest` resolution
- `git diff --check`
