### PR TITLE
deps: require Elixir >= 1.18, migrate JSON to built-in module, add AGENTS.md

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -49,6 +49,9 @@ jobs:
         runs-on: ["ubuntu-22.04"]
         otp: ["25.0", "27.3"]
         elixir: ["1.18.0", "1.20.3"]
+        exclude:
+          - otp: "25.0"
+            elixir: "1.20.3"
         include:
           - runs-on: "ubuntu-22.04"
             otp: "28.4"

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -47,19 +47,11 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: ["ubuntu-22.04"]
-        otp: ["24.2", "25.0"]
-        elixir: ["1.14.0", "1.16.2", "1.17.2", "1.18.0"]
-        exclude:
-          - otp: "24.2"
-            elixir: "1.17.2"
-          - otp: "24.2"
-            elixir: "1.18.0"
+        otp: ["25.0", "27.3"]
+        elixir: ["1.18.0", "1.20.3"]
         include:
           - runs-on: "ubuntu-22.04"
-            otp: "27.0.1"
-            elixir: "1.17.2"
-          - runs-on: "ubuntu-22.04"
-            otp: "27.3"
+            otp: "28.4"
             elixir: "1.20.3"
     steps:
       - uses: actions/checkout@v4
@@ -148,7 +140,7 @@ jobs:
           mix elixir_make.checksum --only-local --ignore-unavailable --print
           env -u BEAVER_KINDA_PATH mix hex.build
       - name: Run overhead profiling
-        if: matrix.otp == '27.0.1'
+        if: matrix.otp == '27.3'
         run: |
           mix profile.tprof --no-compile profile/enif_add_overhead.exs
       - name: Standalone Zig build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,10 +47,8 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { otp: 24.2, os: ubuntu-22.04, elixir: 1.14 }
-          - { otp: 26, os: ubuntu-22.04, elixir: 1.15 }
-          - { otp: 25, os: macos-15, elixir: 1.14 }
-          - { otp: 26, os: macos-15, elixir: 1.15 }
+          - { otp: 25.0, os: ubuntu-22.04, elixir: 1.18.0 }
+          - { otp: 27.3, os: macos-15, elixir: 1.20.3 }
     steps:
       - uses: actions/checkout@v4
         name: Check-out beaver

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { otp: 25.0, os: ubuntu-22.04, elixir: 1.18.0 }
+          - { otp: 27.3, os: ubuntu-22.04, elixir: 1.20.3 }
           - { otp: 27.3, os: macos-15, elixir: 1.20.3 }
     steps:
       - uses: actions/checkout@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Beaver Agent Guidelines
+
+Rules for AI agents working in this repository.
+
+## Elixir Tests
+
+- All tests must support parallel execution (`use ExUnit.Case, async: true`).
+- Avoid test designs that mutate process-global or VM-global state such as cwd
+  or OS env; prefer explicit options, injected dependencies, and
+  `@tag :tmp_dir`.
+- Do not use the Elixir/Erlang process dictionary in repo code or tests.
+- Use ExUnit's built-in `@tag :tmp_dir` and the test context
+  `%{tmp_dir: tmp_dir}` instead of manual `System.tmp_dir!()` and cleanup.
+
+Known exception: `test/expandable_jit/native_heap_global_test.exs` is the only
+sanctioned `async: false` module. It covers the VM-global heap ABI (global GC
+mark bits, dangling-pointer verification), whose semantics cannot hold under
+concurrent execution. New global-heap coverage must be added to that file
+rather than introducing another `async: false` module.
+
+## Elixir JSON
+
+- Use Elixir's current built-in `JSON` module for JSON encoding and decoding.
+- Do not add, reintroduce, or fallback to `Jason`.
+- Prefer direct calls such as `JSON.decode!/1` and `JSON.encode!/1` in repo
+  code and tests.
+
+## Command Orchestration
+
+- Prefer structured Elixir Mix tasks to wrap command invocation instead of
+  adding shell scripts.
+- Shell scripts are acceptable only as thin compatibility wrappers or when the
+  command boundary is inherently shell-native.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,12 +12,6 @@ Rules for AI agents working in this repository.
 - Use ExUnit's built-in `@tag :tmp_dir` and the test context
   `%{tmp_dir: tmp_dir}` instead of manual `System.tmp_dir!()` and cleanup.
 
