### PR TITLE
Complete Beaver.Slang IRDL coverage

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,13 @@
-locals_without_parens = [deftype: 1, defattr: 1, defop: 2, defalias: 2]
+locals_without_parens = [
+  deftype: 1,
+  deftype: 2,
+  defattr: 1,
+  defattr: 2,
+  defop: 2,
+  defalias: 2,
+  defconstraint: 2
+]
+
 # Used by "mix format"
 [
   locals_without_parens: locals_without_parens,

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -3,6 +3,7 @@ locals_without_parens = [
   deftype: 2,
   defattr: 1,
   defattr: 2,
+  defop: 1,
   defop: 2,
   defalias: 2,
   defconstraint: 2

--- a/guides/slang.md
+++ b/guides/slang.md
@@ -1,0 +1,123 @@
+# Defining dynamic dialects with Slang
+
+`Beaver.Slang` defines MLIR types, attributes, and operations in Elixir, then
+builds an IRDL schema that MLIR can verify and load at runtime. The declaration
+names are preserved in the schema, so diagnostics and generated IR remain
+readable.
+
+## A complete dialect
+
+```elixir
+defmodule Geometry do
+  use Beaver.Slang, name: "geometry"
+
+  defconstraint integer_like do
+    all_of([base("!builtin.integer"), any()])
+  end
+
+  defconstraint direction_value do
+    any_of([
+      Beaver.MLIR.Attribute.string("left"),
+      Beaver.MLIR.Attribute.string("right")
+    ])
+  end
+
+  deftype index(element = ^integer_like)
+  deftype token()
+  defattr direction(value = ^direction_value)
+
+  defop consume_token(value = base(token()))
+
+  defop sequence(head = any(), tail = variadic(any()), fallback = optional(any())),
+    results: [value: optional(any())]
+
+  defop scope(),
+    attributes: [label: base("#builtin.string")],
+    regions: [body: {:region, args: [], size: 1}],
+    traits: [:isolated_from_above, :no_terminator]
+
+  defop yield(), traits: [:terminator]
+end
+```
+
+Build and inspect the schema without changing the context's registered dynamic
+dialects:
+
+```elixir
+schema = Geometry.__slang_dialect__(ctx)
+Beaver.MLIR.verify!(schema)
+IO.puts(Beaver.MLIR.to_string(schema, generic: true))
+```
+
+Load it when operations, types, or attributes from the dialect are needed:
+
+```elixir
+result = Beaver.Slang.load(ctx, Geometry)
+true = Beaver.MLIR.LogicalResult.success?(result)
+```
+
+## Constraints
+
+`any()` accepts any type or attribute. `is(value)` requires one exact MLIR type
+or attribute. `any_of(list)` and `all_of(list)` compose constraints, including
+constraints already produced by another combinator.
+
+`base("!dialect.type")` and `base("#dialect.attribute")` constrain the base type
+or attribute without constraining its parameters. A Slang type or attribute
+constructor can also supply the base reference, as in `base(token())` above.
+
+Use `defconstraint` for a reusable constraint and reference it with `^name`.
+`defalias` remains available as an equivalent concise spelling.
+
+## Names and cardinality
+
+Names are inferred from assignments and variables:
+
+```elixir
+deftype pair(left = any(), right = any())
+defop add(lhs = any(), rhs = any()), results: [sum: any()]
+```
+
+For expressions that do not bind a variable, pass `parameter_names`,
+`operand_names`, or `result_names` explicitly:
+
+```elixir
+deftype pair(any(), any()), parameter_names: [:left, :right]
+
+defop add(any(), any()),
+  operand_names: [:lhs, :rhs],
+  results: [any()],
+  result_names: [:sum]
+```
+
+Operation attributes and regions are keyword lists, so their keys are their
+schema names. `optional` and `variadic` apply to operation operands and results,
+which are the entities for which upstream IRDL exposes variadicity. Type and
+attribute parameters, operation attributes, and regions are single entries.
+
+Regions accept these descriptors:
+
+- `:any` allows any region shape.
+- `{:sized, positive_integer}` constrains the block count.
+- `{:region, args: constraints, size: positive_integer}` constrains entry-block
+  arguments, block count, or both. Omit either option to leave it unconstrained.
+
+## Schema and runtime interfaces
+
+The IRDL module and external operation interfaces have different lifetimes.
+`__slang_dialect__/1` only constructs the schema. `Beaver.Slang.load/2`
+canonicalizes and verifies it, registers the dialect, and only then attaches
+the requested built-in dynamic traits:
+
+- `:terminator`
+- `:isolated_from_above`
+- `:no_terminator`
+
+Keeping attachment out of schema construction makes the IRDL module safe to
+inspect, serialize, and test without mutating dialect registration. It also
+makes failures attributable to either schema verification or interface
+attachment instead of interleaving the two phases.
+
+Slang assigns every generated IRDL operation the source location of its
+declaration. Invalid nested constraints therefore report the `deftype`,
+`defattr`, or `defop` line rather than an implementation line inside Slang.

--- a/guides/slang.md
+++ b/guides/slang.md
@@ -118,6 +118,10 @@ inspect, serialize, and test without mutating dialect registration. It also
 makes failures attributable to either schema verification or interface
 attachment instead of interleaving the two phases.
 
+Dynamic dialect and trait registration is local to an `MLIR.Context`; it is not
+stored in IRDL or operation bytecode. Call `Beaver.Slang.load/2` once for every
+new context before parsing text or reading bytecode that uses the dialect.
+
 Slang assigns every generated IRDL operation the source location of its
 declaration. Invalid nested constraints therefore report the `deftype`,
 `defattr`, or `defop` line rather than an implementation line inside Slang.

--- a/lib/beaver/slang.ex
+++ b/lib/beaver/slang.ex
@@ -2,17 +2,23 @@ defmodule Beaver.Slang do
   use Beaver
   alias Beaver.MLIR.Dialect.IRDL
   @variadic_tags [:variadic, :optional, :single]
-  @callback __slang_dialect__(ctx :: Beaver.MLIR.Context.t()) :: :ok | {:error, String.t()}
+  @dynamic_traits [:terminator, :isolated_from_above, :no_terminator]
+  @callback __slang_dialect__(ctx :: Beaver.MLIR.Context.t()) :: Beaver.MLIR.Module.t()
+  @callback __slang_traits__() :: [{String.t(), [atom()]}]
+  @callback __slang_dialect_name__() :: String.t()
   @moduledoc """
-  Provides macros and utilities for defining MLIR dialects in Elixir.
+  Defines extensible MLIR dialects in Elixir and compiles their schemas to
+  [IRDL](https://mlir.llvm.org/docs/Dialects/IRDL/).
 
-  This module allows you to define MLIR dialects using Elixir macros, which are internally compiled to
-  [IRDL](https://mlir.llvm.org/docs/Dialects/IRDL/). It provides:
+  Slang supports named type and attribute parameters, named operation operands,
+  results, attributes and regions, reusable constraints, `any_of`, `all_of` and
+  `base` constraints, and optional or variadic operands and results. Built-in
+  dynamic operation traits can be attached when the dialect is loaded.
 
-  - Macro-based dialect definition
-  - Operation creation and manipulation
-  - Type and attribute handling
-  - Constraint definition support
+  Schema construction and runtime interface attachment are separate:
+  `__slang_dialect__/1` builds the inspectable IRDL module, while `load/2`
+  verifies and registers that module before attaching traits. See the
+  [Slang guide](slang.html) for a complete dialect and the supported syntax.
   """
 
   @doc """
@@ -29,6 +35,7 @@ defmodule Beaver.Slang do
       Module.register_attribute(__MODULE__, :__slang__operation__, accumulate: true)
       Module.register_attribute(__MODULE__, :__slang__creator__, accumulate: true)
       Module.register_attribute(__MODULE__, :__slang__type__, accumulate: true)
+      Module.register_attribute(__MODULE__, :__slang__trait__, accumulate: true)
     end
   end
 
@@ -43,6 +50,12 @@ defmodule Beaver.Slang do
         )
       end
 
+      @doc false
+      def __slang_traits__, do: Enum.reverse(@__slang__trait__)
+
+      @doc false
+      def __slang_dialect_name__, do: @__slang_dialect_name__
+
       use Beaver.MLIR.Dialect,
         dialect: @__slang_dialect_name__,
         ops: @__slang__operation__ || []
@@ -56,7 +69,12 @@ defmodule Beaver.Slang do
 
     quote do
       mlir do
-        opts = [ctx: Beaver.Env.context(), ip: Beaver.Env.block()]
+        opts = [
+          ctx: Beaver.Env.context(),
+          ip: Beaver.Env.block(),
+          loc: Kernel.var!(slang_internal_source_loc)
+        ]
+
         unquote(alias_name)(opts)
       end
     end
@@ -69,7 +87,8 @@ defmodule Beaver.Slang do
       unquote(var) =
         Beaver.Slang.create_constraint(unquote(right),
           ip: Beaver.Env.block(),
-          ctx: Beaver.Env.context()
+          ctx: Beaver.Env.context(),
+          loc: Kernel.var!(slang_internal_source_loc)
         )
     end
   end
@@ -88,37 +107,54 @@ defmodule Beaver.Slang do
     use Beaver
 
     mlir ctx: opts[:ctx], ip: Beaver.Deferred.fetch_insertion_point(opts) do
-      Beaver.MLIR.Dialect.IRDL.is(expected: t) >>> ~t{!irdl.attribute}
+      loc = constraint_location(opts, Beaver.Env.context())
+      Beaver.MLIR.Dialect.IRDL.is([loc, expected: t]) >>> ~t{!irdl.attribute}
     end
   end
 
   @doc false
   # This function applies the target op to the given SSA (Static Single Assignment) form.
   defp op_applier(ssa) do
-    i =
-      Enum.find_index(ssa.arguments, fn
-        {:slang_target_op, _} -> true
-        _ -> false
-      end)
-
-    {{:slang_target_op, op}, arguments} = List.pop_at(ssa.arguments, i)
+    {op, arguments} = pop_metadata!(ssa.arguments, :slang_target_op)
+    {names, arguments} = pop_metadata!(arguments, :slang_names)
+    {loc, arguments} = pop_metadata!(arguments, :slang_location)
     n = arguments |> Enum.count(&match?(%MLIR.Value{}, &1))
 
-    names =
-      if op in [:operands, :results, :parameters] do
-        names =
-          Range.new(1, n, 1) |> Enum.map(&MLIR.Attribute.string("#{op}_#{&1}"))
+    if length(names) != n do
+      raise ArgumentError,
+            "#{op} declares #{length(names)} names for #{n} constraints: #{inspect(names)}"
+    end
 
-        [names: MLIR.Attribute.array(names)]
-      else
-        []
+    names = Enum.map(names, &MLIR.Attribute.string/1)
+
+    names_attr =
+      case op do
+        op when op in [:operands, :results, :parameters, :regions] ->
+          [names: MLIR.Attribute.array(names)]
+
+        :attributes ->
+          [attributeValueNames: MLIR.Attribute.array(names)]
+
+        _ ->
+          []
       end
 
-    arguments = arguments ++ names
+    arguments = arguments ++ names_attr
 
     apply(Beaver.MLIR.Dialect.IRDL, op, [
-      %{ssa | arguments: arguments}
+      %{ssa | arguments: arguments, loc: loc}
     ])
+  end
+
+  defp pop_metadata!(arguments, key) do
+    case Enum.find_index(arguments, &match?({^key, _}, &1)) do
+      nil ->
+        raise ArgumentError, "missing internal Slang metadata #{inspect(key)}"
+
+      index ->
+        {{^key, value}, arguments} = List.pop_at(arguments, index)
+        {value, arguments}
+    end
   end
 
   # This function determines the variadicity of the given values based on the provided options. It generates the variadicity attribute for the values if needed.
@@ -168,33 +204,74 @@ defmodule Beaver.Slang do
       opts,
       fn ctx ->
         mlir ip: Beaver.Deferred.fetch_insertion_point(opts), ctx: ctx do
-          op_applier slang_target_op: op, sym_name: "\"#{name}\"" do
+          source_loc = source_location(opts, ctx)
+
+          op_applier slang_target_op: op,
+                     slang_names: [],
+                     slang_location: source_loc,
+                     sym_name: "\"#{name}\"" do
             region do
               block _op() do
-                {args, ret} = constrain_f.(Beaver.Env.block(), ctx)
+                {args, ret, attributes, regions} = constrain_f.(Beaver.Env.block(), ctx)
 
-                case strip_variadicity(args) do
-                  [] ->
-                    []
-
-                  args ->
-                    op_applier(
-                      args,
-                      get_variadicity(args, opts),
-                      slang_target_op: args_op
-                    ) >>> []
-                end
-
-                case {return_op, strip_variadicity(ret)} do
+                case {args, strip_variadicity(args)} do
                   {_, []} ->
                     []
 
-                  {return_op, ret} when not is_nil(return_op) ->
+                  {descriptors, args} ->
+                    op_applier(
+                      args,
+                      get_variadicity(descriptors, opts),
+                      slang_target_op: args_op,
+                      slang_names: opts[:argument_names],
+                      slang_location: source_loc
+                    ) >>> []
+                end
+
+                case {return_op, ret, strip_variadicity(ret)} do
+                  {_, _, []} ->
+                    []
+
+                  {return_op, descriptors, ret} when not is_nil(return_op) ->
                     op_applier(
                       ret
-                      |> Enum.map(&create_constraint(&1, ip: Beaver.Env.block(), ctx: ctx)),
-                      get_variadicity(ret, opts),
-                      slang_target_op: return_op
+                      |> Enum.map(
+                        &create_constraint(&1,
+                          ip: Beaver.Env.block(),
+                          ctx: ctx,
+                          loc: source_loc
+                        )
+                      ),
+                      get_variadicity(descriptors, opts),
+                      slang_target_op: return_op,
+                      slang_names: opts[:result_names],
+                      slang_location: source_loc
+                    ) >>> []
+                end
+
+                case attributes do
+                  [] ->
+                    []
+
+                  attributes ->
+                    op_applier(
+                      attributes,
+                      slang_target_op: :attributes,
+                      slang_names: opts[:attribute_names],
+                      slang_location: source_loc
+                    ) >>> []
+                end
+
+                case regions do
+                  [] ->
+                    []
+
+                  regions ->
+                    op_applier(
+                      regions,
+                      slang_target_op: :regions,
+                      slang_names: opts[:region_names],
+                      slang_location: source_loc
                     ) >>> []
                 end
               end
@@ -203,6 +280,21 @@ defmodule Beaver.Slang do
         end
       end
     )
+  end
+
+  defp source_location(opts, ctx) do
+    case opts[:source] do
+      %{file: file, line: line} ->
+        Beaver.Deferred.create(MLIR.Location.file(name: file, line: line), ctx)
+
+      _ ->
+        Beaver.Deferred.create(MLIR.Location.unknown(), ctx)
+    end
+  end
+
+  @doc false
+  def constraint_location(opts, ctx) do
+    opts[:loc] || source_location(opts, ctx)
   end
 
   # This function generates the AST for an argument based on the given index.
@@ -227,7 +319,8 @@ defmodule Beaver.Slang do
           unquote(get_slang_arg_ast(i)) =
             Beaver.Slang.create_constraint(unquote(ast),
               ip: Beaver.Env.block(),
-              ctx: Beaver.Env.context()
+              ctx: Beaver.Env.context(),
+              loc: Kernel.var!(slang_internal_source_loc)
             )
         end
     end
@@ -254,12 +347,153 @@ defmodule Beaver.Slang do
     for {v, i} <- Enum.with_index(args), do: transform_variable(v, i)
   end
 
-  defp build_extra_constraints(extra_constraints) do
-    for {ast, {mod, func}} <- extra_constraints || [] do
-      quote do
-        apply(unquote(mod), unquote(func), [unquote(ast), block, ctx])
-      end
+  defp declaration_name({:=, _, [var, _]}, index, prefix),
+    do: declaration_name(var, index, prefix)
+
+  defp declaration_name({tag, value}, index, prefix) when tag in @variadic_tags,
+    do: declaration_name(value, index, prefix)
+
+  defp declaration_name({name, _, nil}, _index, _prefix) when is_atom(name),
+    do: Atom.to_string(name)
+
+  defp declaration_name(_ast, index, prefix), do: "#{prefix}_#{index + 1}"
+
+  defp normalize_names!(asts, nil, prefix) do
+    asts
+    |> Enum.with_index()
+    |> Enum.map(fn {ast, index} -> declaration_name(ast, index, prefix) end)
+    |> uniquify_names()
+  end
+
+  defp normalize_names!(asts, names, _prefix) when is_list(names) do
+    names = Enum.map(names, &normalize_name!/1)
+
+    if length(asts) != length(names) do
+      raise ArgumentError,
+            "expected #{length(asts)} names, got #{length(names)}: #{inspect(names)}"
     end
+
+    if length(Enum.uniq(names)) != length(names) do
+      raise ArgumentError, "Slang declaration names must be unique: #{inspect(names)}"
+    end
+
+    names
+  end
+
+  defp normalize_names!(_asts, names, _prefix) do
+    raise ArgumentError, "expected a list of Slang declaration names, got: #{inspect(names)}"
+  end
+
+  defp normalize_name!(name) when is_atom(name), do: Atom.to_string(name)
+  defp normalize_name!(name) when is_binary(name) and name != "", do: name
+
+  defp normalize_name!(name) do
+    raise ArgumentError, "expected a non-empty atom or string name, got: #{inspect(name)}"
+  end
+
+  defp uniquify_names(names) do
+    {names, _used} =
+      Enum.map_reduce(names, MapSet.new(), fn name, used ->
+        unique_name = available_name(name, used, 1)
+        {unique_name, MapSet.put(used, unique_name)}
+      end)
+
+    names
+  end
+
+  defp available_name(name, used, suffix) do
+    candidate = if suffix == 1, do: name, else: "#{name}_#{suffix}"
+
+    if MapSet.member?(used, candidate) do
+      available_name(name, used, suffix + 1)
+    else
+      candidate
+    end
+  end
+
+  defp uniquify_declaration_names(argument_names, result_names, attribute_names, region_names) do
+    names = uniquify_names(argument_names ++ result_names ++ attribute_names ++ region_names)
+
+    {argument_names, names} = Enum.split(names, length(argument_names))
+    {result_names, names} = Enum.split(names, length(result_names))
+    {attribute_names, region_names} = Enum.split(names, length(attribute_names))
+
+    {argument_names, result_names, attribute_names, region_names}
+  end
+
+  defp split_named_values(nil, _prefix, _explicit_names), do: {[], []}
+
+  defp split_named_values(values, prefix, explicit_names) when is_list(values) do
+    if named_value_keyword?(values) do
+      if explicit_names do
+        raise ArgumentError,
+              "cannot combine named #{prefix} entries with an explicit #{prefix}_names option"
+      end
+
+      {Enum.map(values, &elem(&1, 1)), Enum.map(values, &(&1 |> elem(0) |> normalize_name!()))}
+    else
+      {values, normalize_names!(values, explicit_names, prefix)}
+    end
+  end
+
+  defp split_named_values(value, prefix, explicit_names) do
+    values = [value]
+    {values, normalize_names!(values, explicit_names, prefix)}
+  end
+
+  defp named_value_keyword?(values) do
+    Keyword.keyword?(values) and
+      Enum.all?(values, fn {name, _value} -> name not in @variadic_tags end)
+  end
+
+  defp normalize_results_ast(nil, _explicit_names), do: {quote(do: []), []}
+
+  defp normalize_results_ast({:__block__, meta, expressions}, explicit_names) do
+    {result_values, result_names} =
+      expressions
+      |> List.last()
+      |> split_named_values("result", explicit_names)
+
+    result_expression = quote(do: [unquote_splicing(result_values)])
+    expressions = List.replace_at(expressions, -1, result_expression)
+    {{:__block__, meta, expressions}, result_names}
+  end
+
+  defp normalize_results_ast(results, explicit_names) do
+    {result_values, result_names} = split_named_values(results, "result", explicit_names)
+    {quote(do: [unquote_splicing(result_values)]), result_names}
+  end
+
+  defp split_attributes(nil), do: {[], []}
+
+  defp split_attributes(attributes) when is_list(attributes) do
+    if Keyword.keyword?(attributes) do
+      {Enum.map(attributes, &elem(&1, 1)),
+       Enum.map(attributes, &(&1 |> elem(0) |> normalize_name!()))}
+    else
+      raise ArgumentError,
+            "operation attributes must be a keyword list of name: constraint entries"
+    end
+  end
+
+  defp split_attributes(attributes) do
+    raise ArgumentError,
+          "operation attributes must be a keyword list, got: #{Macro.to_string(attributes)}"
+  end
+
+  defp normalize_traits!(nil), do: []
+
+  defp normalize_traits!(traits) when is_list(traits) do
+    traits = Enum.uniq(traits)
+
+    case traits -- @dynamic_traits do
+      [] -> traits
+      unsupported -> raise ArgumentError, "unsupported Slang traits: #{inspect(unsupported)}"
+    end
+  end
+
+  defp normalize_traits!(traits) do
+    raise ArgumentError, "expected a list of Slang traits, got: #{inspect(traits)}"
   end
 
   defp normalize_region_descriptor(:any) do
@@ -295,12 +529,12 @@ defmodule Beaver.Slang do
     %{args: args, size: size}
   end
 
-  defp build_region_arguments(%{args: args, size: size}, block, ctx) do
+  defp build_region_arguments(%{args: args, size: size}, block, ctx, loc) do
     constrained_args? = not is_nil(args)
 
     args =
       for arg <- args || [] do
-        create_constraint(arg, ip: block, ctx: ctx)
+        create_constraint(arg, ip: block, ctx: ctx, loc: loc)
       end
 
     attrs =
@@ -330,30 +564,30 @@ defmodule Beaver.Slang do
     args ++ attrs
   end
 
-  defp do_gen_region(region, block, ctx) do
+  defp do_gen_region(region, block, ctx, loc) do
     use Beaver
 
     region_args =
       region
       |> normalize_region_descriptor()
-      |> build_region_arguments(block, ctx)
+      |> build_region_arguments(block, ctx, loc)
 
     %Beaver.SSA{
       arguments: region_args,
       results: [Beaver.Deferred.create(~t{!irdl.region}, ctx)],
       ip: block,
       ctx: ctx,
-      loc: Beaver.Deferred.create(MLIR.Location.unknown(), ctx),
+      loc: loc,
       evaluator: &MLIR.Operation.eval_ssa/1
     }
     |> IRDL.region()
   end
 
   @doc false
-  def gen_region(regions, block, ctx) do
+  def gen_region(regions, block, ctx, loc) do
     regions
     |> List.wrap()
-    |> Enum.map(&do_gen_region(&1, block, ctx))
+    |> Enum.map(&do_gen_region(&1, block, ctx, loc))
   end
 
   @doc false
@@ -364,6 +598,19 @@ defmodule Beaver.Slang do
     creator = String.to_atom("create_" <> name)
     attr_name = String.to_atom("__slang__" <> "#{op}" <> "__")
     args_var_ast = get_args_as_vars(args)
+    argument_names = normalize_names!(args, opts[:argument_names], Atom.to_string(args_op))
+
+    {result_ast, result_names} = normalize_results_ast(do_block, opts[:result_names])
+    {attribute_values, attribute_names} = split_attributes(opts[:attributes])
+    {region_values, region_names} = split_named_values(opts[:regions], "region", nil)
+
+    {argument_names, result_names, attribute_names, region_names} =
+      uniquify_declaration_names(
+        argument_names,
+        result_names,
+        attribute_names,
+        region_names
+      )
 
     input_constrains =
       args
@@ -373,11 +620,39 @@ defmodule Beaver.Slang do
         transform_constraint(ast, i)
       end)
 
-    extra_constraints = build_extra_constraints(opts[:extra_constraints])
+    {attribute_constraints, attribute_vars} =
+      attribute_values
+      |> Macro.postwalk(&transform_defop_pins/1)
+      |> Enum.with_index(length(args))
+      |> Enum.map_reduce([], fn {ast, i}, vars ->
+        {transform_constraint(ast, i), vars ++ [transform_variable(ast, i)]}
+      end)
+
+    creator_opts =
+      opts
+      |> Keyword.drop([:argument_names, :result_names, :attributes, :regions, :traits])
+      |> Keyword.merge(
+        argument_names: argument_names,
+        result_names: result_names,
+        attribute_names: attribute_names,
+        region_names: region_names
+      )
+
+    traits = normalize_traits!(opts[:traits])
 
     quote do
       Module.put_attribute(__MODULE__, unquote(attr_name), unquote(name))
       @__slang__creator__ {unquote(op), __MODULE__, unquote(creator)}
+      unquote(
+        if traits == [] do
+          quote(do: :ok)
+        else
+          quote do
+            @__slang__trait__ {unquote(name), unquote(traits)}
+          end
+        end
+      )
+
       def unquote(creator)(opts) do
         Beaver.Slang.run_creator(
           unquote(name),
@@ -387,12 +662,29 @@ defmodule Beaver.Slang do
             use Beaver
 
             mlir ip: block, ctx: ctx do
+              Kernel.var!(slang_internal_source_loc) =
+                Beaver.Slang.constraint_location(unquote(Macro.escape(creator_opts)), ctx)
+
               unquote_splicing(input_constrains)
-              unquote_splicing(extra_constraints)
-              {[unquote_splicing(args_var_ast)], unquote(do_block)}
+              unquote_splicing(attribute_constraints)
+
+              regions =
+                Beaver.Slang.gen_region(
+                  unquote(region_values),
+                  block,
+                  ctx,
+                  Kernel.var!(slang_internal_source_loc)
+                )
+
+              {
+                [unquote_splicing(args_var_ast)],
+                unquote(result_ast),
+                [unquote_splicing(attribute_vars)],
+                regions
+              }
             end
           end,
-          opts ++ unquote(opts)
+          opts ++ unquote(Macro.escape(creator_opts))
         )
       end
     end
@@ -424,13 +716,20 @@ defmodule Beaver.Slang do
     end)
   end
 
-  defp gen_create_element_creator(element, call) do
+  defp gen_create_element_creator(element, call, opts, caller) do
     {name, args} =
       call
       |> Macro.decompose_call()
 
+    opts = Keyword.validate!(opts, [:parameter_names])
+    source = %{file: caller.file, line: caller.line}
+
     [
-      gen_creator(element, :parameters, call, nil, need_variadicity: false),
+      gen_creator(element, :parameters, call, nil,
+        need_variadicity: false,
+        argument_names: opts[:parameter_names],
+        source: source
+      ),
       quote do
         def unquote(name)(unquote_splicing(get_args_as_vars(args)), opts \\ []) do
           {:parametric,
@@ -451,27 +750,47 @@ defmodule Beaver.Slang do
   @doc """
   This macro defines a type in the dialect.
   """
-  defmacro deftype(call) do
-    gen_create_element_creator(:type, call)
+  defmacro deftype(call, opts \\ []) do
+    gen_create_element_creator(:type, call, opts, __CALLER__)
   end
 
   @doc """
   This macro defines a attribute in the dialect.
   """
-  defmacro defattr(call) do
-    gen_create_element_creator(:attribute, call)
+  defmacro defattr(call, opts \\ []) do
+    gen_create_element_creator(:attribute, call, opts, __CALLER__)
   end
 
   @doc """
   This macro defines an operation in the dialect. It generates the AST for the creator function for the operation.
   """
   defmacro defop(call, block \\ nil) do
-    gen_creator(:operation, :operands, call, block[:do],
+    block =
+      Keyword.validate!(block || [], [
+        :do,
+        :results,
+        :result_names,
+        :operand_names,
+        :attributes,
+        :regions,
+        :traits
+      ])
+
+    if Keyword.has_key?(block, :do) and Keyword.has_key?(block, :results) do
+      raise ArgumentError, "defop accepts either a do block or :results, not both"
+    end
+
+    results = Keyword.get(block, :results, block[:do])
+
+    gen_creator(:operation, :operands, call, results,
       return_op: :results,
       need_variadicity: true,
-      extra_constraints: [
-        {block[:regions], {Beaver.Slang, :gen_region}}
-      ]
+      argument_names: block[:operand_names],
+      result_names: block[:result_names],
+      attributes: block[:attributes],
+      regions: block[:regions],
+      traits: block[:traits],
+      source: %{file: __CALLER__.file, line: __CALLER__.line}
     )
   end
 
@@ -479,11 +798,13 @@ defmodule Beaver.Slang do
     String.to_atom("alias_" <> Atom.to_string(def_name))
   end
 
-  @doc """
-  This macro defines an alias for a lengthy type. It generates the AST for the alias function.
-  """
-  defmacro defalias(call, block) do
-    {name, _args} = call |> Macro.decompose_call()
+  defp gen_constraint(call, block) do
+    {name, args} = call |> Macro.decompose_call()
+
+    if args != [] do
+      raise ArgumentError, "named Slang constraints do not accept arguments"
+    end
+
     alias_name = get_alias_name(name)
     block = block |> Macro.postwalk(&transform_defop_pins/1)
 
@@ -493,15 +814,33 @@ defmodule Beaver.Slang do
         use Beaver
 
         mlir ctx: opts[:ctx], ip: Beaver.Deferred.fetch_insertion_point(opts) do
+          Kernel.var!(slang_internal_source_loc) =
+            Beaver.Slang.constraint_location(opts, Beaver.Env.context())
+
           unquote(block[:do])
           |> Beaver.Slang.create_parametric(
             ctx: Beaver.Env.context(),
-            ip: Beaver.Env.block()
+            ip: Beaver.Env.block(),
+            loc: Kernel.var!(slang_internal_source_loc)
           )
         end
       end
     end
   end
+
+  @doc """
+  Defines a reusable named constraint.
+
+  Reference it from another declaration with `^name`.
+  """
+  defmacro defconstraint(call, block), do: gen_constraint(call, block)
+
+  @doc """
+  Defines a reusable named constraint.
+
+  `defalias` is retained as a concise spelling of `defconstraint`.
+  """
+  defmacro defalias(call, block), do: gen_constraint(call, block)
 
   @doc """
   This macro generates the AST for the any_of attribute in the dialect.
@@ -513,13 +852,91 @@ defmodule Beaver.Slang do
       mlir do
         types =
           for t <- unquote(types) do
-            Beaver.MLIR.Dialect.IRDL.is(expected: t) >>> ~t{!irdl.attribute}
+            Beaver.Slang.create_constraint(t,
+              ip: Beaver.Env.block(),
+              ctx: Beaver.Env.context(),
+              loc: Kernel.var!(slang_internal_source_loc)
+            )
           end
 
-        Beaver.MLIR.Dialect.IRDL.any_of(types) >>> ~t{!irdl.attribute}
+        Beaver.MLIR.Dialect.IRDL.any_of([Kernel.var!(slang_internal_source_loc) | types]) >>>
+          ~t{!irdl.attribute}
       end
     end
   end
+
+  @doc """
+  Generates an `irdl.all_of` constraint.
+  """
+  defmacro all_of(types) do
+    quote do
+      use Beaver
+
+      mlir do
+        types =
+          for t <- unquote(types) do
+            Beaver.Slang.create_constraint(t,
+              ip: Beaver.Env.block(),
+              ctx: Beaver.Env.context(),
+              loc: Kernel.var!(slang_internal_source_loc)
+            )
+          end
+
+        Beaver.MLIR.Dialect.IRDL.all_of([Kernel.var!(slang_internal_source_loc) | types]) >>>
+          ~t{!irdl.attribute}
+      end
+    end
+  end
+
+  @doc false
+  def create_base({:parametric, symbol, _values, _element}, opts) do
+    create_base({:base_ref, symbol}, opts)
+  end
+
+  def create_base({:base_ref, symbol}, opts) do
+    Beaver.Deferred.from_opts(opts, fn ctx ->
+      mlir ctx: ctx, ip: Beaver.Deferred.fetch_insertion_point(opts) do
+        loc = constraint_location(opts, ctx)
+
+        IRDL.base([loc, base_ref: Beaver.Deferred.create(symbol, ctx)]) >>>
+          ~t{!irdl.attribute}
+      end
+    end)
+  end
+
+  def create_base(name, opts) when is_binary(name) do
+    Beaver.Deferred.from_opts(opts, fn ctx ->
+      mlir ctx: ctx, ip: Beaver.Deferred.fetch_insertion_point(opts) do
+        loc = constraint_location(opts, ctx)
+        IRDL.base([loc, base_name: MLIR.Attribute.string(name)]) >>> ~t{!irdl.attribute}
+      end
+    end)
+  end
+
+  @doc """
+  Generates an `irdl.base` constraint from a base name or a Slang type/attribute.
+
+  Base names use upstream IRDL spelling such as `"!builtin.integer"` or
+  `"#builtin.string"`.
+  """
+  defmacro base(base) do
+    quote do
+      Beaver.Slang.create_base(unquote(base),
+        ip: Beaver.Env.block(),
+        ctx: Beaver.Env.context(),
+        loc: Kernel.var!(slang_internal_source_loc)
+      )
+    end
+  end
+
+  @doc "Marks an operand or result constraint as variadic."
+  defmacro variadic(constraint), do: quote(do: {:variadic, unquote(constraint)})
+
+  @doc "Marks an operand or result constraint as optional."
+  defmacro optional(constraint), do: quote(do: {:optional, unquote(constraint)})
+
+  @doc "Marks an operand or result constraint as a required singleton."
+  defmacro single(constraint), do: quote(do: {:single, unquote(constraint)})
 
   @doc """
   This macro generates the AST for `irdl.is` op, usually used to create a constraint on type
@@ -529,7 +946,10 @@ defmodule Beaver.Slang do
       use Beaver
 
       mlir do
-        Beaver.MLIR.Dialect.IRDL.is(expected: unquote(type)) >>>
+        Beaver.MLIR.Dialect.IRDL.is([
+          Kernel.var!(slang_internal_source_loc),
+          expected: unquote(type)
+        ]) >>>
           ~t{!irdl.attribute}
       end
     end
@@ -543,7 +963,8 @@ defmodule Beaver.Slang do
       use Beaver
 
       mlir do
-        Beaver.MLIR.Dialect.IRDL.any() >>> ~t{!irdl.attribute}
+        Beaver.MLIR.Dialect.IRDL.any(Kernel.var!(slang_internal_source_loc)) >>>
+          ~t{!irdl.attribute}
       end
     end
   end
@@ -557,7 +978,8 @@ defmodule Beaver.Slang do
       opts,
       fn ctx ->
         mlir ctx: ctx, ip: Beaver.Deferred.fetch_insertion_point(opts) do
-          IRDL.parametric(values, base_type: base_type) >>> ~t{!irdl.attribute}
+          loc = constraint_location(opts, ctx)
+          IRDL.parametric([loc | values], base_type: base_type) >>> ~t{!irdl.attribute}
         end
       end
     )
@@ -590,14 +1012,45 @@ defmodule Beaver.Slang do
     )
   end
 
+  @trait_factories %{
+    terminator: :mlirDynamicOpTraitIsTerminatorCreate,
+    isolated_from_above: :mlirDynamicOpTraitIsIsolatedFromAboveCreate,
+    no_terminator: :mlirDynamicOpTraitNoTerminatorCreate
+  }
+
+  defp attach_dynamic_traits(ctx, dialect, traits) do
+    for {operation, operation_traits} <- traits,
+        trait <- operation_traits do
+      dynamic_trait = apply(MLIR.CAPI, Map.fetch!(@trait_factories, trait), [])
+      operation_name = MLIR.StringRef.create("#{dialect}.#{operation}")
+
+      unless MLIR.CAPI.mlirDynamicOpTraitAttach(dynamic_trait, operation_name, ctx)
+             |> Beaver.Native.to_term() do
+        MLIR.CAPI.mlirDynamicOpTraitDestroy(dynamic_trait)
+
+        raise ArgumentError,
+              "failed to attach #{inspect(trait)} to dynamic operation #{dialect}.#{operation}"
+      end
+    end
+
+    :ok
+  end
+
   @doc """
   This function loads the MLIR dialect into the MLIR context. It invokes the internal function of the provided module to create the dialect's IRDL module and performs additional MLIR transformations and verification.
   """
   def load(ctx, mod) when is_atom(mod) do
-    apply(mod, :__slang_dialect__, [ctx])
-    |> Beaver.MLIR.Transform.canonicalize()
-    |> Beaver.Composer.run!()
-    |> MLIR.verify!()
-    |> Beaver.MLIR.CAPI.mlirLoadIRDLDialects()
+    result =
+      apply(mod, :__slang_dialect__, [ctx])
+      |> Beaver.MLIR.Transform.canonicalize()
+      |> Beaver.Composer.run!()
+      |> MLIR.verify!()
+      |> Beaver.MLIR.CAPI.mlirLoadIRDLDialects()
+
+    if MLIR.LogicalResult.success?(result) do
+      attach_dynamic_traits(ctx, mod.__slang_dialect_name__(), mod.__slang_traits__())
+    end
+
+    result
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -57,6 +57,7 @@ defmodule Beaver.MixProject do
       extras: [
         "guides/your-first-beaver-compiler.livemd",
         "guides/incremental-compilation-runtime.md",
+        "guides/slang.md",
         "CONTRIBUTING.md",
         "README.md"
       ],

--- a/test/slang_complete_test.exs
+++ b/test/slang_complete_test.exs
@@ -103,10 +103,21 @@ defmodule SlangCompleteTest do
       |> MLIR.Module.create!(ctx: ctx)
       |> MLIR.verify!()
 
+    bytecode = MLIR.Bytecode.write!(text_roundtrip)
+    fresh_ctx = MLIR.Context.create()
+    on_exit(fn -> MLIR.Context.destroy(fresh_ctx) end)
+
+    refute MLIR.Context.terminator?(fresh_ctx, "complete_slang.yield")
+
+    assert CompleteSlang
+           |> then(&Beaver.Slang.load(fresh_ctx, &1))
+           |> MLIR.LogicalResult.success?()
+
+    assert MLIR.Context.terminator?(fresh_ctx, "complete_slang.yield")
+
     bytecode_roundtrip =
-      text_roundtrip
-      |> MLIR.Bytecode.write!()
-      |> MLIR.Bytecode.read!(ctx: ctx)
+      bytecode
+      |> MLIR.Bytecode.read!(ctx: fresh_ctx)
       |> MLIR.verify!()
 
     assert MLIR.to_string(bytecode_roundtrip, generic: true) ==

--- a/test/slang_complete_test.exs
+++ b/test/slang_complete_test.exs
@@ -1,0 +1,135 @@
+defmodule SlangCompleteTest do
+  use Beaver.Case, async: true
+  alias Beaver.MLIR
+
+  @moduletag :smoke
+
+  @valid_module ~S"""
+  module {
+    "complete_slang.scope"() ({
+    ^bb0:
+    }) {label = "ok"} : () -> ()
+  }
+  """
+
+  test "emits a complete, named IRDL schema", %{ctx: ctx} do
+    schema = CompleteSlang.__slang_dialect__(ctx) |> MLIR.verify!()
+    rendered = MLIR.to_string(schema, generic: true)
+
+    assert rendered =~ ~s{"irdl.all_of"}
+    assert rendered =~ ~s{base_name = "!builtin.integer"}
+    assert rendered =~ ~s{base_name = "#builtin.string"}
+    assert rendered =~ ~s{base_ref = @complete_slang::@token}
+    assert rendered =~ ~s{names = ["element"]}
+    assert rendered =~ ~s{names = ["item"]}
+    assert rendered =~ ~s{names = ["value"]}
+    assert rendered =~ ~s{names = ["head", "tail", "fallback"]}
+    assert rendered =~ ~s{names = ["input"]}
+    assert rendered =~ ~s{names = ["output"]}
+    assert rendered =~ ~s{variadicity_array[single, variadic, optional]}
+    assert rendered =~ ~s{variadicity_array[optional]}
+    assert rendered =~ ~s{"irdl.attributes"}
+    assert rendered =~ ~s{attributeValueNames = ["label"]}
+    assert rendered =~ ~s{"irdl.regions"}
+    assert rendered =~ ~s{names = ["body"]}
+  end
+
+  test "loads types, attributes, operation attributes, regions, and dynamic traits", %{ctx: ctx} do
+    assert CompleteSlang.__slang_traits__() == [
+             {"scope", [:isolated_from_above, :no_terminator]},
+             {"yield", [:terminator]}
+           ]
+
+    assert CompleteSlang |> then(&Beaver.Slang.load(ctx, &1)) |> MLIR.LogicalResult.success?()
+    assert MLIR.Context.terminator?(ctx, "complete_slang.yield")
+
+    type = CompleteSlang.box(MLIR.Type.i32()) |> Beaver.Deferred.create(ctx)
+
+    attribute =
+      CompleteSlang.direction(MLIR.Attribute.string("left")) |> Beaver.Deferred.create(ctx)
+
+    refute MLIR.null?(type)
+    refute MLIR.null?(attribute)
+    assert MLIR.to_string(type) == "!complete_slang.box<i32>"
+    assert MLIR.to_string(attribute) == ~s{#complete_slang.direction<"left">}
+
+    assert @valid_module |> MLIR.Module.create!(ctx: ctx) |> MLIR.verify?()
+
+    assert_raise ArgumentError, ~r/expected base attribute 'builtin.string'/, fn ->
+      ~S[module { "complete_slang.scope"() ({ ^bb0: }) {label = 42 : i32} : () -> () }]
+      |> MLIR.Module.create!(ctx: ctx)
+    end
+  end
+
+  test "enforces isolated-from-above and terminator semantics", %{ctx: ctx} do
+    Beaver.Slang.load(ctx, CompleteSlang)
+
+    assert_raise ArgumentError, ~r/using value defined outside the region/, fn ->
+      ~S"""
+      module {
+        func.func @bad(%arg0: i32) {
+          "complete_slang.scope"() ({
+          ^bb0:
+            "complete_slang.consume"(%arg0) : (i32) -> ()
+          }) {label = "bad"} : () -> ()
+          return
+        }
+      }
+      """
+      |> MLIR.Module.create!(ctx: ctx)
+    end
+
+    assert_raise ArgumentError, ~r/must be the last operation in the parent block/, fn ->
+      ~S"""
+      module {
+        "complete_slang.scope"() ({
+        ^bb0:
+          "complete_slang.yield"() : () -> ()
+          "complete_slang.yield"() : () -> ()
+        }) {label = "bad"} : () -> ()
+      }
+      """
+      |> MLIR.Module.create!(ctx: ctx)
+    end
+  end
+
+  test "round-trips a dynamic dialect through text and bytecode", %{ctx: ctx} do
+    Beaver.Slang.load(ctx, CompleteSlang)
+    original = MLIR.Module.create!(@valid_module, ctx: ctx) |> MLIR.verify!()
+
+    text_roundtrip =
+      original
+      |> MLIR.to_string(generic: true)
+      |> MLIR.Module.create!(ctx: ctx)
+      |> MLIR.verify!()
+
+    bytecode_roundtrip =
+      text_roundtrip
+      |> MLIR.Bytecode.write!()
+      |> MLIR.Bytecode.read!(ctx: ctx)
+      |> MLIR.verify!()
+
+    assert MLIR.to_string(bytecode_roundtrip, generic: true) ==
+             MLIR.to_string(original, generic: true)
+  end
+
+  test "reports invalid constraints at their Slang declaration", %{ctx: ctx} do
+    Code.compile_string(
+      ~S"""
+      defmodule InvalidSlangSourceLocation do
+        use Beaver.Slang, name: "invalid_slang_source_location"
+        deftype broken(value = base("invalid"))
+      end
+      """,
+      "/tmp/invalid_slang_source_location.ex"
+    )
+
+    {:error, diagnostics} =
+      apply(InvalidSlangSourceLocation, :__slang_dialect__, [ctx])
+      |> MLIR.verify()
+
+    message = MLIR.Diagnostic.format(diagnostics)
+    assert message =~ "/tmp/invalid_slang_source_location.ex:3"
+    assert message =~ "the base type or attribute name should start with '!' or '#'"
+  end
+end

--- a/test/support/complete_slang_dialect.ex
+++ b/test/support/complete_slang_dialect.ex
@@ -1,0 +1,38 @@
+defmodule CompleteSlang do
+  @moduledoc false
+  use Beaver.Slang, name: "complete_slang"
+
+  defconstraint integer_like do
+    all_of([base("!builtin.integer"), any()])
+  end
+
+  defconstraint direction_value do
+    any_of([
+      Beaver.MLIR.Attribute.string("left"),
+      Beaver.MLIR.Attribute.string("right")
+    ])
+  end
+
+  deftype box(element = ^integer_like)
+  deftype token()
+  deftype named_parameters(any()), parameter_names: [:item]
+  defattr direction(value = ^direction_value)
+
+  defop(consume(value = any()))
+  defop(consume_token(value = base(token())))
+
+  defop sequence(head = any(), tail = variadic(any()), fallback = optional(any())),
+    results: [value: optional(any())]
+
+  defop named_io(single(any())),
+    operand_names: [:input],
+    results: [single(any())],
+    result_names: [:output]
+
+  defop scope(),
+    attributes: [label: base("#builtin.string")],
+    regions: [body: {:region, args: [], size: 1}],
+    traits: [:isolated_from_above, :no_terminator]
+
+  defop yield(), traits: [:terminator]
+end


### PR DESCRIPTION
Closes #460.

## Summary

- emit named IRDL parameters, operands, results, operation attributes, and regions from Slang declarations
- add reusable `defconstraint` definitions plus `all_of`, `base`, and explicit cardinality helpers
- preserve optional and variadic operand/result descriptors and attach built-in dynamic operation traits after dialect registration
- propagate declaration source locations through nested constraints for actionable diagnostics
- document the full supported dialect syntax and schema/runtime interface boundary
- add full-dialect semantic tests and text/bytecode round-trip coverage

## Impact

Dynamic dialects can now describe the documented IRDL constraint and operation surface directly in Slang without dropping attributes, regions, names, variadicity, or built-in operation semantics.

## Validation

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix test` — 209 passed, 8 excluded
- `mix docs` — completed; only pre-existing CAPI/hidden-type documentation warnings remain
