### PR TITLE
Build incremental MLIR compilation runtime

### DIFF
--- a/bench/incremental_compilation.exs
+++ b/bench/incremental_compilation.exs
@@ -1,0 +1,33 @@
+alias Beaver.MLIR
+
+source = """
+module {
+  func.func @add(%lhs: i32, %rhs: i32) -> i32 {
+    %result = arith.addi %lhs, %rhs : i32
+    return %result : i32
+  }
+}
+"""
+
+{:ok, cold_cache} = MLIR.CompilationCache.Memory.start_link()
+{:ok, warm_cache} = MLIR.CompilationCache.Memory.start_link()
+cold_cache = {:memory, cold_cache}
+warm_cache = {:memory, warm_cache}
+pipeline = "canonicalize,cse"
+
+MLIR.CompilationRuntime.compile!(source, cache: warm_cache, pipeline: pipeline)
+
+Benchee.run(
+  %{
+    "cold compile" => fn ->
+      MLIR.CompilationRuntime.invalidate(cold_cache)
+      MLIR.CompilationRuntime.compile!(source, cache: cold_cache, pipeline: pipeline)
+    end,
+    "warm compile" => fn ->
+      MLIR.CompilationRuntime.compile!(source, cache: warm_cache, pipeline: pipeline)
+    end
+  },
+  warmup: 2,
+  time: 5,
+  memory_time: 2
+)

--- a/guides/incremental-compilation-runtime.md
+++ b/guides/incremental-compilation-runtime.md
@@ -1,0 +1,75 @@
+# Incremental MLIR compilation
+
+`Beaver.MLIR.CompilationRuntime` shortens the edit–compile–reload loop for NIFs
+and other native extensions. A long-running BEAM application owns one LLVM
+thread pool, and every default MLIR context leases that pool instead of creating
+another one.
+
+The runtime caches transformed MLIR bytecode rather than a live context or JIT.
+This makes the handoff explicit: the same validated artifact can be loaded into
+a new execution engine or emitted as an object file.
+
+```elixir
+alias Beaver.MLIR
+
+source = File.read!("native/kernel.mlir")
+
+compile_opts = [
+  pipeline: "convert-func-to-llvm,convert-arith-to-llvm",
+  target: %{triple: "aarch64-apple-darwin", features: "+neon"},
+  schema_version: "my_dynamic_dialect/v3",
+  cache: {:file, ".beaver/cache"}
+]
+
+artifact = MLIR.CompilationRuntime.compile!(source, compile_opts)
+
+jit = MLIR.CompilationRuntime.jit!(artifact)
+MLIR.CompilationRuntime.emit_object!(artifact, "_build/native/kernel.o")
+
+# After editing native/kernel.mlir, compile and load the replacement first.
+next_artifact =
+  "native/kernel.mlir"
+  |> File.read!()
+  |> MLIR.CompilationRuntime.compile!(compile_opts)
+
+next_jit = MLIR.CompilationRuntime.jit!(next_artifact)
+MLIR.ExecutionEngine.destroy(jit)
+jit = next_jit
+```
+
+The artifact key contains the source digest and structural hash, Beaver's LLVM
+version, pipeline identity, target configuration, dynamic dialect/schema
+version, and requested bytecode version. Changing any of these inputs is a
+cache miss. Stored bytecode is checksummed and its metadata is revalidated
+before use; read, write, or validation failure falls back to a normal compile.
+
+For a custom Elixir pass or another runtime function, provide a stable version
+because a closure is not a deterministic cache identity:
+
+```elixir
+MLIR.CompilationRuntime.compile!(source,
+  pipeline: [MyPass],
+  pipeline_version: {MyPass, 4}
+)
+```
+
+Use `cache: :memory` for process-local iteration, or `cache: {:file, path}` to
+reuse artifacts across BEAM restarts. Invalidate one lookup key or the whole
+backend explicitly:
+
+```elixir
+MLIR.CompilationRuntime.invalidate(:memory, artifact.metadata.lookup_key)
+MLIR.CompilationRuntime.invalidate({:file, ".beaver/cache"})
+```
+
+Compilation emits events below `[:beaver, :mlir, :compilation]` for cache
+lookup/hit/miss/failure, parse, transform, serialization, codegen, JIT load,
+object emission, and execution. Measurements use native time units. If the
+`:telemetry` package is not installed, pass a callback with
+`telemetry: fn event, measurements, metadata -> ... end`.
+
+Run the cold/warm comparison with:
+
+```sh
+mix run bench/incremental_compilation.exs
+```