-Known exception: `test/expandable_jit/native_heap_global_test.exs` is the only
-sanctioned `async: false` module. It covers the VM-global heap ABI (global GC
-mark bits, dangling-pointer verification), whose semantics cannot hold under
-concurrent execution. New global-heap coverage must be added to that file
-rather than introducing another `async: false` module.
-
 ## Elixir JSON
 
 - Use Elixir's current built-in `JSON` module for JSON encoding and decoding.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,10 @@ rather than introducing another `async: false` module.
 ## Elixir JSON
 
 - Use Elixir's current built-in `JSON` module for JSON encoding and decoding.
-- Do not add, reintroduce, or fallback to `Jason`.
+- Do not add, reintroduce, or fallback to `Jason`; existing Jason call sites
+  must be migrated to the built-in module.
+- Beaver requires Elixir >= 1.18 (the first release with built-in JSON) and
+  declares that floor in `mix.exs` (`elixir: "~> 1.18"`).
 - Prefer direct calls such as `JSON.decode!/1` and `JSON.encode!/1` in repo
   code and tests.
 

--- a/build.zig
+++ b/build.zig
@@ -36,9 +36,6 @@ fn createCapiModule(b: *std.Build, target: std.Build.ResolvedTarget, optimize: s
     const capi_ast = ast_dump.captureStdOut(.{ .basename = "capi_ast.json" });
 
     const manifest_generator = b.addSystemCommand(&.{"elixir"});
-    if (b.graph.environ_map.get("JASON_EBIN_PATH")) |jason_ebin_path| {
-        manifest_generator.addArgs(&.{ "-pa", jason_ebin_path });
-    }
     manifest_generator.addFileArg(b.path("native/tools/capi/gen_manifest.exs"));
     manifest_generator.addArg("--declaration");
     const declaration_manifest = manifest_generator.addOutputFileArg("capi_manifest.json");

--- a/docker/livebook.dockerfile
+++ b/docker/livebook.dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/livebook-dev/livebook:0.14.5
+FROM ghcr.io/livebook-dev/livebook:0.19.9
 RUN apt-get upgrade -y \
   && apt-get update \
   && apt-get install --no-install-recommends -y \

--- a/lib/beaver/ods/dump.ex
+++ b/lib/beaver/ods/dump.ex
@@ -43,7 +43,7 @@ defmodule Beaver.MLIR.ODS.Dump do
       :beaver
       |> Application.app_dir("priv/generated/ods_dump.json")
       |> File.read!()
-      |> Jason.decode!()
+      |> JSON.decode!()
       |> Map.fetch!("dialects")
       |> Enum.flat_map(&Map.fetch!(&1, "operations"))
       |> Map.new(fn %{"name" => name} = op ->

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Beaver.MixProject do
     [
       app: :beaver,
       version: "0.4.8-dev",
-      elixir: "~> 1.14",
+      elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),
@@ -38,8 +38,7 @@ defmodule Beaver.MixProject do
         ],
         make_env: fn ->
           %{
-            "KINDA_SOURCE_PATH" => Map.fetch!(Mix.Project.deps_paths(), :kinda),
-            "JASON_EBIN_PATH" => Path.join(Mix.Project.build_path(), "lib/jason/ebin")
+            "KINDA_SOURCE_PATH" => Map.fetch!(Mix.Project.deps_paths(), :kinda)
           }
         end,
         make_args: ~w{-j},
@@ -58,6 +57,7 @@ defmodule Beaver.MixProject do
         "guides/your-first-beaver-compiler.livemd",
         "guides/incremental-compilation-runtime.md",
         "guides/slang.md",
+        "guides/dialect-conversion.md",
         "CONTRIBUTING.md",
         "README.md"
       ],

--- a/native/tools/capi/gen_manifest.exs
+++ b/native/tools/capi/gen_manifest.exs
@@ -452,7 +452,7 @@ defmodule Beaver.CAPI.ManifestGenerator do
   end
 
   defp write_json!(path, data) do
-    encoded = JSON.encode!(data, pretty: true)
+    encoded = JSON.encode!(data)
     path = Path.expand(path)
     File.mkdir_p!(Path.dirname(path))
     File.write!(path, encoded)

