### PR TITLE
Split Beaver CAPI compilation surfaces

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -33,7 +33,7 @@ permissions:
 # Remove this paired ref after Kinda 0.11.0 is published; Mix will then use the
 # locked Hex dependency without a separate checkout.
 env:
-  KINDA_REF: "99298bc542b0634444454fc8126bd0e7050cc5e6"
+  KINDA_REF: "2f78600bb0fe53ea35cbdecd4b8a2c8242fe558d"
 
 concurrency:
   group: build-and-test-${{ github.ref }}-${{ inputs.llvm_prebuilt_asset_name || inputs.llvm_prebuilt_asset_revision || 'default' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ permissions:
 env:
   CADDY_VERSION: "2.11.4"
   # Remove after Kinda 0.11.0 is published and locked by Mix.
-  KINDA_REF: "99298bc542b0634444454fc8126bd0e7050cc5e6"
+  KINDA_REF: "2f78600bb0fe53ea35cbdecd4b8a2c8242fe558d"
 
 jobs:
   generate_id:

--- a/lib/beaver/mlir/capi.ex
+++ b/lib/beaver/mlir/capi.ex
@@ -10,135 +10,23 @@ defmodule Beaver.MLIR.CAPI do
   - `mlirPassManagerRunOnOp`: the MLIR pass implemented in Elixir.
   - `mlirOperationVerify`, `mlirAttributeParseGet`, `mlirTypeParseGet`, `mlirModuleCreateParse`: the diagnostic handler implemented in Elixir.
   """
-  use Kinda.CodeGen, with: Beaver.MLIR.CAPI.CodeGen, root: __MODULE__, codec: Beaver.Native
+  use Kinda.CodeGen,
+    with: Beaver.MLIR.CAPI.CodeGen,
+    root: __MODULE__,
+    raw_module: __MODULE__.Raw,
+    codec: Beaver.Native,
+    surface: :public
 
-  @on_load :load_nif
+  # Recompile the Elixir surface only when the generated C API changes. Native
+  # implementation files are tracked independently by the native build.
+  @external_resource Beaver.MLIR.CAPI.CodeGen.declaration_manifest_path()
 
-  def load_nif do
-    nif_file = ~c"#{:code.priv_dir(:beaver)}/lib/libBeaverNIF"
-    dylib = "#{nif_file}.dylib"
+  for {name, arity} <- Beaver.MLIR.CAPI.Handwritten.functions() do
+    args = Macro.generate_arguments(arity, __MODULE__)
+    call = {{:., [], [__MODULE__.Raw, name]}, [], args}
 
-    if File.exists?(dylib) do
-      dylib
-      |> Path.basename()
-      |> File.ln_s("#{nif_file}.so")
-    end
-
-    case :erlang.load_nif(nif_file, 0) do
-      :ok -> :ok
-      {:error, {:reload, _}} -> :ok
-      {:error, reason} -> IO.puts("Failed to load nif: #{inspect(reason)}")
-    end
+    def unquote(name)(unquote_splicing(args)), do: unquote(call)
   end
 
-  # setting up elixir re-compilation triggered by changes in external files
-  for path <-
-        ~w{#{Mix.Project.project_file() |> Path.dirname() |> Path.join("external_files.txt") |> File.read!()}}
-        |> Enum.flat_map(&Path.wildcard/1) do
-    @external_resource path
-  end
-
-  # stubs for hand-written NIFs
-  def beaver_raw_create_mlir_pass(
-        _ctx,
-        _name,
-        _argument,
-        _description,
-        _op_name,
-        _callbacks
-      ),
-      do: :erlang.nif_error(:not_loaded)
-
-  def beaver_raw_create_mlir_rewrite_pattern(
-        _root_name,
-        _benefit,
-        _context,
-        _construct,
-        _destruct,
-        _match_and_rewrite
-      ),
-      do: :erlang.nif_error(:not_loaded)
-
-  def beaver_raw_destroy_frozen_rewrite_pattern_set(_ctx, _set),
-    do: :erlang.nif_error(:not_loaded)
-
-  def beaver_raw_destroy_rewrite_pattern_set(_ctx, _set),
-    do: :erlang.nif_error(:not_loaded)
-
-  def beaver_raw_apply_rewrite_pattern_set_with_module(_ctx, _mod, _set, _cfg),
-    do: :erlang.nif_error(:not_loaded)
-
-  def beaver_raw_apply_rewrite_pattern_set_with_op(_ctx, _op, _set, _cfg),
-    do: :erlang.nif_error(:not_loaded)
-
-  def beaver_raw_run_pm_on_op_async(_pm, _op), do: :erlang.nif_error(:not_loaded)
-  def beaver_raw_destroy_pm_async(_pm), do: :erlang.nif_error(:not_loaded)
-
-  def beaver_raw_callback_reply(_token, _is_success), do: :erlang.nif_error(:not_loaded)
-
-  def beaver_raw_value_replace_uses_with_if(_from, _replacement, _predicate),
-    do: :erlang.nif_error(:not_loaded)
-
-  def beaver_raw_registered_ops(_ctx), do: :erlang.nif_error(:not_loaded)
-  def beaver_raw_registered_dialects(_ctx), do: :erlang.nif_error(:not_loaded)
-
-  for f <- ~w{
-    StringRef
-    Attribute
-    Type
-    Operation
-    OperationSpecialized
-    OperationGeneric
-    OperationBytecode
-    Value
-    AffineMap
-    Location
-    OpPassManager
-    Identifier
-    Diagnostic
-  } do
-    f = :"beaver_raw_to_string_#{f}"
-    def unquote(f)(_), do: :erlang.nif_error(:not_loaded)
-    {f, 1}
-  end
-
-  def beaver_raw_get_string_ref(_), do: :erlang.nif_error(:not_loaded)
-  def beaver_raw_read_opaque_ptr(_, _), do: :erlang.nif_error(:not_loaded)
-  def beaver_raw_deallocate_opaque_ptr(_), do: :erlang.nif_error(:not_loaded)
-  def beaver_raw_get_null_ptr(), do: :erlang.nif_error(:not_loaded)
-  def beaver_raw_context_attach_diagnostic_handler(_, _), do: :erlang.nif_error(:not_loaded)
-  def beaver_raw_jit_invoke_with_terms(_jit, _name, _args), do: :erlang.nif_error(:not_loaded)
-
-  def beaver_raw_jit_invoke_with_terms_cpu_bound(_jit, _name, _args),
-    do: :erlang.nif_error(:not_loaded)
-
-  def beaver_raw_jit_invoke_with_terms_io_bound(_jit, _name, _args),
-    do: :erlang.nif_error(:not_loaded)
-
-  def beaver_raw_jit_register_enif(_jit), do: :erlang.nif_error(:not_loaded)
-  def beaver_raw_enif_signatures(_ctx), do: :erlang.nif_error(:not_loaded)
-  def beaver_raw_enif_functions(), do: :erlang.nif_error(:not_loaded)
-  def beaver_raw_mlir_type_of_enif_obj(_ctx, _obj), do: :erlang.nif_error(:not_loaded)
-  def beaver_raw_string_printer_callback(), do: :erlang.nif_error(:not_loaded)
-  def beaver_raw_string_printer_flush(_sp), do: :erlang.nif_error(:not_loaded)
-  def beaver_raw_memref_type_get_strides_and_offset(_type), do: :erlang.nif_error(:not_loaded)
-  def beaver_raw_unranked_memref_descriptor_empty(_rank), do: :erlang.nif_error(:not_loaded)
-
-  def beaver_raw_unranked_memref_descriptor_get_rank(_unranked_memref_descriptor),
-    do: :erlang.nif_error(:not_loaded)
-
-  def beaver_raw_unranked_memref_descriptor_get_offset(_unranked_memref_descriptor),
-    do: :erlang.nif_error(:not_loaded)
-
-  def beaver_raw_unranked_memref_descriptor_get_sizes(_unranked_memref_descriptor),
-    do: :erlang.nif_error(:not_loaded)
-
-  def beaver_raw_unranked_memref_descriptor_get_strides(_unranked_memref_descriptor),
-    do: :erlang.nif_error(:not_loaded)
-
-  def beaver_raw_unranked_memref_descriptor_deallocate_with_c(_unranked_memref_descriptor),
-    do: :erlang.nif_error(:not_loaded)
-
-  def beaver_raw_unranked_memref_descriptor_deallocate_with_enif(_unranked_memref_descriptor),
-    do: :erlang.nif_error(:not_loaded)
+  defdelegate load_nif(), to: __MODULE__.Raw
 end

--- a/lib/beaver/mlir/capi_codegen.ex
+++ b/lib/beaver/mlir/capi_codegen.ex
@@ -132,10 +132,15 @@ defmodule Beaver.MLIR.CAPI.CodeGen do
       ) ++ [%KindDecl{module_name: Beaver.Printer, kind_functions: [make: 0]}]
   end
 
-  @impl Kinda.CodeGen
-  def declaration_manifest do
+  @doc false
+  def declaration_manifest_path do
     Application.app_dir(:beaver)
     |> Path.join("priv/capi_manifest.json")
+  end
+
+  @impl Kinda.CodeGen
+  def declaration_manifest do
+    declaration_manifest_path()
     |> DeclarationManifest.load!()
   end
 end

--- a/lib/beaver/mlir/capi_handwritten.ex
+++ b/lib/beaver/mlir/capi_handwritten.ex
@@ -1,0 +1,56 @@
+defmodule Beaver.MLIR.CAPI.Handwritten do
+  @moduledoc false
+
+  @functions [
+    beaver_raw_apply_rewrite_pattern_set_with_module: 4,
+    beaver_raw_apply_rewrite_pattern_set_with_op: 4,
+    beaver_raw_callback_reply: 2,
+    beaver_raw_context_attach_diagnostic_handler: 2,
+    beaver_raw_create_mlir_pass: 6,
+    beaver_raw_create_mlir_rewrite_pattern: 6,
+    beaver_raw_deallocate_opaque_ptr: 1,
+    beaver_raw_destroy_frozen_rewrite_pattern_set: 2,
+    beaver_raw_destroy_pm_async: 1,
+    beaver_raw_destroy_rewrite_pattern_set: 2,
+    beaver_raw_enif_functions: 0,
+    beaver_raw_enif_signatures: 1,
+    beaver_raw_get_null_ptr: 0,
+    beaver_raw_get_string_ref: 1,
+    beaver_raw_jit_invoke_with_terms: 3,
+    beaver_raw_jit_invoke_with_terms_cpu_bound: 3,
+    beaver_raw_jit_invoke_with_terms_io_bound: 3,
+    beaver_raw_jit_register_enif: 1,
+    beaver_raw_memref_type_get_strides_and_offset: 1,
+    beaver_raw_mlir_type_of_enif_obj: 2,
+    beaver_raw_read_opaque_ptr: 2,
+    beaver_raw_registered_dialects: 1,
+    beaver_raw_registered_ops: 1,
+    beaver_raw_run_pm_on_op_async: 2,
+    beaver_raw_string_printer_callback: 0,
+    beaver_raw_string_printer_flush: 1,
+    beaver_raw_to_string_AffineMap: 1,
+    beaver_raw_to_string_Attribute: 1,
+    beaver_raw_to_string_Diagnostic: 1,
+    beaver_raw_to_string_Identifier: 1,
+    beaver_raw_to_string_Location: 1,
+    beaver_raw_to_string_OpPassManager: 1,
+    beaver_raw_to_string_Operation: 1,
+    beaver_raw_to_string_OperationBytecode: 1,
+    beaver_raw_to_string_OperationGeneric: 1,
+    beaver_raw_to_string_OperationSpecialized: 1,
+    beaver_raw_to_string_StringRef: 1,
+    beaver_raw_to_string_Type: 1,
+    beaver_raw_to_string_Value: 1,
+    beaver_raw_unranked_memref_descriptor_deallocate_with_c: 1,
+    beaver_raw_unranked_memref_descriptor_deallocate_with_enif: 1,
+    beaver_raw_unranked_memref_descriptor_empty: 1,
+    beaver_raw_unranked_memref_descriptor_get_offset: 1,
+    beaver_raw_unranked_memref_descriptor_get_rank: 1,
+    beaver_raw_unranked_memref_descriptor_get_sizes: 1,
+    beaver_raw_unranked_memref_descriptor_get_strides: 1,
+    beaver_raw_value_replace_uses_with_if: 3
+  ]
+
+  @doc false
+  def functions, do: @functions
+end

--- a/lib/beaver/mlir/capi_raw.ex
+++ b/lib/beaver/mlir/capi_raw.ex
@@ -1,0 +1,37 @@
+defmodule Beaver.MLIR.CAPI.Raw do
+  @moduledoc false
+
+  use Kinda.CodeGen,
+    with: Beaver.MLIR.CAPI.CodeGen,
+    root: Beaver.MLIR.CAPI,
+    codec: Beaver.Native,
+    surface: :raw
+
+  @external_resource Beaver.MLIR.CAPI.CodeGen.declaration_manifest_path()
+
+  for {name, arity} <- Beaver.MLIR.CAPI.Handwritten.functions() do
+    args = Macro.generate_arguments(arity, __MODULE__)
+
+    @doc false
+    def unquote(name)(unquote_splicing(args)), do: :erlang.nif_error(:not_loaded)
+  end
+
+  @on_load :load_nif
+
+  def load_nif do
+    nif_file = ~c"#{:code.priv_dir(:beaver)}/lib/libBeaverNIF"
+    dylib = "#{nif_file}.dylib"
+
+    if File.exists?(dylib) do
+      dylib
+      |> Path.basename()
+      |> File.ln_s("#{nif_file}.so")
+    end
+
+    case :erlang.load_nif(nif_file, 0) do
+      :ok -> :ok
+      {:error, {:reload, _}} -> :ok
+      {:error, reason} -> IO.puts("Failed to load nif: #{inspect(reason)}")
+    end
+  end
+end

--- a/native/src/diagnostic.zig
+++ b/native/src/diagnostic.zig
@@ -73,7 +73,6 @@ pub fn call_with_diagnostics(env: beam.env, ctx: mlir_capi.Context.T, f: anytype
 
 pub fn WithDiagnosticsNIF(comptime name: anytype) e.ErlNifFunc {
     const bang = kinda.BangFunc(@import("prelude.zig").allKinds, c, name);
-    const nifPrefix = "Elixir.Beaver.MLIR.CAPI.";
     const nifSuffix = "WithDiagnostics";
     const AttachAndRun = struct {
         fn with_diagnostics(env: beam.env, n: c_int, args: [*c]const beam.term) !beam.term {
@@ -81,7 +80,7 @@ pub fn WithDiagnosticsNIF(comptime name: anytype) e.ErlNifFunc {
             return call_with_diagnostics(env, ctx, bang.nif, .{ env, n - 1, args[1..] });
         }
     };
-    return result.nif(nifPrefix ++ name ++ nifSuffix, 1 + bang.arity, AttachAndRun.with_diagnostics).entry;
+    return result.nif(name ++ nifSuffix, 1 + bang.arity, AttachAndRun.with_diagnostics).entry;
 }
 
 pub const nifs = .{};

--- a/native/src/mlir_capi.zig
+++ b/native/src/mlir_capi.zig
@@ -3,7 +3,7 @@ const kinda = @import("kinda");
 const e = kinda.erl_nif;
 const beam = kinda.beam;
 const string_ref = @import("string_ref.zig");
-pub const root_module = "Elixir.Beaver.MLIR.CAPI";
+pub const root_module = "Elixir.Beaver.MLIR.CAPI.Raw";
 fn NativeKind(comptime t: type, comptime n: []const u8) type {
     const nativeModPrefix = "Elixir.Beaver.Native.";
     return kinda.ResourceKind(t, nativeModPrefix ++ n);

--- a/native/src/prelude.zig
+++ b/native/src/prelude.zig
@@ -1,19 +1,20 @@
 pub const c = @import("c_api");
 const kinda = @import("kinda");
 const e = kinda.erl_nif;
-const nifPrefix = "Elixir.Beaver.MLIR.CAPI.";
 pub const allKinds = @import("mlir_capi.zig").allKinds;
 pub fn nif(comptime name: anytype) e.ErlNifFunc {
     @setEvalBranchQuota(10000);
-    return kinda.NIFFunc(allKinds, c, name, .{ .nif_name = nifPrefix ++ name });
+    return kinda.NIFFunc(allKinds, c, name, .{});
 }
 pub fn nifDirtyCPU(comptime name: []const u8, comptime nif_name: ?[]const u8) e.ErlNifFunc {
     @setEvalBranchQuota(10000);
-    return kinda.NIFFunc(allKinds, c, name, .{ .flags = e.ERL_NIF_DIRTY_JOB_CPU_BOUND, .nif_name = nifPrefix ++ (if (nif_name) |v| v else name) });
+    const exported_name = if (nif_name) |v| v else name;
+    return kinda.NIFFunc(allKinds, c, name, .{ .flags = e.ERL_NIF_DIRTY_JOB_CPU_BOUND, .nif_name = exported_name.ptr });
 }
 pub fn nifDirtyIO(comptime name: []const u8, comptime nif_name: ?[]const u8) e.ErlNifFunc {
     @setEvalBranchQuota(10000);
-    return kinda.NIFFunc(allKinds, c, name, .{ .flags = e.ERL_NIF_DIRTY_JOB_IO_BOUND, .nif_name = nifPrefix ++ (if (nif_name) |v| v else name) });
+    const exported_name = if (nif_name) |v| v else name;
+    return kinda.NIFFunc(allKinds, c, name, .{ .flags = e.ERL_NIF_DIRTY_JOB_IO_BOUND, .nif_name = exported_name.ptr });
 }
 
 const result = @import("kinda").result;

--- a/test/capi_manifest_test.exs
+++ b/test/capi_manifest_test.exs
@@ -2,9 +2,16 @@ defmodule Beaver.MLIR.CAPI.ManifestTest do
   use ExUnit.Case, async: true
 
   alias Beaver.MLIR.CAPI
-  alias Kinda.CodeGen.DeclarationManifest
+  alias Kinda.CodeGen.{DeclarationManifest, DeclarationSurfaces}
 
   @moduletag :smoke
+
+  test "Elixir CAPI recompilation tracks the generated ABI manifest only" do
+    expected = [CAPI.CodeGen.declaration_manifest_path()]
+
+    assert CAPI.__info__(:attributes)[:external_resource] == expected
+    assert CAPI.Raw.__info__(:attributes)[:external_resource] == expected
+  end
 
   test "declaration manifest matches the generated public and raw surfaces" do
     declaration_manifest = CAPI.CodeGen.declaration_manifest()
@@ -26,6 +33,17 @@ defmodule Beaver.MLIR.CAPI.ManifestTest do
     assert MapSet.size(expected) > 2_000
     assert MapSet.subset?(expected, raw)
     assert MapSet.subset?(expected, public)
+
+    resolved_declarations =
+      CAPI.__kinda_declaration_surfaces__()
+      |> DeclarationSurfaces.nif_decls()
+
+    generated = Enum.find(resolved_declarations, &(&1.wrapper_name == :mlirContextCreate))
+    arity = if is_list(generated.params), do: length(generated.params), else: generated.params
+
+    assert generated.nif_name != generated.wrapper_name
+    refute MapSet.member?(raw, {generated.nif_name, arity})
+    refute MapSet.member?(public, {generated.nif_name, arity})
   end
 
   test "declaration manifest preserves signature and wrapper policy metadata" do


### PR DESCRIPTION
## Summary

- consume the split Kinda generation surfaces introduced by beaver-lodge/kinda#59
- move NIF stubs and native library loading into `Beaver.MLIR.CAPI.Raw`
- compile public CAPI wrappers independently and call raw functions directly
- replace duplicated handwritten stubs with one shared function manifest
- make generated ABI metadata the only external resource for the Elixir CAPI surfaces
- register generated Zig NIF entries under the new raw module without hidden proxy names

## Why

`Beaver.MLIR.CAPI` previously embedded a large resolved declaration graph and generated a `CAPI -> Raw -> CAPI` proxy cycle. It also tracked every native source as an Elixir external resource. Together these made CAPI recompilation the dominant part of Beaver's Elixir build and caused native-only changes to invalidate Elixir modules.

The public and raw surfaces can now compile independently, while native-only edits stay inside the native build boundary.

## Impact

- forced `capi.ex` compilation changed from about 4.97s to 0.47s for the public surface and 0.81s for the raw surface
- the full Elixir compilation cycle changed from about 6.17s to 3.73s
- the public CAPI BEAM changed from about 5.9MB to 536KB
- touching a Zig implementation file recompiles zero Elixir modules

## Validation

- `BEAVER_KINDA_PATH=../kinda mix compile --warnings-as-errors --force`
- `BEAVER_KINDA_PATH=../kinda mix test` — 189 passed, 8 excluded
- focused CAPI manifest and runtime tests
- native Zig build and NIF loading through `Beaver.MLIR.CAPI.Raw`
- `mix format --check-formatted` and `git diff --check`

## Dependency

Depends on beaver-lodge/kinda#59.