--- a/lib/beaver/application.ex
+++ b/lib/beaver/application.ex
@@ -4,6 +4,8 @@ defmodule Beaver.Application do
   @moduledoc false
   def start(_type, _args) do
     [
+      MLIR.ThreadPool.child_spec(name: MLIR.ThreadPool.default_name()),
+      MLIR.CompilationCache.Memory.child_spec(name: MLIR.CompilationCache.Memory.default_name()),
       MLIR.Pass.global_registrar_child_specs(),
       MLIR.RewritePattern.global_registrar_child_specs(),
       MLIR.Rewrite.thread_pool_child_spec()

--- a/lib/beaver/composer.ex
+++ b/lib/beaver/composer.ex
@@ -169,9 +169,11 @@ defmodule Beaver.Composer do
   @doc """
   Run the passes on the operation.
 
-  > #### Must be a multi-threaded context if an Elixir pass is in the pipeline {: .info}
+  > #### Elixir callback safety {: .info}
   >
-  > MLIR context's thread pool is used to run the CAPI. If an Elixir pass is in the pipeline, the context must be multi-threaded otherwise there can be a deadlock. Also note that it can be more expensive than a C/C++ implementation due to the overhead of the thread pool.
+  > Native pipelines and Elixir passes use the context's shared elastic LLVM
+  > thread pool outside BEAM scheduler threads. Nested callback work can expand
+  > the pool rather than starving it.
   """
   def run(
         %__MODULE__{op: op} = composer,

--- a/lib/beaver/mlir.ex
+++ b/lib/beaver/mlir.ex
@@ -137,7 +137,12 @@ defmodule Beaver.MLIR do
           | Identifier.t()
 
   @type dump_opts :: [generic: boolean()]
-  @type print_opts :: [generic: boolean(), bytecode: boolean(), ctx: Deferred.context_arg()]
+  @type print_opts :: [
+          generic: boolean(),
+          bytecode: boolean(),
+          bytecode_version: integer(),
+          ctx: Deferred.context_arg()
+        ]
   @type null_safe_result(t) :: t | {:error, String.t()}
   @spec dump(printable(), dump_opts()) :: null_safe_result(:ok)
   @spec dump!(printable(), dump_opts()) :: printable()
@@ -192,7 +197,12 @@ defmodule Beaver.MLIR do
   def to_string(mlir, opts \\ [])
 
   def to_string(%Operation{ref: ref}, opts) do
+    operation = %Operation{ref: ref}
+
     cond do
+      opts[:bytecode] == true and opts[:bytecode_version] ->
+        MLIR.Bytecode.write!(operation, desired_emit_version: opts[:bytecode_version])
+
       opts[:bytecode] ->
         :Bytecode
 
@@ -205,7 +215,10 @@ defmodule Beaver.MLIR do
       true ->
         nil
     end
-    |> then(&apply(CAPI, :"beaver_raw_to_string_Operation#{&1}", [ref]))
+    |> then(fn
+      bytecode when is_binary(bytecode) -> bytecode
+      suffix -> apply(CAPI, :"beaver_raw_to_string_Operation#{suffix}", [ref])
+    end)
   end
 
   def to_string(%Beaver.MLIR.Module{} = module, opts) do

--- a/lib/beaver/mlir/bytecode.ex
+++ b/lib/beaver/mlir/bytecode.ex
@@ -1,0 +1,61 @@
+defmodule Beaver.MLIR.Bytecode do
+  @moduledoc """
+  Reads and writes versioned MLIR bytecode.
+
+  `:desired_emit_version` asks MLIR to emit a specific bytecode version. MLIR
+  returns an error instead of silently emitting another version when the
+  requested version cannot be honored.
+  """
+
+  alias Beaver.MLIR
+  import MLIR.CAPI
+
+  @type write_option :: {:desired_emit_version, integer() | nil}
+
+  @spec write(MLIR.Module.t() | MLIR.Operation.t(), [write_option()]) ::
+          {:ok, binary()} | {:error, :unsupported_bytecode_version}
+  def write(module_or_operation, opts \\ []) do
+    operation = MLIR.Operation.from_module(module_or_operation)
+    config = mlirBytecodeWriterConfigCreate()
+
+    try do
+      case Keyword.get(opts, :desired_emit_version) do
+        nil ->
+          :ok
+
+        version when is_integer(version) ->
+          mlirBytecodeWriterConfigDesiredEmitVersion(config, version)
+      end
+
+      {result, bytecode} =
+        Beaver.Printer.run(fn callback, user_data ->
+          mlirOperationWriteBytecodeWithConfig(operation, config, callback, user_data)
+        end)
+
+      if MLIR.LogicalResult.success?(result) do
+        {:ok, bytecode}
+      else
+        {:error, :unsupported_bytecode_version}
+      end
+    after
+      mlirBytecodeWriterConfigDestroy(config)
+    end
+  end
+
+  @spec write!(MLIR.Module.t() | MLIR.Operation.t(), [write_option()]) :: binary()
+  def write!(module_or_operation, opts \\ []) do
+    case write(module_or_operation, opts) do
+      {:ok, bytecode} ->
+        bytecode
+
+      {:error, :unsupported_bytecode_version} ->
+        raise ArgumentError, "MLIR could not honor the requested bytecode emit version"
+    end
+  end
+
+  @spec read(binary(), keyword()) :: {:ok, MLIR.Module.t()} | {:error, MLIR.diagnostics()}
+  defdelegate read(bytecode, opts \\ []), to: MLIR.Module, as: :create
+
+  @spec read!(binary(), keyword()) :: MLIR.Module.t()
+  defdelegate read!(bytecode, opts \\ []), to: MLIR.Module, as: :create!
+end

--- a/lib/beaver/mlir/compilation_cache.ex
+++ b/lib/beaver/mlir/compilation_cache.ex
@@ -1,0 +1,37 @@
+defmodule Beaver.MLIR.CompilationCache do
+  @moduledoc """
+  Common access to the incremental compiler's memory and filesystem caches.
+
+  A cache can be `:memory`, `{:memory, server}`, `{:file, directory}`, a memory
+  cache server, or a `Beaver.MLIR.CompilationCache.File` value.
+  """
+
+  alias __MODULE__.{File, Memory}
+
+  @type cache ::
+          :memory
+          | {:memory, GenServer.server()}
+          | {:file, Path.t()}
+          | GenServer.server()
+          | File.t()
+
+  @spec get(cache(), String.t()) :: {:ok, map()} | :miss | {:error, term()}
+  def get(cache, key), do: dispatch(cache, :get, [key])
+
+  @spec put(cache(), String.t(), map()) :: :ok | {:error, term()}
+  def put(cache, key, value), do: dispatch(cache, :put, [key, value])
+
+  @spec delete(cache(), String.t()) :: :ok | {:error, term()}
+  def delete(cache, key), do: dispatch(cache, :delete, [key])
+
+  @spec clear(cache()) :: :ok | {:error, term()}
+  def clear(cache), do: dispatch(cache, :clear, [])
+
+  defp dispatch(:memory, function, args),
+    do: apply(Memory, function, [Memory.default_name() | args])
+
+  defp dispatch({:memory, server}, function, args), do: apply(Memory, function, [server | args])
+  defp dispatch({:file, root}, function, args), do: apply(File, function, [File.new(root) | args])
+  defp dispatch(%File{} = cache, function, args), do: apply(File, function, [cache | args])
+  defp dispatch(server, function, args), do: apply(Memory, function, [server | args])
+end

--- a/lib/beaver/mlir/compilation_cache/file.ex
+++ b/lib/beaver/mlir/compilation_cache/file.ex
@@ -44,9 +44,9 @@ defmodule Beaver.MLIR.CompilationCache.File do
       temporary = destination <> ".tmp.#{System.unique_integer([:positive])}"
 
       try do
-        with :ok <- File.write(temporary, :erlang.term_to_binary(value, [:deterministic])),
-             :ok <- File.rename(temporary, destination) do
-          :ok
+        case File.write(temporary, :erlang.term_to_binary(value, [:deterministic])) do
+          :ok -> File.rename(temporary, destination)
+          error -> error
         end
       after
         File.rm(temporary)
@@ -66,13 +66,15 @@ defmodule Beaver.MLIR.CompilationCache.File do
   @spec clear(t()) :: :ok | {:error, term()}
   def clear(cache) do
     with {:ok, entries} <- list(cache) do
-      Enum.reduce_while(entries, :ok, fn entry, :ok ->
-        case File.rm(Path.join(cache.root, entry)) do
-          :ok -> {:cont, :ok}
-          {:error, :enoent} -> {:cont, :ok}
-          error -> {:halt, error}
-        end
-      end)
+      Enum.reduce_while(entries, :ok, &remove_entry(cache.root, &1, &2))
+    end
+  end
+
+  defp remove_entry(root, entry, :ok) do
+    case File.rm(Path.join(root, entry)) do
+      :ok -> {:cont, :ok}
+      {:error, :enoent} -> {:cont, :ok}
+      error -> {:halt, error}
     end
   end
 

--- a/lib/beaver/mlir/compilation_cache/file.ex
+++ b/lib/beaver/mlir/compilation_cache/file.ex
@@ -1,0 +1,88 @@
+defmodule Beaver.MLIR.CompilationCache.File do
+  @moduledoc """
+  Filesystem backend for incremental compilation artifacts.
+
+  Entries are written through a temporary file and atomically renamed. Reads
+  use safe Erlang term decoding; malformed entries are reported to the runtime,
+  which invalidates them and recompiles.
+  """
+
+  defstruct [:root]
+
+  @type t :: %__MODULE__{root: Path.t()}
+
+  @spec new(Path.t()) :: t()
+  def new(root), do: %__MODULE__{root: Path.expand(root)}
+
+  @spec get(t(), String.t()) :: {:ok, map()} | :miss | {:error, term()}
+  def get(cache, key) do
+    path = path(cache, key)
+
+    case File.read(path) do
+      {:ok, binary} ->
+        try do
+          case :erlang.binary_to_term(binary, [:safe]) do
+            value when is_map(value) -> {:ok, value}
+            _ -> {:error, :invalid_entry}
+          end
+        rescue
+          ArgumentError -> {:error, :invalid_entry}
+        end
+
+      {:error, :enoent} ->
+        :miss
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @spec put(t(), String.t(), map()) :: :ok | {:error, term()}
+  def put(cache, key, value) do
+    with :ok <- File.mkdir_p(cache.root) do
+      destination = path(cache, key)
+      temporary = destination <> ".tmp.#{System.unique_integer([:positive])}"
+
+      try do
+        with :ok <- File.write(temporary, :erlang.term_to_binary(value, [:deterministic])),
+             :ok <- File.rename(temporary, destination) do
+          :ok
+        end
+      after
+        File.rm(temporary)
+      end
+    end
+  end
+
+  @spec delete(t(), String.t()) :: :ok | {:error, term()}
+  def delete(cache, key) do
+    case File.rm(path(cache, key)) do
+      :ok -> :ok
+      {:error, :enoent} -> :ok
+      other -> other
+    end
+  end
+
+  @spec clear(t()) :: :ok | {:error, term()}
+  def clear(cache) do
+    with {:ok, entries} <- list(cache) do
+      Enum.reduce_while(entries, :ok, fn entry, :ok ->
+        case File.rm(Path.join(cache.root, entry)) do
+          :ok -> {:cont, :ok}
+          {:error, :enoent} -> {:cont, :ok}
+          error -> {:halt, error}
+        end
+      end)
+    end
+  end
+
+  defp list(cache) do
+    case File.ls(cache.root) do
+      {:ok, entries} -> {:ok, Enum.filter(entries, &String.ends_with?(&1, ".beaver-cache"))}
+      {:error, :enoent} -> {:ok, []}
+      other -> other
+    end
+  end
+
+  defp path(cache, key), do: Path.join(cache.root, key <> ".beaver-cache")
+end

--- a/lib/beaver/mlir/compilation_cache/memory.ex
+++ b/lib/beaver/mlir/compilation_cache/memory.ex
@@ -1,0 +1,44 @@
+defmodule Beaver.MLIR.CompilationCache.Memory do
+  @moduledoc "In-memory backend for incremental compilation artifacts."
+
+  use GenServer
+
+  @default_name __MODULE__
+
+  def default_name, do: @default_name
+
+  def start_link(opts \\ []) do
+    {name, opts} = Keyword.pop(opts, :name)
+    GenServer.start_link(__MODULE__, opts, if(name, do: [name: name], else: []))
+  end
+
+  def get(server \\ @default_name, key), do: call(server, {:get, key})
+  def put(server \\ @default_name, key, value), do: call(server, {:put, key, value})
+  def delete(server \\ @default_name, key), do: call(server, {:delete, key})
+  def clear(server \\ @default_name), do: call(server, :clear)
+
+  @impl GenServer
+  def init(_opts), do: {:ok, %{}}
+
+  @impl GenServer
+  def handle_call({:get, key}, _from, state) do
+    case Map.fetch(state, key) do
+      {:ok, value} -> {:reply, {:ok, value}, state}
+      :error -> {:reply, :miss, state}
+    end
+  end
+
+  def handle_call({:put, key, value}, _from, state),
+    do: {:reply, :ok, Map.put(state, key, value)}
+
+  def handle_call({:delete, key}, _from, state),
+    do: {:reply, :ok, Map.delete(state, key)}
+
+  def handle_call(:clear, _from, _state), do: {:reply, :ok, %{}}
+
+  defp call(server, message) do
+    GenServer.call(server, message)
+  catch
+    :exit, reason -> {:error, reason}
+  end
+end

--- a/lib/beaver/mlir/compilation_runtime.ex
+++ b/lib/beaver/mlir/compilation_runtime.ex
@@ -1,0 +1,390 @@
+defmodule Beaver.MLIR.CompilationRuntime do
+  @moduledoc """
+  Incremental MLIR compilation for long-running BEAM applications.
+
+  The runtime caches transformed, versioned MLIR bytecode. Cache lookup uses a
+  fast source digest plus every compatibility input; the stored artifact key
+  additionally contains MLIR's structural hash. A hit therefore skips parsing
+  and the transform pipeline, while JIT and object emission consume the same
+  validated bytecode.
+
+  ## Cache compatibility
+
+  The following inputs invalidate an artifact automatically:
+
+    * source content and structural hash;
+    * the LLVM revision used to build Beaver;
+    * pass/transform pipeline identity;
+    * target configuration;
+    * dynamic dialect/schema version;
+    * requested bytecode emit version.
+
+  Custom pass functions are not stable cache identities. Supply an explicit
+  `:pipeline_version` whenever `:pipeline` contains runtime functions.
+
+  ## Telemetry
+
+  If the `:telemetry` library is loaded, events are emitted below
+  `[:beaver, :mlir, :compilation, ...]`. A three-argument callback can also be
+  supplied in the `:telemetry` option. Durations use native time units.
+  """
+
+  alias Beaver.Composer
+  alias Beaver.MLIR
+  alias MLIR.CompilationCache
+  alias __MODULE__.{Artifact, CacheKey}
+
+  @entry_format 1
+
+  @type compile_option ::
+          {:cache, CompilationCache.cache()}
+          | {:pipeline, term()}
+          | {:pipeline_version, term()}
+          | {:target, term()}
+          | {:schema_version, term()}
+          | {:desired_emit_version, integer() | nil}
+          | {:context, MLIR.Context.t()}
+          | {:context_options, keyword()}
+          | {:llvm_revision, String.t()}
+          | {:telemetry, (list(atom()), map(), map() -> any())}
+
+  @spec llvm_revision() :: String.t()
+  def llvm_revision do
+    MLIR.CAPI.beaverGetLLVMVersion() |> MLIR.to_string()
+  end
+
+  @spec compile(binary() | MLIR.Module.t(), [compile_option()]) ::
+          {:ok, Artifact.t()} | {:error, Exception.t()}
+  def compile(source, opts \\ []) do
+    {:ok, compile!(source, opts)}
+  rescue
+    exception -> {:error, exception}
+  end
+
+  @spec compile!(binary() | MLIR.Module.t(), [compile_option()]) :: Artifact.t()
+  def compile!(source, opts \\ []) do
+    cache = Keyword.get(opts, :cache, :memory)
+    {source_bytes, source_context} = source_bytes_and_context(source)
+    inputs = compatibility_inputs(source_bytes, opts)
+    lookup_key = CacheKey.lookup(inputs)
+
+    {cached, cache_lookup_duration} = timed(fn -> CompilationCache.get(cache, lookup_key) end)
+
+    MLIR.Telemetry.emit(
+      [:cache, :lookup],
+      %{duration: cache_lookup_duration},
+      %{lookup_key: lookup_key},
+      opts
+    )
+
+    case validate_cache_entry(cached, lookup_key, inputs) do
+      {:ok, entry} ->
+        timings = %{cache_lookup: cache_lookup_duration, parse: 0, transform: 0, serialize: 0}
+        emit_cache_result(:hit, lookup_key, timings, opts)
+        artifact_from_entry(entry, :hit, timings)
+
+      {:miss, reason} ->
+        if reason != :not_found do
+          CompilationCache.delete(cache, lookup_key)
+
+          MLIR.Telemetry.emit(
+            [:cache, :failure],
+            %{count: 1},
+            %{lookup_key: lookup_key, reason: reason},
+            opts
+          )
+        end
+
+        compile_miss(
+          source_bytes,
+          source_context,
+          inputs,
+          lookup_key,
+          cache,
+          cache_lookup_duration,
+          opts
+        )
+    end
+  end
+
+  @doc "Explicitly invalidate one cache lookup key, or all entries."
+  @spec invalidate(CompilationCache.cache(), String.t() | :all) :: :ok | {:error, term()}
+  def invalidate(cache \\ :memory, key \\ :all)
+  def invalidate(cache, :all), do: CompilationCache.clear(cache)
+  def invalidate(cache, key) when is_binary(key), do: CompilationCache.delete(cache, key)
+
+  @doc "Create and initialize a JIT from a validated compilation artifact."
+  @spec jit!(Artifact.t(), keyword()) :: MLIR.ExecutionEngine.t()
+  def jit!(%Artifact{} = artifact, opts \\ []) do
+    {jit, codegen_duration} =
+      timed(fn ->
+        with_module(artifact, opts, fn module ->
+          MLIR.ExecutionEngine.create!(module, execution_engine_opts(opts))
+        end)
+      end)
+
+    MLIR.Telemetry.emit(
+      [:codegen],
+      %{duration: codegen_duration},
+      event_metadata(artifact),
+      opts
+    )
+
+    if Keyword.get(opts, :initialize, true) do
+      {jit, load_duration} = timed(fn -> MLIR.ExecutionEngine.init(jit) end)
+
+      MLIR.Telemetry.emit(
+        [:jit_load],
+        %{duration: load_duration},
+        event_metadata(artifact),
+        opts
+      )
+
+      jit
+    else
+      jit
+    end
+  end
+
+  @doc "Emit an object file from the same normalized artifact used by `jit!/2`."
+  @spec emit_object!(Artifact.t(), Path.t(), keyword()) :: Path.t()
+  def emit_object!(%Artifact{} = artifact, path, opts \\ []) do
+    opts = Keyword.merge([object_dump: true, enable_pic: true], opts)
+    jit = jit!(artifact, Keyword.put(opts, :initialize, false))
+
+    try do
+      {path, duration} = timed(fn -> MLIR.ExecutionEngine.emit_object!(jit, path) end)
+
+      MLIR.Telemetry.emit(
+        [:object_emission],
+        %{duration: duration},
+        Map.put(event_metadata(artifact), :path, path),
+        opts
+      )
+
+      path
+    after
+      MLIR.ExecutionEngine.destroy(jit)
+    end
+  end
+
+  defp compile_miss(
+         source_bytes,
+         source_context,
+         inputs,
+         lookup_key,
+         cache,
+         cache_lookup_duration,
+         opts
+       ) do
+    {context, owned_context?} = compilation_context(source_context, opts)
+
+    try do
+      {module, parse_duration} =
+        timed(fn -> MLIR.Bytecode.read!(source_bytes, ctx: context) end)
+
+      try do
+        structural_hash =
+          module
+          |> MLIR.Operation.from_module()
+          |> MLIR.Operation.structural_hash(ignore_locations: true)
+
+        {module, transform_duration} = timed(fn -> run_pipeline(module, opts) end)
+
+        {bytecode, serialize_duration} =
+          timed(fn ->
+            MLIR.Bytecode.write!(module,
+              desired_emit_version: Keyword.get(opts, :desired_emit_version)
+            )
+          end)
+
+        artifact_key = CacheKey.artifact(inputs, structural_hash)
+
+        metadata =
+          Map.merge(inputs, %{
+            structural_hash: structural_hash,
+            lookup_key: lookup_key,
+            artifact_key: artifact_key
+          })
+
+        entry = %{
+          format: @entry_format,
+          lookup_key: lookup_key,
+          artifact_key: artifact_key,
+          metadata: metadata,
+          bytecode: bytecode,
+          bytecode_digest: digest(bytecode)
+        }
+
+        case CompilationCache.put(cache, lookup_key, entry) do
+          :ok ->
+            :ok
+
+          {:error, reason} ->
+            MLIR.Telemetry.emit(
+              [:cache, :failure],
+              %{count: 1},
+              %{lookup_key: lookup_key, reason: {:write, reason}},
+              opts
+            )
+        end
+
+        timings = %{
+          cache_lookup: cache_lookup_duration,
+          parse: parse_duration,
+          transform: transform_duration,
+          serialize: serialize_duration
+        }
+
+        emit_stage(:parse, parse_duration, artifact_key, opts)
+        emit_stage(:transform, transform_duration, artifact_key, opts)
+        emit_stage(:serialize, serialize_duration, artifact_key, opts)
+        emit_cache_result(:miss, lookup_key, timings, opts)
+
+        artifact_from_entry(entry, :miss, timings)
+      after
+        MLIR.Module.destroy(module)
+      end
+    after
+      if owned_context?, do: MLIR.Context.destroy(context)
+    end
+  end
+
+  defp source_bytes_and_context(%MLIR.Module{} = module) do
+    {MLIR.Bytecode.write!(module), MLIR.context(module)}
+  end
+
+  defp source_bytes_and_context(source) when is_binary(source), do: {source, nil}
+
+  defp compilation_context(source_context, opts) do
+    case Keyword.get(opts, :context, source_context) do
+      nil -> {MLIR.Context.create(Keyword.get(opts, :context_options, [])), true}
+      context -> {context, false}
+    end
+  end
+
+  defp compatibility_inputs(source_bytes, opts) do
+    %{
+      source_digest: digest(source_bytes),
+      llvm_revision: Keyword.get_lazy(opts, :llvm_revision, &llvm_revision/0),
+      pipeline: pipeline_identity(opts),
+      target: Keyword.get(opts, :target, %{}),
+      schema_version: Keyword.get(opts, :schema_version, :static),
+      bytecode_version: Keyword.get(opts, :desired_emit_version, :current)
+    }
+  end
+
+  defp pipeline_identity(opts) do
+    case Keyword.fetch(opts, :pipeline_version) do
+      {:ok, version} -> version
+      :error -> assert_deterministic_pipeline!(Keyword.get(opts, :pipeline, []))
+    end
+  end
+
+  defp assert_deterministic_pipeline!(pipeline) when is_function(pipeline) do
+    raise ArgumentError, ":pipeline_version is required for function-based pipelines"
+  end
+
+  defp assert_deterministic_pipeline!(pipeline) when is_list(pipeline) do
+    Enum.map(pipeline, &assert_deterministic_pipeline!/1)
+  end
+
+  defp assert_deterministic_pipeline!({operation, passes}) do
+    {operation, assert_deterministic_pipeline!(passes)}
+  end
+
+  defp assert_deterministic_pipeline!(pipeline)
+       when is_binary(pipeline) or is_atom(pipeline),
+       do: pipeline
+
+  defp assert_deterministic_pipeline!(pipeline) do
+    raise ArgumentError,
+          ":pipeline_version is required for non-data pipeline #{inspect(pipeline, limit: 5)}"
+  end
+
+  defp run_pipeline(module, opts) do
+    case Keyword.get(opts, :pipeline, []) do
+      [] ->
+        module
+
+      pipeline ->
+        pipeline
+        |> List.wrap()
+        |> Enum.reduce(Composer.new(module), &Composer.append(&2, &1))
+        |> Composer.run!()
+    end
+  end
+
+  defp validate_cache_entry(:miss, _lookup_key, _inputs), do: {:miss, :not_found}
+  defp validate_cache_entry({:error, reason}, _lookup_key, _inputs), do: {:miss, {:read, reason}}
+
+  defp validate_cache_entry({:ok, entry}, lookup_key, inputs) do
+    with true <- entry[:format] == @entry_format,
+         true <- entry[:lookup_key] == lookup_key,
+         %{structural_hash: structural_hash} = metadata <- entry[:metadata],
+         true <- Map.take(metadata, Map.keys(inputs)) == inputs,
+         true <- entry[:artifact_key] == CacheKey.artifact(inputs, structural_hash),
+         bytecode when is_binary(bytecode) <- entry[:bytecode],
+         true <- entry[:bytecode_digest] == digest(bytecode) do
+      {:ok, entry}
+    else
+      _ -> {:miss, :incompatible_or_corrupt_entry}
+    end
+  rescue
+    _ -> {:miss, :incompatible_or_corrupt_entry}
+  end
+
+  defp artifact_from_entry(entry, cache_status, timings) do
+    %Artifact{
+      key: entry.artifact_key,
+      bytecode: entry.bytecode,
+      metadata: entry.metadata,
+      cache: cache_status,
+      timings: timings
+    }
+  end
+
+  defp with_module(artifact, opts, fun) do
+    context = MLIR.Context.create(Keyword.get(opts, :context_options, []))
+
+    try do
+      MLIR.Context.register_translations(context)
+      module = MLIR.Bytecode.read!(artifact.bytecode, ctx: context)
+
+      try do
+        fun.(module)
+      after
+        MLIR.Module.destroy(module)
+      end
+    after
+      MLIR.Context.destroy(context)
+    end
+  end
+
+  defp execution_engine_opts(opts) do
+    Keyword.take(opts, [:shared_lib_paths, :opt_level, :object_dump, :enable_pic, :dirty])
+  end
+
+  defp emit_stage(stage, duration, artifact_key, opts) do
+    MLIR.Telemetry.emit([stage], %{duration: duration}, %{artifact_key: artifact_key}, opts)
+  end
+
+  defp emit_cache_result(result, lookup_key, timings, opts) do
+    MLIR.Telemetry.emit(
+      [:cache, result],
+      %{count: 1},
+      %{lookup_key: lookup_key, timings: timings},
+      opts
+    )
+  end
+
+  defp event_metadata(artifact), do: %{artifact_key: artifact.key, cache: artifact.cache}
+
+  defp digest(binary), do: :crypto.hash(:sha256, binary) |> Base.encode16(case: :lower)
+
+  defp timed(fun) do
+    started = System.monotonic_time()
+    result = fun.()
+    {result, System.monotonic_time() - started}
+  end
+end

--- a/lib/beaver/mlir/compilation_runtime/artifact.ex
+++ b/lib/beaver/mlir/compilation_runtime/artifact.ex
@@ -1,0 +1,14 @@
+defmodule Beaver.MLIR.CompilationRuntime.Artifact do
+  @moduledoc "A reusable, version-checked MLIR bytecode compilation artifact."
+
+  @enforce_keys [:key, :bytecode, :metadata, :cache, :timings]
+  defstruct [:key, :bytecode, :metadata, :cache, :timings]
+
+  @type t :: %__MODULE__{
+          key: String.t(),
+          bytecode: binary(),
+          metadata: map(),
+          cache: :hit | :miss,
+          timings: %{optional(atom()) => integer()}
+        }
+end

--- a/lib/beaver/mlir/compilation_runtime/cache_key.ex
+++ b/lib/beaver/mlir/compilation_runtime/cache_key.ex
@@ -1,0 +1,47 @@
+defmodule Beaver.MLIR.CompilationRuntime.CacheKey do
+  @moduledoc "Deterministic compatibility keys for incremental MLIR artifacts."
+
+  @version 1
+
+  @spec lookup(map()) :: String.t()
+  def lookup(inputs), do: digest({:beaver_mlir_lookup, @version, normalize(inputs)})
+
+  @spec artifact(map(), non_neg_integer()) :: String.t()
+  def artifact(inputs, structural_hash) do
+    digest({:beaver_mlir_artifact, @version, normalize(inputs), structural_hash})
+  end
+
+  @spec digest(term()) :: String.t()
+  def digest(term) do
+    term
+    |> :erlang.term_to_binary([:deterministic])
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.encode16(case: :lower)
+  end
+
+  defp normalize(%_{} = struct) do
+    {:struct, struct.__struct__ |> Atom.to_string(), struct |> Map.from_struct() |> normalize()}
+  end
+
+  defp normalize(map) when is_map(map) do
+    {:map,
+     map
+     |> Enum.map(fn {key, value} -> {normalize(key), normalize(value)} end)
+     |> Enum.sort()}
+  end
+
+  defp normalize(tuple) when is_tuple(tuple) do
+    {:tuple, tuple |> Tuple.to_list() |> Enum.map(&normalize/1)}
+  end
+
+  defp normalize(list) when is_list(list), do: Enum.map(list, &normalize/1)
+
+  defp normalize(value)
+       when is_atom(value) or is_binary(value) or is_number(value),
+       do: value
+
+  defp normalize(value) do
+    raise ArgumentError,
+          "cache inputs must be deterministic data, got: #{inspect(value, limit: 5)}"
+  end
+end

--- a/lib/beaver/mlir/context.ex
+++ b/lib/beaver/mlir/context.ex
@@ -4,7 +4,11 @@ defmodule Beaver.MLIR.Context do
   """
   alias Beaver.MLIR
   import MLIR.CAPI
-  use Kinda.ResourceKind, raw_module: Beaver.MLIR.CAPI.Raw, codec: Beaver.Native
+
+  use Kinda.ResourceKind,
+    raw_module: Beaver.MLIR.CAPI.Raw,
+    codec: Beaver.Native,
+    fields: [thread_pool_owner: nil, thread_pool_lease: nil]
 
   @doc """
   Run a function with a registry appended to the context.
@@ -24,12 +28,19 @@ defmodule Beaver.MLIR.Context do
   defp load_all_dialects(ctx) do
     with_registry(ctx, fn registry ->
       mlirRegisterAllDialects(registry)
+      # Appending copies the registry's current contents. `with_registry/2`
+      # appended it while empty, so append again after registration.
       mlirContextAppendDialectRegistry(ctx, registry)
       mlirContextLoadAllAvailableDialects(ctx)
     end)
   end
 
-  @type context_option :: {:allow_unregistered, boolean()} | {:all_dialects, boolean()}
+  @type context_option ::
+          {:allow_unregistered, boolean()}
+          | {:all_dialects, boolean()}
+          | {:threading, boolean()}
+          | {:thread_pool, :application | MLIR.LLVMThreadPool.t() | GenServer.server() | nil}
+          | {:registry, MLIR.DialectRegistry.t() | [MLIR.DialectRegistry.t()]}
   @spec create([context_option()]) :: __MODULE__.t()
   @doc """
   Create a MLIR context. By default it registers and loads all dialects.
@@ -37,13 +48,89 @@ defmodule Beaver.MLIR.Context do
   def create(opts \\ []) do
     allow_unregistered = Keyword.get(opts, :allow_unregistered, false)
     all_dialects = Keyword.get(opts, :all_dialects, true)
+    threading = Keyword.get(opts, :threading, true)
 
-    mlirContextCreate()
-    |> tap(fn ctx -> if all_dialects, do: load_all_dialects(ctx) end)
-    |> tap(&mlirContextSetAllowUnregisteredDialects(&1, allow_unregistered))
+    if not threading and Keyword.has_key?(opts, :thread_pool) do
+      raise ArgumentError, ":thread_pool cannot be used with threading: false"
+    end
+
+    {pool, owner, lease} = resolve_thread_pool(opts, threading)
+    ctx = mlirContextCreate()
+
+    try do
+      if pool do
+        # MLIR requires threading to be disabled before replacing its
+        # internally-owned pool; setting the external pool enables it again.
+        mlirContextEnableMultithreading(ctx, false)
+        mlirContextSetThreadPool(ctx, pool)
+      end
+
+      if not threading, do: mlirContextEnableMultithreading(ctx, false)
+
+      opts
+      |> Keyword.get(:registry, [])
+      |> List.wrap()
+      |> Enum.each(&mlirContextAppendDialectRegistry(ctx, &1))
+
+      if all_dialects, do: load_all_dialects(ctx)
+      mlirContextSetAllowUnregisteredDialects(ctx, allow_unregistered)
+
+      %{ctx | thread_pool_owner: owner, thread_pool_lease: lease}
+    rescue
+      exception ->
+        mlirContextDestroy(ctx)
+        if owner, do: MLIR.ThreadPool.checkin(owner, lease)
+        reraise exception, __STACKTRACE__
+    end
   end
 
-  defdelegate destroy(ctx), to: MLIR.CAPI, as: :mlirContextDestroy
+  def destroy(%__MODULE__{} = ctx) do
+    try do
+      mlirContextDestroy(ctx)
+    after
+      if ctx.thread_pool_owner do
+        MLIR.ThreadPool.checkin(ctx.thread_pool_owner, ctx.thread_pool_lease)
+      end
+    end
+  end
+
+  defp resolve_thread_pool(_opts, false), do: {nil, nil, nil}
+
+  defp resolve_thread_pool(opts, true) do
+    case Keyword.get(opts, :thread_pool, :application) do
+      nil ->
+        {nil, nil, nil}
+
+      %MLIR.LLVMThreadPool{} = pool ->
+        {pool, nil, nil}
+
+      :application ->
+        checkout_if_running(MLIR.ThreadPool.default_name())
+
+      owner when is_atom(owner) or is_pid(owner) or is_tuple(owner) ->
+        checkout(owner)
+    end
+  end
+
+  defp checkout_if_running(owner) do
+    case GenServer.whereis(owner) do
+      nil ->
+        {nil, nil, nil}
+
+      _pid ->
+        checkout(owner)
+    end
+  end
+
+  defp checkout(owner) do
+    case MLIR.ThreadPool.checkout(owner) do
+      {%MLIR.LLVMThreadPool{} = pool, lease} ->
+        {pool, owner, lease}
+
+      {:error, :closing} ->
+        raise ArgumentError, "the selected MLIR thread pool is closing"
+    end
+  end
 
   def allow_unregistered_dialects(ctx, allow \\ true) do
     mlirContextSetAllowUnregisteredDialects(ctx, allow)

--- a/lib/beaver/mlir/execution_engine.ex
+++ b/lib/beaver/mlir/execution_engine.ex
@@ -26,7 +26,8 @@ defmodule Beaver.MLIR.ExecutionEngine do
           {:opt_level, opt_level},
           {:object_dump, object_dump},
           {:enable_pic, enable_pic},
-          {:dirty, dirty}
+          {:dirty, dirty},
+          {:telemetry, (list(atom()), map(), map() -> any())}
         ]
   @spec create!(MLIR.Module.t(), opts()) :: t()
   def create!(module, opts \\ []) do
@@ -76,15 +77,27 @@ defmodule Beaver.MLIR.ExecutionEngine do
       end
       |> List.wrap()
 
-    Beaver.Native.apply_dirty(
-      :mlirExecutionEngineInvokePacked,
-      [
-        jit,
-        MLIR.StringRef.create(symbol),
-        Beaver.Native.array(arg_ptr_list ++ return_ptr, Beaver.Native.OpaquePtr, mut: true)
-      ],
-      opts[:dirty]
+    {result, duration} =
+      timed(fn ->
+        Beaver.Native.apply_dirty(
+          :mlirExecutionEngineInvokePacked,
+          [
+            jit,
+            MLIR.StringRef.create(symbol),
+            Beaver.Native.array(arg_ptr_list ++ return_ptr, Beaver.Native.OpaquePtr, mut: true)
+          ],
+          opts[:dirty]
+        )
+      end)
+
+    Beaver.MLIR.Telemetry.emit(
+      [:execution],
+      %{duration: duration},
+      %{symbol: to_string(symbol)},
+      opts
     )
+
+    result
     |> then(
       &if MLIR.LogicalResult.success?(&1) do
         return || :ok
@@ -105,10 +118,50 @@ defmodule Beaver.MLIR.ExecutionEngine do
 
   defdelegate destroy(jit), to: MLIR.CAPI, as: :mlirExecutionEngineDestroy
 
+  @doc "Look up a symbol in an execution engine."
+  @spec lookup(t(), String.t() | MLIR.StringRef.t(), keyword()) :: Beaver.Native.OpaquePtr.t()
+  def lookup(jit, symbol, opts \\ []) do
+    function =
+      if Keyword.get(opts, :packed, false),
+        do: :mlirExecutionEngineLookupPacked,
+        else: :mlirExecutionEngineLookup
+
+    apply(MLIR.CAPI, function, [jit, MLIR.StringRef.create(symbol)])
+  end
+
+  @doc "Register a native pointer under a symbol name."
+  @spec register_symbol(t(), String.t() | MLIR.StringRef.t(), Beaver.Native.OpaquePtr.t()) :: t()
+  def register_symbol(jit, symbol, pointer) do
+    mlirExecutionEngineRegisterSymbol(jit, MLIR.StringRef.create(symbol), pointer)
+    jit
+  end
+
+  @doc """
+  Write the object captured by an engine created with `object_dump: true`.
+  """
+  @spec emit_object!(t(), Path.t()) :: Path.t()
+  def emit_object!(jit, path) do
+    path = Path.expand(path)
+    path |> Path.dirname() |> File.mkdir_p!()
+    mlirExecutionEngineDumpToObjectFile(jit, MLIR.StringRef.create(path))
+
+    if File.regular?(path) do
+      path
+    else
+      raise "MLIR execution engine did not emit an object file at #{path}"
+    end
+  end
+
   @doc """
   Get the paths to the runtime libraries provided by MLIR.
   """
   def runtime_libs do
     Path.join([:code.priv_dir(:beaver), "lib", "*"]) |> Path.wildcard()
+  end
+
+  defp timed(fun) do
+    started = System.monotonic_time()
+    result = fun.()
+    {result, System.monotonic_time() - started}
   end
 end

--- a/lib/beaver/mlir/rewrite_pattern_set.ex
+++ b/lib/beaver/mlir/rewrite_pattern_set.ex
@@ -106,7 +106,8 @@ defmodule Beaver.MLIR.RewritePatternSet do
   end
 
   @doc """
-  Use thread pool of the given `ctx` to destroy the given `MLIR.RewritePatternSet` or `MLIR.FrozenRewritePatternSet`.
+  Destroy the given `MLIR.RewritePatternSet` or `MLIR.FrozenRewritePatternSet`
+  outside a BEAM scheduler thread.
   """
   def threaded_destroy(ctx, set) do
     do_destroy(ctx, set)

--- a/lib/beaver/mlir/telemetry.ex
+++ b/lib/beaver/mlir/telemetry.ex
@@ -1,0 +1,20 @@
+defmodule Beaver.MLIR.Telemetry do
+  @moduledoc false
+
+  @prefix [:beaver, :mlir, :compilation]
+
+  def emit(event_suffix, measurements, metadata, opts \\ []) do
+    event = @prefix ++ event_suffix
+
+    if function_exported?(:telemetry, :execute, 3) do
+      apply(:telemetry, :execute, [event, measurements, metadata])
+    end
+
+    case Keyword.get(opts, :telemetry) do
+      callback when is_function(callback, 3) -> callback.(event, measurements, metadata)
+      _ -> :ok
+    end
+
+    :ok
+  end
+end

--- a/lib/beaver/mlir/thread_pool.ex
+++ b/lib/beaver/mlir/thread_pool.ex
@@ -1,0 +1,132 @@
+defmodule Beaver.MLIR.ThreadPool do
+  @moduledoc """
+  Owns an LLVM thread pool that can be shared by multiple MLIR contexts.
+
+  The application starts one pool under `default_name/0`. `MLIR.Context.create/1`
+  checks out a lease from it by default and returns the lease when the context is
+  destroyed. Calling `close/1` while contexts are attached defers native pool
+  destruction until the final lease is returned.
+
+  If an owner is forcibly terminated while leases remain, the native pool is
+  deliberately retained so attached MLIR contexts never hold a dangling pool
+  pointer. Use `close/1` for deterministic reclamation.
+
+  An explicit owner can be selected with `thread_pool: owner`, or a raw
+  `Beaver.MLIR.LLVMThreadPool` can be supplied when its lifetime is managed by
+  the caller.
+  """
+
+  use GenServer
+
+  alias Beaver.MLIR
+
+  @default_name __MODULE__
+
+  @spec default_name() :: module()
+  def default_name, do: @default_name
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    {name, opts} = Keyword.pop(opts, :name)
+    GenServer.start_link(__MODULE__, opts, if(name, do: [name: name], else: []))
+  end
+
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    %{
+      id: Keyword.get(opts, :name, __MODULE__),
+      start: {__MODULE__, :start_link, [opts]},
+      restart: :transient,
+      type: :worker
+    }
+  end
+
+  @spec checkout(GenServer.server()) ::
+          {MLIR.LLVMThreadPool.t(), reference()} | {:error, :closing}
+  def checkout(owner \\ @default_name), do: GenServer.call(owner, :checkout)
+
+  @spec checkin(GenServer.server(), reference()) :: :ok
+  def checkin(owner \\ @default_name, lease) do
+    GenServer.cast(owner, {:checkin, lease})
+  catch
+    :exit, _ -> :ok
+  end
+
+  @spec pool(GenServer.server()) :: MLIR.LLVMThreadPool.t()
+  def pool(owner \\ @default_name), do: GenServer.call(owner, :pool)
+
+  @doc "Create a caller-owned native pool for use with `MLIR.Context.create/1`."
+  @spec create() :: MLIR.LLVMThreadPool.t()
+  def create, do: MLIR.CAPI.mlirLlvmThreadPoolCreate()
+
+  @doc "Destroy a caller-owned native pool after all attached contexts are gone."
+  @spec destroy(MLIR.LLVMThreadPool.t()) :: :ok
+  defdelegate destroy(pool), to: MLIR.CAPI, as: :mlirLlvmThreadPoolDestroy
+
+  @spec max_concurrency(GenServer.server() | MLIR.LLVMThreadPool.t()) :: non_neg_integer()
+  def max_concurrency(owner \\ @default_name)
+
+  def max_concurrency(%MLIR.LLVMThreadPool{} = pool) do
+    MLIR.CAPI.mlirLlvmThreadPoolGetMaxConcurrency(pool) |> Beaver.Native.to_term()
+  end
+
+  def max_concurrency(owner), do: owner |> pool() |> max_concurrency()
+
+  @doc """
+  Closes the owner. Returns `:deferred` if attached contexts still hold leases.
+  """
+  @spec close(GenServer.server()) :: :ok | :deferred
+  def close(owner \\ @default_name), do: GenServer.call(owner, :close)
+
+  @impl GenServer
+  def init(opts) do
+    concurrency = Keyword.get(opts, :concurrency, System.schedulers_online())
+
+    unless is_integer(concurrency) and concurrency > 0 do
+      raise ArgumentError, ":concurrency must be a positive integer"
+    end
+
+    pool = MLIR.CAPI.beaverLlvmThreadPoolCreateElastic(concurrency)
+    {:ok, %{pool: pool, leases: MapSet.new(), closing?: false}}
+  end
+
+  @impl GenServer
+  def handle_call(:pool, _from, state), do: {:reply, state.pool, state}
+
+  def handle_call(:checkout, _from, %{closing?: true} = state) do
+    {:reply, {:error, :closing}, state}
+  end
+
+  def handle_call(:checkout, _from, state) do
+    lease = make_ref()
+    {:reply, {state.pool, lease}, %{state | leases: MapSet.put(state.leases, lease)}}
+  end
+
+  def handle_call(:close, _from, %{leases: leases} = state) do
+    if MapSet.size(leases) == 0 do
+      {:stop, :normal, :ok, state}
+    else
+      {:reply, :deferred, %{state | closing?: true}}
+    end
+  end
+
+  @impl GenServer
+  def handle_cast({:checkin, lease}, state) do
+    state = %{state | leases: MapSet.delete(state.leases, lease)}
+
+    if state.closing? and MapSet.size(state.leases) == 0 do
+      {:stop, :normal, state}
+    else
+      {:noreply, state}
+    end
+  end
+
+  @impl GenServer
+  def terminate(_reason, state) do
+    if MapSet.size(state.leases) == 0 do
+      destroy(state.pool)
+    end
+
+    :ok
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -56,6 +56,7 @@ defmodule Beaver.MixProject do
       main: "Beaver",
       extras: [
         "guides/your-first-beaver-compiler.livemd",
+        "guides/incremental-compilation-runtime.md",
         "CONTRIBUTING.md",
         "README.md"
       ],

--- a/native/include/mlir-c/Beaver/Context.h
+++ b/native/include/mlir-c/Beaver/Context.h
@@ -7,8 +7,20 @@
 extern "C" {
 #endif
 
+/// Schedules callback-bridging work on the context's LLVM pool, outside BEAM
+/// scheduler threads. An elastic pool prevents nested pass/rewrite callbacks
+/// from starving a pool shared by multiple contexts.
 MLIR_CAPI_EXPORTED bool beaverContextAddWork(MlirContext context,
                                              void (*task)(void *), void *arg);
+
+/// Creates a reusable thread pool that grows beyond its reported parallelism
+/// when every worker is blocked by nested synchronous callback work.
+MLIR_CAPI_EXPORTED MlirLlvmThreadPool
+beaverLlvmThreadPoolCreateElastic(unsigned maxConcurrency);
+
+/// Returns the LLVM version and source revision used to build Beaver. The
+/// returned string has static storage duration and must not be freed.
+MLIR_CAPI_EXPORTED MlirStringRef beaverGetLLVMVersion(void);
 
 #ifdef __cplusplus
 }

--- a/native/lib/CAPI/Beaver.cpp
+++ b/native/lib/CAPI/Beaver.cpp
@@ -7,9 +7,131 @@
 #include "mlir/Dialect/IRDL/IRDLLoading.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
 #include "mlir/IR/ExtensibleDialect.h"
+#include "llvm/Config/llvm-config.h"
 #include "llvm/Support/ThreadPool.h"
+#include "llvm/Support/VCSRevision.h"
+#include <algorithm>
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
 
 using namespace mlir;
+
+namespace {
+/// A reusable pool with a nominal MLIR parallelism limit and elastic workers.
+/// MLIR uses `getMaxConcurrency()` to bound ordinary parallel algorithms. The
+/// pool itself may grow past that number when active work synchronously waits
+/// for BEAM callbacks which start nested MLIR work on the same shared pool.
+class BeaverElasticThreadPool final : public llvm::ThreadPoolInterface {
+public:
+  explicit BeaverElasticThreadPool(unsigned maxConcurrency)
+      : maxConcurrency(std::max(1u, maxConcurrency)) {}
+
+  ~BeaverElasticThreadPool() override {
+    {
+      std::unique_lock<std::mutex> lock(mutex);
+      completion.wait(lock, [this]() { return outstanding == 0; });
+      shuttingDown = true;
+    }
+    available.notify_all();
+    for (std::thread &thread : threads)
+      thread.join();
+  }
+
+  void wait() override {
+    std::unique_lock<std::mutex> lock(mutex);
+    completion.wait(lock, [this]() { return outstanding == 0; });
+  }
+
+  void wait(llvm::ThreadPoolTaskGroup &group) override {
+    std::unique_lock<std::mutex> lock(mutex);
+    completion.wait(lock, [this, &group]() {
+      auto it = groupOutstanding.find(&group);
+      return it == groupOutstanding.end() || it->second == 0;
+    });
+  }
+
+  unsigned getMaxConcurrency() const override { return maxConcurrency; }
+
+private:
+  void asyncEnqueue(llvm::unique_function<void()> task,
+                    llvm::ThreadPoolTaskGroup *group) override {
+    std::lock_guard<std::mutex> lock(mutex);
+    assert(!shuttingDown && "queueing work during pool destruction");
+    tasks.emplace_back(std::move(task), group);
+    ++outstanding;
+    if (group)
+      ++groupOutstanding[group];
+
+    const size_t inactiveWorkers = threads.size() - activeWorkers;
+    if (tasks.size() > inactiveWorkers)
+      threads.emplace_back([this]() { workerLoop(); });
+    else
+      available.notify_one();
+  }
+
+  void workerLoop() {
+    while (true) {
+      llvm::unique_function<void()> task;
+      llvm::ThreadPoolTaskGroup *group = nullptr;
+      {
+        std::unique_lock<std::mutex> lock(mutex);
+        available.wait(lock,
+                       [this]() { return shuttingDown || !tasks.empty(); });
+        if (shuttingDown && tasks.empty())
+          return;
+        task = std::move(tasks.front().first);
+        group = tasks.front().second;
+        tasks.pop_front();
+        ++activeWorkers;
+      }
+
+      task();
+
+      {
+        std::lock_guard<std::mutex> lock(mutex);
+        --activeWorkers;
+        --outstanding;
+        if (group) {
+          auto it = groupOutstanding.find(group);
+          if (--it->second == 0)
+            groupOutstanding.erase(it);
+        }
+      }
+      completion.notify_all();
+    }
+  }
+
+  const unsigned maxConcurrency;
+  std::mutex mutex;
+  std::condition_variable available;
+  std::condition_variable completion;
+  std::deque<std::pair<llvm::unique_function<void()>,
+                       llvm::ThreadPoolTaskGroup *>>
+      tasks;
+  std::vector<std::thread> threads;
+  std::unordered_map<llvm::ThreadPoolTaskGroup *, size_t> groupOutstanding;
+  size_t activeWorkers = 0;
+  size_t outstanding = 0;
+  bool shuttingDown = false;
+};
+} // namespace
+
+MLIR_CAPI_EXPORTED MlirLlvmThreadPool
+beaverLlvmThreadPoolCreateElastic(unsigned maxConcurrency) {
+  return wrap(static_cast<llvm::ThreadPoolInterface *>(
+      new BeaverElasticThreadPool(maxConcurrency)));
+}
+
+MLIR_CAPI_EXPORTED MlirStringRef beaverGetLLVMVersion() {
+  static const std::string versionAndRevision =
+      std::string(LLVM_VERSION_STRING) + "@" + LLVM_REVISION;
+  return wrap(llvm::StringRef(versionAndRevision));
+}
 
 MLIR_CAPI_EXPORTED MlirStringRef beaverPassGetArgument(MlirPass pass) {
   auto argument = unwrap(pass)->getArgument();
@@ -277,14 +399,15 @@ beaverGreedyRewriteDriverConfigGet() {
 
 MLIR_CAPI_EXPORTED bool beaverContextAddWork(MlirContext context,
                                              void (*task)(void *), void *arg) {
-  if (unwrap(context)->isMultithreadingEnabled()) {
-    unwrap(mlirContextGetThreadPool(context))->async([task, arg]() {
-      task(arg);
-    });
-    return true;
-  } else {
+  if (!unwrap(context)->isMultithreadingEnabled())
     return false;
-  }
+
+  // Callback bridges may recursively schedule more bridge work (for example,
+  // an Elixir pass applying an Elixir rewrite pattern). The application-owned
+  // elastic pool can grow when all current workers wait for nested callbacks.
+  unwrap(mlirContextGetThreadPool(context))->async(
+      [task, arg]() { task(arg); });
+  return true;
 }
 
 MLIR_CAPI_EXPORTED MlirType beaverDenseElementsAttrGetType(MlirAttribute attr) {

--- a/test/bytecode_test.exs
+++ b/test/bytecode_test.exs
@@ -26,4 +26,17 @@ defmodule BytecodeTest do
     Beaver.Dummy.gigantic(ctx)
     |> roundtrip_bytecode
   end
+
+  test "bytecode writer accepts an explicit desired emit version", %{ctx: ctx} do
+    module = MLIR.Module.create!("module {}", ctx: ctx)
+
+    assert {:ok, bytecode} = MLIR.Bytecode.write(module, desired_emit_version: 0)
+    assert String.starts_with?(bytecode, "ML\xEFR")
+
+    roundtripped = MLIR.Bytecode.read!(bytecode, ctx: ctx)
+    assert MLIR.verify?(roundtripped)
+
+    MLIR.Module.destroy(roundtripped)
+    MLIR.Module.destroy(module)
+  end
 end

--- a/test/capi_test.exs
+++ b/test/capi_test.exs
@@ -95,7 +95,7 @@ defmodule MlirTest do
     module_body = mlirModuleGetBody(module)
     mlirBlockInsertOwnedOperation(module_body, 0, func_op)
     MLIR.verify!(module)
-    mlirContextDestroy(ctx)
+    MLIR.Context.destroy(ctx)
   end
 
   test "elixir dialect" do
@@ -159,7 +159,7 @@ defmodule MlirTest do
 
     mlirPassManagerDestroy(pm)
     mlirModuleDestroy(module)
-    mlirContextDestroy(ctx)
+    MLIR.Context.destroy(ctx)
   end
 
   test "Run a generic pass" do
@@ -174,7 +174,7 @@ defmodule MlirTest do
     :ok = MLIR.PassManager.destroy(pm)
     mlirModuleDestroy(module)
     mlirTypeIDAllocatorDestroy(type_id_allocator)
-    mlirContextDestroy(ctx)
+    MLIR.Context.destroy(ctx)
   end
 
   test "Run a func operation pass", %{ctx: ctx} do
@@ -261,7 +261,7 @@ defmodule MlirTest do
 
     MLIR.ExecutionEngine.destroy(jit)
     MLIR.Module.destroy(module)
-    mlirContextDestroy(ctx)
+    MLIR.Context.destroy(ctx)
   end
 
   test "affine expr and map", %{ctx: ctx} do

--- a/test/compilation_runtime_test.exs
+++ b/test/compilation_runtime_test.exs
@@ -1,0 +1,150 @@
+defmodule CompilationRuntimeTest do
+  use ExUnit.Case, async: true
+
+  alias Beaver.MLIR
+  alias MLIR.CompilationCache
+  alias MLIR.CompilationRuntime
+
+  @source """
+  module {
+    func.func @add(%lhs: i32, %rhs: i32) -> i32 attributes {llvm.emit_c_interface} {
+      %result = arith.addi %lhs, %rhs : i32
+      return %result : i32
+    }
+  }
+  """
+
+  @lowering_pipeline "convert-func-to-llvm,convert-arith-to-llvm"
+
+  setup do
+    cache = start_supervised!({CompilationCache.Memory, []})
+    %{cache: {:memory, cache}}
+  end
+
+  test "an unchanged compile skips parse and transforms on a cache hit", %{cache: cache} do
+    parent = self()
+
+    telemetry = fn event, measurements, metadata ->
+      send(parent, {event, measurements, metadata})
+    end
+
+    opts = [cache: cache, pipeline: "canonicalize", telemetry: telemetry]
+
+    first = CompilationRuntime.compile!(@source, opts)
+    second = CompilationRuntime.compile!(@source, opts)
+
+    assert first.cache == :miss
+    assert second.cache == :hit
+    assert first.key == second.key
+    assert first.bytecode == second.bytecode
+    assert is_integer(first.metadata.structural_hash)
+    assert second.timings.parse == 0
+    assert second.timings.transform == 0
+
+    assert_received {[:beaver, :mlir, :compilation, :cache, :miss], %{count: 1}, _}
+    assert_received {[:beaver, :mlir, :compilation, :cache, :hit], %{count: 1}, _}
+  end
+
+  test "all compatibility dimensions invalidate independently", %{cache: cache} do
+    base = [
+      cache: cache,
+      pipeline: "canonicalize",
+      target: %{triple: "host"},
+      schema_version: 1,
+      llvm_revision: "llvm-a"
+    ]
+
+    assert CompilationRuntime.compile!(@source, base).cache == :miss
+    assert CompilationRuntime.compile!(@source, base).cache == :hit
+
+    for changed <- [
+          Keyword.put(base, :desired_emit_version, 0),
+          Keyword.put(base, :pipeline, "cse"),
+          Keyword.put(base, :target, %{triple: "other"}),
+          Keyword.put(base, :schema_version, 2),
+          Keyword.put(base, :llvm_revision, "llvm-b"),
+          Keyword.put(base, :source, @source <> "\n")
+        ] do
+      {source, changed} = Keyword.pop(changed, :source, @source)
+      assert CompilationRuntime.compile!(source, changed).cache == :miss
+    end
+  end
+
+  test "a corrupt cache entry is invalidated and compilation falls back", %{cache: cache} do
+    artifact = CompilationRuntime.compile!(@source, cache: cache)
+    lookup_key = artifact.metadata.lookup_key
+    :ok = CompilationCache.put(cache, lookup_key, %{format: 1, bytecode: "not bytecode"})
+
+    repaired = CompilationRuntime.compile!(@source, cache: cache)
+
+    assert repaired.cache == :miss
+    assert String.starts_with?(repaired.bytecode, "ML\xEFR")
+    assert CompilationRuntime.compile!(@source, cache: cache).cache == :hit
+  end
+
+  test "filesystem cache survives backend instances and supports invalidation" do
+    root = Path.join(System.tmp_dir!(), "beaver-cache-#{System.unique_integer([:positive])}")
+    on_exit(fn -> File.rm_rf!(root) end)
+
+    first_cache = CompilationCache.File.new(root)
+    second_cache = CompilationCache.File.new(root)
+
+    artifact = CompilationRuntime.compile!(@source, cache: first_cache)
+    assert artifact.cache == :miss
+    assert CompilationRuntime.compile!(@source, cache: second_cache).cache == :hit
+
+    assert :ok = CompilationRuntime.invalidate(second_cache)
+    assert CompilationRuntime.compile!(@source, cache: first_cache).cache == :miss
+  end
+
+  test "runtime functions require an explicit pipeline version", %{cache: cache} do
+    assert_raise ArgumentError, ~r/pipeline_version/, fn ->
+      CompilationRuntime.compile!(@source, cache: cache, pipeline: fn -> :ok end)
+    end
+  end
+
+  test "an unavailable cache backend does not block compilation" do
+    {:ok, cache} = CompilationCache.Memory.start_link()
+    :ok = GenServer.stop(cache)
+
+    artifact = CompilationRuntime.compile!(@source, cache: {:memory, cache})
+
+    assert artifact.cache == :miss
+    assert is_binary(artifact.bytecode)
+  end
+
+  @tag :smoke
+  test "JIT and object emission consume the same normalized artifact", %{cache: cache} do
+    artifact =
+      CompilationRuntime.compile!(@source,
+        cache: cache,
+        pipeline: @lowering_pipeline,
+        target: %{triple: "host"}
+      )
+
+    jit = CompilationRuntime.jit!(artifact)
+
+    try do
+      lhs = Beaver.Native.I32.make(20)
+      rhs = Beaver.Native.I32.make(22)
+      result = Beaver.Native.I32.make(0)
+
+      MLIR.ExecutionEngine.invoke!(jit, "add", [lhs, rhs], result)
+      assert Beaver.Native.to_term(result) == 42
+
+      pointer = MLIR.ExecutionEngine.lookup(jit, "add")
+      assert %Beaver.Native.OpaquePtr{} = pointer
+      assert jit == MLIR.ExecutionEngine.register_symbol(jit, "beaver_test_add", pointer)
+    after
+      MLIR.ExecutionEngine.destroy(jit)
+    end
+
+    object_path =
+      Path.join(System.tmp_dir!(), "beaver-runtime-#{System.unique_integer([:positive])}.o")
+
+    on_exit(fn -> File.rm(object_path) end)
+
+    assert CompilationRuntime.emit_object!(artifact, object_path) == object_path
+    assert File.stat!(object_path).size > 0
+  end
+end

--- a/test/thread_pool_test.exs
+++ b/test/thread_pool_test.exs
@@ -1,0 +1,66 @@
+defmodule ThreadPoolTest do
+  use ExUnit.Case, async: true
+
+  alias Beaver.MLIR
+
+  test "multiple contexts share an owned pool and defer teardown" do
+    {:ok, owner} = MLIR.ThreadPool.start_link()
+    monitor = Process.monitor(owner)
+
+    first = MLIR.Context.create(thread_pool: owner)
+    second = MLIR.Context.create(thread_pool: owner)
+
+    assert first.thread_pool_owner == owner
+    assert second.thread_pool_owner == owner
+
+    first_threads =
+      MLIR.CAPI.mlirContextGetNumThreads(first)
+      |> Beaver.Native.to_term()
+
+    second_threads =
+      MLIR.CAPI.mlirContextGetNumThreads(second)
+      |> Beaver.Native.to_term()
+
+    assert first_threads == MLIR.ThreadPool.max_concurrency(owner)
+    assert second_threads == first_threads
+    assert :deferred = MLIR.ThreadPool.close(owner)
+
+    assert_raise ArgumentError, ~r/thread pool is closing/, fn ->
+      MLIR.Context.create(thread_pool: owner)
+    end
+
+    MLIR.Context.destroy(first)
+    assert Process.alive?(owner)
+    MLIR.Context.destroy(second)
+
+    assert_receive {:DOWN, ^monitor, :process, ^owner, :normal}
+  end
+
+  test "context threading and registry options are explicit" do
+    context = MLIR.Context.create(threading: false, all_dialects: false)
+
+    assert MLIR.CAPI.mlirContextGetNumThreads(context) |> Beaver.Native.to_term() == 1
+    MLIR.Context.destroy(context)
+
+    registry = MLIR.CAPI.mlirDialectRegistryCreate()
+    MLIR.CAPI.mlirRegisterAllDialects(registry)
+
+    context =
+      MLIR.Context.create(
+        registry: registry,
+        all_dialects: false,
+        thread_pool: nil
+      )
+
+    assert MLIR.CAPI.mlirContextGetNumRegisteredDialects(context) |> Beaver.Native.to_term() > 0
+
+    MLIR.Context.destroy(context)
+    MLIR.CAPI.mlirDialectRegistryDestroy(registry)
+  end
+
+  test "a disabled context rejects an external pool" do
+    assert_raise ArgumentError, ~r/thread_pool/, fn ->
+      MLIR.Context.create(threading: false, thread_pool: :application)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- add an application-owned elastic LLVM thread pool with context leases, explicit registry/threading/pool options, and deferred teardown
- add versioned MLIR bytecode APIs plus deterministic memory and filesystem compilation caches
- key artifacts by structural IR hash, LLVM source revision, pipeline, target, dialect schema, and bytecode version
- add cache-to-JIT/object handoff, symbol lookup/registration, stage telemetry, invalidation, corruption checks, and compilation fallback
- document the edit/compile/reload loop and add a cold/warm benchmark

## Why

Beaver exposed parsing, transformations, JIT, and serialization independently. Native-extension development repeatedly rebuilt those layers and recreated compiler resources. This integrates them into a reusable runtime optimized for rapid iteration while keeping cached artifacts version-compatible.

## Benchmark

On an Apple M5 with Elixir 1.20.3 and Erlang 27.3.3:

- cold compile: about 2.10 ms
- warm cache hit: about 0.00470 ms
- warm path: about 448x faster in the included sample

## Validation

- `BEAVER_KINDA_PATH=../kinda mix test` — 201 passed, 8 excluded
- `BEAVER_KINDA_PATH=../kinda mix compile --force --warnings-as-errors`
- `mix format --check-formatted`
- `git diff --check`
- `BEAVER_KINDA_PATH=../kinda mix docs`
- `BEAVER_KINDA_PATH=../kinda mix run bench/incremental_compilation.exs`

Closes #461