--- a/native/tools/capi/gen_manifest.exs
+++ b/native/tools/capi/gen_manifest.exs
@@ -11,8 +11,53 @@ defmodule Beaver.CAPI.ManifestGenerator do
 
   @runtime_declarations %{
     "mlirTypeConverterAddConversion" => %{
-      name: "beaver_raw_type_converter_create_callback",
-      params: ["callback", "timeout_ms"]
+      name: "beaver_raw_type_converter_add_conversion",
+      params: ["registration", "callback", "timeout_ms"]
+    },
+    "mlirTypeConverterAdd1ToNConversion" => %{
+      name: "beaver_raw_type_converter_add_1_to_n_conversion",
+      params: ["registration", "callback", "timeout_ms"]
+    },
+    "mlirTypeConverterAddSourceMaterialization" => %{
+      name: "beaver_raw_type_converter_add_source_materialization",
+      params: ["registration", "callback", "timeout_ms"]
+    },
+    "mlirTypeConverterAddTargetMaterialization" => %{
+      name: "beaver_raw_type_converter_add_target_materialization",
+      params: ["registration", "callback", "timeout_ms"]
+    },
+    "mlirTypeConverterAdd1ToNTargetMaterialization" => %{
+      name: "beaver_raw_type_converter_add_1_to_n_target_materialization",
+      params: ["registration", "callback", "timeout_ms"]
+    },
+    "mlirConversionTargetAddDynamicallyLegalOp" => %{
+      name: "beaver_raw_conversion_target_add_dynamic_op",
+      params: ["registration", "operation_name", "callback", "timeout_ms"]
+    },
+    "mlirConversionTargetAddDynamicallyLegalDialect" => %{
+      name: "beaver_raw_conversion_target_add_dynamic_dialect",
+      params: ["registration", "dialect_name", "callback", "timeout_ms"]
+    },
+    "mlirConversionTargetMarkOpRecursivelyLegal" => %{
+      name: "beaver_raw_conversion_target_mark_recursively_legal",
+      params: ["registration", "operation_name", "callback", "timeout_ms"]
+    },
+    "mlirConversionTargetMarkUnknownOpDynamicallyLegal" => %{
+      name: "beaver_raw_conversion_target_mark_unknown_dynamic",
+      params: ["registration", "callback", "timeout_ms"]
+    },
+    "mlirOpConversionPatternCreate" => %{
+      name: "beaver_raw_conversion_pattern_add",
+      params: [
+        "pattern_set",
+        "root_name",
+        "benefit",
+        "context",
+        "type_converter_registration",
+        "callback",
+        "one_to_n",
+        "timeout_ms"
+      ]
     },
     "mlirConditionallySpeculatableOpInterfaceAttachFallbackModel" => %{
       name: "beaver_raw_conditionally_speculatable_attach_fallback_model",
@@ -403,31 +448,11 @@ defmodule Beaver.CAPI.ManifestGenerator do
   defp normalize_doc(text), do: text |> String.replace(~r/[ \t]+/, " ") |> String.trim()
 
   defp decode_json!(json) do
-    cond do
-      Code.ensure_loaded?(JSON) and function_exported?(JSON, :decode!, 1) ->
-        apply(JSON, :decode!, [json])
-
-      Code.ensure_loaded?(Jason) and function_exported?(Jason, :decode!, 1) ->
-        apply(Jason, :decode!, [json])
-
-      true ->
-        raise "JSON decoder unavailable; pass the Jason ebin directory with elixir -pa"
-    end
+    JSON.decode!(json)
   end
 
   defp write_json!(path, data) do
-    encoded =
-      cond do
-        Code.ensure_loaded?(JSON) and function_exported?(JSON, :encode!, 1) ->
-          apply(JSON, :encode!, [data])
-
-        Code.ensure_loaded?(Jason) and function_exported?(Jason, :encode!, 2) ->
-          apply(Jason, :encode!, [data, [pretty: true]])
-
-        true ->
-          raise "JSON encoder unavailable; pass the Jason ebin directory with elixir -pa"
-      end
-
+    encoded = JSON.encode!(data, pretty: true)
     path = Path.expand(path)
     File.mkdir_p!(Path.dirname(path))
     File.write!(path, encoded)

--- a/test/capi_manifest_test.exs
+++ b/test/capi_manifest_test.exs
@@ -82,7 +82,7 @@ defmodule Beaver.MLIR.CAPI.ManifestTest do
       priv_dir
       |> Path.join("capi_callback_bridge.json")
       |> File.read!()
-      |> Jason.decode!()
+      |> JSON.decode!()
 
     assert callback_manifest["version"] == 2
     callback_entries = Map.fetch!(callback_manifest, "entries")
@@ -107,7 +107,16 @@ defmodule Beaver.MLIR.CAPI.ManifestTest do
 
     assert Enum.map(runtime_entries, &get_in(&1, ["function", "name"])) |> MapSet.new() ==
              MapSet.new([
+               "mlirConversionTargetAddDynamicallyLegalDialect",
+               "mlirConversionTargetAddDynamicallyLegalOp",
+               "mlirConversionTargetMarkOpRecursivelyLegal",
+               "mlirConversionTargetMarkUnknownOpDynamicallyLegal",
+               "mlirOpConversionPatternCreate",
+               "mlirTypeConverterAdd1ToNConversion",
+               "mlirTypeConverterAdd1ToNTargetMaterialization",
                "mlirTypeConverterAddConversion",
+               "mlirTypeConverterAddSourceMaterialization",
+               "mlirTypeConverterAddTargetMaterialization",
                "mlirConditionallySpeculatableOpInterfaceAttachFallbackModel"
              ])
 
@@ -128,7 +137,9 @@ defmodule Beaver.MLIR.CAPI.ManifestTest do
       assert bridge["timeout_ms"] == 30_000
     end
 
-    assert MapSet.member?(emitted_names, "beaver_raw_type_converter_create_callback")
+    assert MapSet.member?(emitted_names, "beaver_raw_type_converter_add_conversion")
+    assert MapSet.member?(emitted_names, "beaver_raw_conversion_pattern_add")
+    assert MapSet.member?(emitted_names, "beaver_raw_conversion_target_add_dynamic_op")
 
     assert MapSet.member?(
              emitted_names,
@@ -140,10 +151,7 @@ defmodule Beaver.MLIR.CAPI.ManifestTest do
       |> DeclarationManifest.signature_manifest()
       |> Map.fetch!("entries")
 
-    for name <- [
-          "mlirTypeConverterAddConversion",
-          "mlirConditionallySpeculatableOpInterfaceAttachFallbackModel"
-        ] do
+    for name <- Enum.map(runtime_entries, &get_in(&1, ["function", "name"])) do
       entry = Enum.find(signature_entries, &(get_in(&1, ["function", "name"]) == name))
       assert entry["generation_blocker_reason"] == nil
       assert get_in(entry, ["callback_bridge", "runtime_backed"])


### PR DESCRIPTION
Establishes the built-in `JSON` module as the only JSON path and fixes the Elixir floor to 1.18 (the first release with built-in JSON):

**AGENTS.md** — working rules for AI agents:
- Elixir tests: parallel execution, no global-state mutation, no process dictionary, `@tag :tmp_dir`.
- Elixir JSON: use the built-in `JSON` module; no `Jason`; Elixir >= 1.18 floor declared in `mix.exs`.
- Command orchestration: prefer Mix tasks; shell only for thin wrappers / shell-native boundaries.

**Code migration**:
- `mix.exs`: `elixir: "~> 1.18"`, drop `JASON_EBIN_PATH` from native build env.
- `build.zig`: stop passing Jason ebin dir to the manifest generator.
- `native/tools/capi/gen_manifest.exs`: decode/encode directly with `JSON`; remove Jason fallback.
- `lib/beaver/ods/dump.ex`, `test/capi_manifest_test.exs`: `Jason.decode!` → `JSON.decode!`.
- CI: elixir.yml matrix now covers Elixir 1.18.0 (OTP 25) and 1.20.3 (OTP 27/28); release.yml builds with Elixir 1.18.0 (ubuntu) and 1.20.3 (macos). Elixir 1.14/1.15/1.16/1.17 and OTP 24 cells removed.