### PR TITLE
Add Transform dialect schedule execution and autotuning

### DIFF
--- a/guides/transform-autotuning.md
+++ b/guides/transform-autotuning.md
@@ -1,0 +1,202 @@
+# Transform schedule execution and autotuning
+
+`Beaver.MLIR.Transform` can execute an upstream named Transform dialect
+sequence directly against a payload. The schedule may be textual MLIR, MLIR
+bytecode, a `Beaver.MLIR.Module`, a nested `Beaver.MLIR.Operation`, or a
+`Beaver.MLIR.Transform.Schedule.Resolved` value.
+
+```elixir
+alias Beaver.MLIR
+
+{:ok, result} =
+  MLIR.Transform.apply_named_sequence(payload, transform_ir,
+    sequence: "__transform_main",
+    expensive_checks: true,
+    enforce_single_top_level_transform_op: true
+  )
+
+result.payload
+result.diagnostics
+```
+
+Both checks default to `true`. Diagnostics are returned as portable trees whose
+locations are strings, so errors remain printable after a temporary schedule
+context is destroyed. Failures are tagged as invalid schedules, propagated
+silenceable failures, or definite failures. Transform handles remain internal
+to upstream `TransformState`; consumed or invalidated handles never become
+long-lived Elixir resources.
+
+## A tiling and vectorization search space
+
+Tune operations leave choices in Transform IR instead of hiding them in host
+language control flow. This example selects a tile size, tiles a matched
+`linalg.matmul`, and chooses whether to vectorize its enclosing isolated op.
+
+```mlir
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(
+      %root: !transform.any_op {transform.readonly}) {
+    %tile = transform.tune.knob<"tile_size">
+      options = [8, 16, 32] -> !transform.param<i64>
+
+    %matmul = transform.structured.match ops{["linalg.matmul"]} in %root
+      : (!transform.any_op) -> !transform.any_op
+
+    %tiled, %loop = transform.structured.tile_using_for %matmul
+      tile_sizes [%tile]
+      : (!transform.any_op, !transform.param<i64>)
+        -> (!transform.any_op, !transform.any_op)
+
+    transform.tune.alternatives<"vectorize"> {
+      %func = transform.get_parent_op %tiled {isolated_from_above}
+        : (!transform.any_op) -> !transform.any_op
+      %vectorized =
+        transform.structured.vectorize_children_and_apply_patterns %func
+        : (!transform.any_op) -> !transform.any_op
+      transform.yield
+    }, {
+      transform.yield
+    }
+
+    transform.yield
+  }
+}
+```
+
+Discovery and enumeration are deterministic. An alternatives choice is visited
+before choices in its regions, and choices from unselected regions do not
+inflate the candidate set.
+
+```elixir
+alias Beaver.MLIR.Transform.Schedule
+
+{:ok, analysis} = Schedule.analyze(transform_ir)
+{:ok, candidates} = Schedule.enumerate(transform_ir, max_candidates: 1_000)
+
+# candidates starts with:
+# %{"tile_size" => 8, "vectorize" => 0}
+# %{"tile_size" => 8, "vectorize" => 1}
+```
+
+An explicit map is the simplest resolver. Functions and modules implementing
+`Beaver.MLIR.Transform.Resolver` are also accepted.
+
+```elixir
+resolved =
+  Schedule.resolve!(transform_ir, %{
+    "tile_size" => 16,
+    "vectorize" => 0
+  })
+
+File.write!("schedule.mlirbc", Schedule.serialize(resolved, :bytecode))
+
+# Replay does not call the resolver or enumerate candidates again.
+MLIR.Transform.apply_named_sequence!(payload, resolved)
+```
+
+Resolution writes `selected` and `selected_region` back into a copied schedule,
+then records text, bytecode, the active choice map, and a SHA-256 digest. Knobs
+in inactive alternatives may remain visibly unresolved because the replayed
+schedule cannot enter those regions.
+
+## Bounded concurrent evaluation
+
+`Beaver.MLIR.Transform.Tuner` evaluates candidates with `Task.async_stream/3`
+using bounded concurrency and ordered result collection. The evaluation hook
+owns the scoring system; Beaver only records values, metadata, failures,
+timeouts, and cancellation deterministically.
+
+```elixir
+alias Beaver.MLIR.Transform.Tuner
+
+cancellation = Tuner.Cancellation.new()
+
+result =
+  Tuner.search!(transform_ir, fn resolved, candidate ->
+    artifact =
+      MLIR.CompilationRuntime.compile!(payload_source,
+        transform_schedule: resolved,
+        cache: {:file, ".beaver/cache"},
+        target: target
+      )
+
+    # Replace this hook with application-specific compile/run benchmarking.
+    {:ok, benchmark.(artifact), %{choices: candidate.choices}}
+  end,
+    max_concurrency: 4,
+    timeout: 30_000,
+    cancellation: cancellation
+  )
+
+winner =
+  Tuner.select(result, fn successful ->
+    Enum.min_by(successful, & &1.value)
+  end)
+
+File.write!("winner.mlirbc", winner.schedule.bytecode)
+```
+
+`CompilationRuntime` includes the resolved schedule identity in its cache key.
+Changing a selection therefore invalidates the transformed artifact, while an
+identical resolved schedule reuses it. A running evaluator can inspect
+`candidate.cancelled?`; `Tuner.Cancellation.cancel/1` also prevents queued work
+from starting. Non-cooperative work is bounded by the per-candidate timeout.
+
+### Correlating candidates with MLIR actions
+
+The tuner emits search and candidate `:start`/`:stop` events below
+`[:beaver, :mlir, :compilation, :autotuning, ...]`. Candidate stop metadata
+includes the resolved schedule digest and status. The evaluator context also
+contains `telemetry_metadata`; pass it to `MLIR.ActionTracing` to tag every
+lower-level pass, rewrite, tiling, and vectorization action with the candidate
+that caused it:
+
+```elixir
+Tuner.search!(transform_ir, fn resolved, candidate ->
+  ctx = MLIR.Context.create()
+  tracing =
+    MLIR.ActionTracing.attach(ctx, metadata: candidate.telemetry_metadata)
+
+  try do
+    artifact =
+      MLIR.CompilationRuntime.compile!(payload_source,
+        context: ctx,
+        transform_schedule: resolved,
+        cache: {:file, ".beaver/cache"},
+        target: target
+      )
+
+    MLIR.ActionTracing.drain(tracing)
+    {:ok, benchmark.(artifact)}
+  after
+    MLIR.ActionTracing.detach(tracing)
+    MLIR.Context.destroy(ctx)
+  end
+end)
+```
+
+Each concurrent candidate should own its context and tracing session. This
+keeps native action observation context-scoped while the shared telemetry sink
+can group events by `candidate_index`, `choices`, and
+`transform_schedule_digest`.
+
+## Constraints without a bundled solver
+
+`Schedule.constraints/2` exports every reachable
+`transform.smt.constrain_params` as generic MLIR text plus its operand/result
+counts and alternatives guards. This works without an SMT installation.
+
+```elixir
+{:ok, constraints} = Schedule.constraints(transform_ir)
+
+solver = fn constraints, selections ->
+  MySolver.validate(constraints, selections)
+end
+
+{:ok, resolved} = Schedule.resolve(transform_ir, choices, solver: solver)
+resolved.solver_metadata
+```
+
+For reusable adapters, implement `Beaver.MLIR.Transform.Solver`. Beaver does not
+assume that one score, solver, or hardware benchmark is authoritative; the
+adapter boundary keeps those policies outside the reproducible schedule.

--- a/lib/beaver/mlir/action_tracing.ex
+++ b/lib/beaver/mlir/action_tracing.ex
@@ -33,6 +33,9 @@ defmodule Beaver.MLIR.ActionTracing do
     automatically. Defaults to `nil` (manual draining).
   - `:telemetry` — optional `(event, measurements, metadata) -> term` callback
     used instead of `:telemetry` events (see `Beaver.MLIR.Telemetry`).
+  - `:metadata` — metadata merged into every emitted action event. Event-owned
+    fields take precedence. This can correlate actions with a higher-level
+    operation such as one Transform autotuning candidate.
   """
 
   use GenServer
@@ -44,7 +47,7 @@ defmodule Beaver.MLIR.ActionTracing do
   defmodule Session do
     @moduledoc "A live context-scoped action tracing session."
     @enforce_keys [:pid, :context]
-    defstruct [:pid, :context, :tags, :locations, :skip, :limit, :drain_interval_ms]
+    defstruct [:pid, :context, :tags, :locations, :skip, :limit, :drain_interval_ms, :metadata]
 
     @type t() :: %__MODULE__{
             pid: pid(),
@@ -53,7 +56,8 @@ defmodule Beaver.MLIR.ActionTracing do
             locations: [String.t()] | nil,
             skip: %{optional(String.t()) => non_neg_integer()},
             limit: %{optional(String.t()) => non_neg_integer()},
-            drain_interval_ms: pos_integer() | nil
+            drain_interval_ms: pos_integer() | nil,
+            metadata: map()
           }
   end
 
@@ -76,6 +80,7 @@ defmodule Beaver.MLIR.ActionTracing do
     locations = normalize_locations!(Keyword.get(opts, :locations))
     skip = normalize_count_map!(Keyword.get(opts, :skip, %{}), :skip)
     limit = normalize_count_map!(Keyword.get(opts, :limit, %{}), :limit)
+    metadata = normalize_metadata!(Keyword.get(opts, :metadata, %{}))
 
     drain_interval_ms =
       case Keyword.get(opts, :drain_interval_ms) do
@@ -104,6 +109,7 @@ defmodule Beaver.MLIR.ActionTracing do
         context: context,
         session: session,
         telemetry: Keyword.get(opts, :telemetry),
+        metadata: metadata,
         drain_interval_ms: drain_interval_ms
       })
 
@@ -114,7 +120,8 @@ defmodule Beaver.MLIR.ActionTracing do
       locations: locations,
       skip: skip,
       limit: limit,
-      drain_interval_ms: drain_interval_ms
+      drain_interval_ms: drain_interval_ms,
+      metadata: metadata
     }
   end
 
@@ -162,7 +169,7 @@ defmodule Beaver.MLIR.ActionTracing do
   @impl true
   def handle_call(:drain, _from, state) do
     events = drain_raw_events(state)
-    emit_events(events, state.telemetry)
+    emit_events(events, state.telemetry, state.metadata)
     {:reply, events, state}
   end
 
@@ -179,7 +186,7 @@ defmodule Beaver.MLIR.ActionTracing do
   @impl true
   def handle_info(:drain_timer, state) do
     events = drain_raw_events(state)
-    emit_events(events, state.telemetry)
+    emit_events(events, state.telemetry, state.metadata)
     schedule_drain(state)
     {:noreply, state}
   end
@@ -244,7 +251,7 @@ defmodule Beaver.MLIR.ActionTracing do
     {event["tag"], event["depth"]}
   end
 
-  defp emit_events(events, telemetry) do
+  defp emit_events(events, telemetry, extra_metadata) do
     events
     |> pair_events()
     |> Enum.each(fn
@@ -254,17 +261,17 @@ defmodule Beaver.MLIR.ActionTracing do
         MLIR.Telemetry.emit(
           [:action, :start],
           %{},
-          start_event,
+          Map.merge(extra_metadata, start_event),
           telemetry: telemetry
         )
 
         MLIR.Telemetry.emit(
           [:action, :stop],
           %{duration: duration},
-          %{
+          Map.merge(extra_metadata, %{
             "tag" => event["tag"],
             "depth" => event["depth"]
-          },
+          }),
           telemetry: telemetry
         )
 
@@ -310,6 +317,11 @@ defmodule Beaver.MLIR.ActionTracing do
 
   defp normalize_count_map!(other, name),
     do: raise(ArgumentError, "invalid #{name}: #{inspect(other)}")
+
+  defp normalize_metadata!(metadata) when is_map(metadata), do: metadata
+
+  defp normalize_metadata!(other),
+    do: raise(ArgumentError, "invalid :metadata: #{inspect(other)}")
 
   defp encode_count_map(map) do
     "{" <> Enum.map_join(map, ",", fn {k, v} -> ~s("#{k}":#{v}) end) <> "}"

--- a/lib/beaver/mlir/attribute.ex
+++ b/lib/beaver/mlir/attribute.ex
@@ -423,11 +423,20 @@ defmodule Beaver.MLIR.Attribute do
       string?(attribute) ->
         mlirStringAttrGetValue(attribute) |> to_string()
 
+      bool?(attribute) ->
+        mlirBoolAttrGetValue(attribute) |> Beaver.Native.to_term()
+
       integer?(attribute) ->
         mlirIntegerAttrGetValueInt(attribute) |> Beaver.Native.to_term()
 
+      float?(attribute) ->
+        mlirFloatAttrGetValueDouble(attribute) |> Beaver.Native.to_term()
+
       flat_symbol_ref?(attribute) ->
         mlirFlatSymbolRefAttrGetValue(attribute) |> to_string()
+
+      unit?(attribute) ->
+        :unit
     end
   end
 

--- a/lib/beaver/mlir/capi.ex
+++ b/lib/beaver/mlir/capi.ex
@@ -11,6 +11,7 @@ defmodule Beaver.MLIR.CAPI do
 
   Here are the list of these MLIR CAPIs and the Elixir code to execute they might trigger:
   - `mlirPassManagerRunOnOp`: the MLIR pass implemented in Elixir.
+  - `mlirTransformApplyNamedSequence`: Transform operations implemented in Elixir.
   - `mlirOperationVerify`, `mlirAttributeParseGet`, `mlirTypeParseGet`, `mlirModuleCreateParse`: native diagnostic collection and any external operation interface reached during parsing or verification.
   """
   use Kinda.CodeGen,

--- a/lib/beaver/mlir/compilation_runtime.ex
+++ b/lib/beaver/mlir/compilation_runtime.ex
@@ -15,6 +15,7 @@ defmodule Beaver.MLIR.CompilationRuntime do
     * source content and structural hash;
     * the LLVM revision used to build Beaver;
     * pass/transform pipeline identity;
+    * resolved Transform schedule identity;
     * target configuration;
     * dynamic dialect/schema version;
     * requested bytecode emit version.
@@ -32,6 +33,8 @@ defmodule Beaver.MLIR.CompilationRuntime do
   alias Beaver.Composer
   alias Beaver.MLIR
   alias MLIR.CompilationCache
+  alias MLIR.Transform
+  alias MLIR.Transform.Schedule, as: TransformSchedule
   alias __MODULE__.{Artifact, CacheKey}
 
   @entry_format 1
@@ -40,6 +43,8 @@ defmodule Beaver.MLIR.CompilationRuntime do
           {:cache, CompilationCache.cache()}
           | {:pipeline, term()}
           | {:pipeline_version, term()}
+          | {:transform_schedule, TransformSchedule.Resolved.t() | binary()}
+          | {:transform_options, keyword()}
           | {:target, term()}
           | {:schema_version, term()}
           | {:desired_emit_version, integer() | nil}
@@ -268,6 +273,8 @@ defmodule Beaver.MLIR.CompilationRuntime do
       source_digest: digest(source_bytes),
       llvm_revision: Keyword.get_lazy(opts, :llvm_revision, &llvm_revision/0),
       pipeline: pipeline_identity(opts),
+      transform_schedule: transform_schedule_identity(opts),
+      transform_options: transform_options_identity(opts),
       target: Keyword.get(opts, :target, %{}),
       schema_version: Keyword.get(opts, :schema_version, :static),
       bytecode_version: Keyword.get(opts, :desired_emit_version, :current)
@@ -278,6 +285,39 @@ defmodule Beaver.MLIR.CompilationRuntime do
     case Keyword.fetch(opts, :pipeline_version) do
       {:ok, version} -> version
       :error -> assert_deterministic_pipeline!(Keyword.get(opts, :pipeline, []))
+    end
+  end
+
+  defp transform_schedule_identity(opts) do
+    case Keyword.get(opts, :transform_schedule) do
+      nil ->
+        :none
+
+      %TransformSchedule.Resolved{} = schedule ->
+        TransformSchedule.cache_identity(schedule)
+
+      schedule when is_binary(schedule) ->
+        TransformSchedule.cache_identity(schedule)
+
+      schedule ->
+        raise ArgumentError,
+              ":transform_schedule must be resolved schedule data or MLIR text/bytecode, got: #{inspect(schedule, limit: 5)}"
+    end
+  end
+
+  defp transform_options_identity(opts) do
+    case Keyword.get(opts, :transform_schedule) do
+      nil ->
+        :none
+
+      _schedule ->
+        transform_options = Keyword.get(opts, :transform_options, [])
+
+        if Keyword.keyword?(transform_options) do
+          Map.new(transform_options)
+        else
+          raise ArgumentError, ":transform_options must be a keyword list"
+        end
     end
   end
 
@@ -303,6 +343,19 @@ defmodule Beaver.MLIR.CompilationRuntime do
   end
 
   defp run_pipeline(module, opts) do
+    module =
+      case Keyword.get(opts, :transform_schedule) do
+        nil ->
+          module
+
+        schedule ->
+          Transform.apply_named_sequence!(
+            module,
+            schedule,
+            Keyword.get(opts, :transform_options, [])
+          )
+      end
+
     case Keyword.get(opts, :pipeline, []) do
       [] ->
         module

--- a/lib/beaver/mlir/diagnostic.ex
+++ b/lib/beaver/mlir/diagnostic.ex
@@ -21,6 +21,16 @@ defmodule Beaver.MLIR.Diagnostic do
 
   defdelegate detach(ctx, handler_id), to: MLIR.CAPI, as: :mlirContextDetachDiagnosticHandler
 
+  @doc "Converts diagnostic locations to strings so the tree is safe beyond context lifetime."
+  def process(diagnostics) when is_list(diagnostics) do
+    Enum.map(diagnostics, &process_diagnostic/1)
+  end
+
+  defp process_diagnostic({severity, location, message, nested}) do
+    location = if is_binary(location), do: location, else: MLIR.to_string(location)
+    {severity, location, message, Enum.map(nested, &process_diagnostic/1)}
+  end
+
   def walk({_, _, _, []} = diagnostic, acc, fun) do
     fun.(diagnostic, acc)
   end

--- a/lib/beaver/mlir/transform.ex
+++ b/lib/beaver/mlir/transform.ex
@@ -1,8 +1,296 @@
 defmodule Beaver.MLIR.Transform do
   @moduledoc """
-  Transformations MLIR provides by default.
+  Transform dialect execution and transformations MLIR provides by default.
+
+  `apply_named_sequence/3` executes a named Transform dialect sequence without
+  routing it through a pass manager. Transform IR may be supplied as a module,
+  an operation nested in a module, textual MLIR, bytecode, or a resolved tuning
+  schedule produced by `Beaver.MLIR.Transform.Schedule`.
+
+  Handles remain owned by MLIR's transform state and never escape this call.
+  Keeping expensive checks enabled (the default) makes use-after-consume handle
+  errors visible as processed diagnostics.
   """
+
+  alias __MODULE__.Schedule
+  alias Beaver.MLIR
+
   use Beaver.ComposerGenerator, prefix: "mlirCreateTransforms"
   use Beaver.ComposerGenerator, prefix: "mlirCreateLinalg"
   use Beaver.ComposerGenerator, prefix: "mlirCreateGPU"
+
+  defmodule Result do
+    @moduledoc "The result of successfully applying a named transform sequence."
+
+    @enforce_keys [:payload, :sequence, :diagnostics]
+    defstruct [:payload, :sequence, :diagnostics]
+
+    @type t() :: %__MODULE__{
+            payload: MLIR.Module.t() | MLIR.Operation.t(),
+            sequence: String.t(),
+            diagnostics: [term()]
+          }
+  end
+
+  defmodule Error do
+    @moduledoc "A structured Transform dialect parsing, resolution, or execution failure."
+
+    defexception [:kind, :reason, diagnostics: [], sequence: nil]
+
+    @type kind() ::
+            :invalid_schedule
+            | :silenceable_failure
+            | :definite_failure
+            | :evaluation_failure
+            | :constraint_failure
+
+    @type t() :: %__MODULE__{
+            kind: kind(),
+            reason: term(),
+            diagnostics: [term()],
+            sequence: String.t() | nil
+          }
+
+    @impl true
+    def message(%__MODULE__{} = error) do
+      prefix =
+        case error.kind do
+          :invalid_schedule -> "invalid transform schedule"
+          :silenceable_failure -> "transform sequence failed silenceably"
+          :definite_failure -> "transform sequence failed definitively"
+          :evaluation_failure -> "transform schedule evaluation failed"
+          :constraint_failure -> "transform schedule constraints failed"
+        end
+
+      prefix =
+        if error.sequence do
+          prefix <> " (#{error.sequence})"
+        else
+          prefix
+        end
+
+      details = if is_nil(error.reason), do: prefix, else: prefix <> ": " <> inspect(error.reason)
+
+      if error.diagnostics == [] do
+        details
+      else
+        MLIR.Diagnostic.format(error.diagnostics, details)
+      end
+    end
+  end
+
+  @type schedule_input() ::
+          MLIR.Module.t()
+          | MLIR.Operation.t()
+          | binary()
+          | Schedule.Resolved.t()
+
+  @type execution_option() ::
+          {:sequence, String.t()}
+          | {:expensive_checks, boolean()}
+          | {:enforce_single_top_level_transform_op, boolean()}
+
+  @doc """
+  Applies a named Transform dialect sequence to a payload operation or module.
+
+  The default sequence is `__transform_main`. LLVM's expensive handle checks
+  and single-top-level-transform enforcement both default to `true` and can be
+  configured independently.
+  """
+  @spec apply_named_sequence(
+          MLIR.Module.t() | MLIR.Operation.t(),
+          schedule_input(),
+          [execution_option()]
+        ) :: {:ok, Result.t()} | {:error, Error.t()}
+  def apply_named_sequence(payload, schedule, opts \\ []) do
+    with :ok <- validate_execution_options(opts),
+         payload_operation <- MLIR.Operation.from_module(payload),
+         context <- MLIR.context(payload_operation) do
+      Schedule.with_module(schedule, context, fn schedule_module ->
+        execute_loaded_schedule(payload, payload_operation, schedule, schedule_module, opts)
+      end)
+    end
+  rescue
+    exception in [ArgumentError] ->
+      {:error,
+       %Error{
+         kind: :invalid_schedule,
+         reason: Exception.message(exception),
+         sequence: Keyword.get(opts, :sequence)
+       }}
+  end
+
+  defp execute_loaded_schedule(payload, payload_operation, schedule, schedule_module, opts) do
+    sequence = Keyword.get(opts, :sequence, Schedule.sequence(schedule))
+
+    case Schedule.find_sequence(schedule_module, sequence) do
+      {:ok, transform_root} ->
+        apply_with_options(
+          payload,
+          payload_operation,
+          schedule_module,
+          transform_root,
+          sequence,
+          opts
+        )
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  @doc "Bang variant of `apply_named_sequence/3`."
+  @spec apply_named_sequence!(
+          MLIR.Module.t() | MLIR.Operation.t(),
+          schedule_input(),
+          [execution_option()]
+        ) :: MLIR.Module.t() | MLIR.Operation.t()
+  def apply_named_sequence!(payload, schedule, opts \\ []) do
+    case apply_named_sequence(payload, schedule, opts) do
+      {:ok, %Result{payload: transformed}} -> transformed
+      {:error, error} -> raise error
+    end
+  end
+
+  @doc "Alias for `apply_named_sequence/3`."
+  def execute(payload, schedule, opts \\ []), do: apply_named_sequence(payload, schedule, opts)
+
+  @doc "Alias for `apply_named_sequence!/3`."
+  def execute!(payload, schedule, opts \\ []), do: apply_named_sequence!(payload, schedule, opts)
+
+  @doc "Creates Transform dialect's `!transform.any_op` type."
+  def any_op_type(opts \\ []) do
+    Beaver.Deferred.from_opts(opts, &MLIR.CAPI.mlirTransformAnyOpTypeGet/1)
+  end
+
+  @doc "Creates Transform dialect's `!transform.any_value` type."
+  def any_value_type(opts \\ []) do
+    Beaver.Deferred.from_opts(opts, &MLIR.CAPI.mlirTransformAnyValueTypeGet/1)
+  end
+
+  @doc "Creates Transform dialect's `!transform.any_param` type."
+  def any_param_type(opts \\ []) do
+    Beaver.Deferred.from_opts(opts, &MLIR.CAPI.mlirTransformAnyParamTypeGet/1)
+  end
+
+  @doc "Creates an operation-specific Transform handle type."
+  def operation_type(operation_name, opts \\ []) when is_binary(operation_name) do
+    Beaver.Deferred.from_opts(opts, fn context ->
+      MLIR.CAPI.mlirTransformOperationTypeGet(
+        context,
+        MLIR.StringRef.create(operation_name)
+      )
+    end)
+  end
+
+  @doc "Creates a Transform parameter type wrapping an MLIR type."
+  def param_type(type) do
+    case type do
+      %MLIR.Type{} -> MLIR.CAPI.mlirTransformParamTypeGet(MLIR.context(type), type)
+      deferred when is_function(deferred, 1) -> &param_type(deferred.(&1))
+    end
+  end
+
+  defp apply_with_options(
+         payload,
+         payload_operation,
+         schedule_module,
+         transform_root,
+         sequence,
+         opts
+       ) do
+    context = MLIR.context(payload_operation)
+    transform_options = MLIR.CAPI.mlirTransformOptionsCreate()
+
+    try do
+      MLIR.CAPI.mlirTransformOptionsEnableExpensiveChecks(
+        transform_options,
+        Keyword.get(opts, :expensive_checks, true)
+      )
+
+      MLIR.CAPI.mlirTransformOptionsEnforceSingleTopLevelTransformOp(
+        transform_options,
+        Keyword.get(opts, :enforce_single_top_level_transform_op, true)
+      )
+
+      {logical_result, diagnostics} =
+        MLIR.CAPI.mlirTransformApplyNamedSequenceWithDiagnostics(
+          context,
+          payload_operation,
+          transform_root,
+          MLIR.Operation.from_module(schedule_module),
+          transform_options
+        )
+
+      diagnostics = MLIR.Diagnostic.process(diagnostics)
+
+      if MLIR.LogicalResult.success?(logical_result) do
+        {:ok, %Result{payload: payload, sequence: sequence, diagnostics: diagnostics}}
+      else
+        {:error,
+         %Error{
+           kind: classify_failure(diagnostics),
+           reason: :transform_application_failed,
+           diagnostics: diagnostics,
+           sequence: sequence
+         }}
+      end
+    after
+      MLIR.CAPI.mlirTransformOptionsDestroy(transform_options)
+    end
+  end
+
+  defp classify_failure(diagnostics) do
+    if Enum.any?(diagnostics, &definite_diagnostic?/1) do
+      :definite_failure
+    else
+      :silenceable_failure
+    end
+  end
+
+  # The upstream C entry point intentionally flattens DiagnosedSilenceableFailure
+  # to LogicalResult. Definite failures retain stable diagnostic wording; all
+  # other execution failures are the propagated silenceable class.
+  defp definite_diagnostic?({_severity, _location, message, nested}) do
+    message = String.downcase(message)
+
+    String.contains?(message, "definite failure") or
+      String.contains?(message, "non-deterministic choice") or
+      String.contains?(message, "callback raised") or
+      String.contains?(message, "callback failed") or
+      String.contains?(message, "callback returned an invalid") or
+      Enum.any?(nested, &definite_diagnostic?/1)
+  end
+
+  defp validate_execution_options(opts) do
+    unless Keyword.keyword?(opts) do
+      raise ArgumentError, "transform execution options must be a keyword list"
+    end
+
+    supported = [
+      :sequence,
+      :expensive_checks,
+      :enforce_single_top_level_transform_op
+    ]
+
+    case Keyword.keys(opts) -- supported do
+      [] ->
+        for key <- [:expensive_checks, :enforce_single_top_level_transform_op],
+            value = Keyword.get(opts, key, true),
+            not is_boolean(value) do
+          raise ArgumentError, "#{inspect(key)} must be boolean, got: #{inspect(value)}"
+        end
+
+        case Keyword.get(opts, :sequence, "__transform_main") do
+          sequence when is_binary(sequence) and sequence != "" ->
+            :ok
+
+          sequence ->
+            raise ArgumentError, ":sequence must be a non-empty string, got: #{inspect(sequence)}"
+        end
+
+      unsupported ->
+        raise ArgumentError, "unsupported transform execution options: #{inspect(unsupported)}"
+    end
+  end
 end

--- a/lib/beaver/mlir/transform/resolver.ex
+++ b/lib/beaver/mlir/transform/resolver.ex
@@ -1,0 +1,16 @@
+defmodule Beaver.MLIR.Transform.Resolver do
+  @moduledoc """
+  Behaviour for resolving Transform Tune choices.
+
+  Resolver state is explicit so one resolver may be reused safely by concurrent
+  tuning candidates. Returning `:unresolved` lets an already selected value be
+  used; otherwise resolution fails for an active choice.
+  """
+
+  alias Beaver.MLIR.Transform.Schedule.Choice
+
+  @callback resolve(Choice.t(), state :: term()) ::
+              {:ok, term(), new_state :: term()}
+              | {:error, term(), new_state :: term()}
+              | {:unresolved, new_state :: term()}
+end

--- a/lib/beaver/mlir/transform/schedule.ex
+++ b/lib/beaver/mlir/transform/schedule.ex
@@ -1,0 +1,846 @@
+defmodule Beaver.MLIR.Transform.Schedule do
+  @moduledoc """
+  Deterministic discovery and resolution of Transform Tune schedules.
+
+  A resolved schedule is immutable BEAM data: MLIR bytecode, printable text,
+  the active choices, and a stable digest. Resolution writes choices back to
+  `transform.tune.knob` and `transform.tune.alternatives`, so replay does not
+  invoke the resolver or repeat a search.
+  """
+
+  alias Beaver.MLIR
+  alias Beaver.MLIR.Transform
+
+  @format 1
+  @default_sequence "__transform_main"
+  @default_max_candidates 10_000
+
+  defmodule Option do
+    @moduledoc "One enumerable option of a Tune choice."
+    @enforce_keys [:index, :value, :mlir]
+    defstruct [:index, :value, :mlir]
+
+    @type t() :: %__MODULE__{index: non_neg_integer(), value: term(), mlir: String.t()}
+  end
+
+  defmodule Choice do
+    @moduledoc "A discovered `transform.tune.knob` or alternatives operation."
+    @enforce_keys [:name, :kind, :options, :path, :guards, :enumerable?]
+    defstruct [:name, :kind, :options, :selected, :domain, :path, :guards, :enumerable?]
+
+    @type kind() :: :knob | :alternatives
+    @type guard() :: {String.t(), non_neg_integer()}
+
+    @type t() :: %__MODULE__{
+            name: String.t(),
+            kind: kind(),
+            options: [Option.t()],
+            selected: term() | nil,
+            domain: String.t() | nil,
+            path: list(term()),
+            guards: [guard()],
+            enumerable?: boolean()
+          }
+  end
+
+  defmodule Constraint do
+    @moduledoc "An exported `transform.smt.constrain_params` operation."
+    @enforce_keys [:ir, :path, :guards]
+    defstruct [:ir, :path, :guards, operands: 0, results: 0]
+
+    @type t() :: %__MODULE__{
+            ir: String.t(),
+            path: list(term()),
+            guards: [Choice.guard()],
+            operands: non_neg_integer(),
+            results: non_neg_integer()
+          }
+  end
+
+  defmodule Analysis do
+    @moduledoc "Serializable discovery result for one named sequence."
+    @enforce_keys [:sequence, :choices, :constraints]
+    defstruct [:sequence, :choices, :constraints]
+
+    @type t() :: %__MODULE__{
+            sequence: String.t(),
+            choices: [Choice.t()],
+            constraints: [Constraint.t()]
+          }
+  end
+
+  defmodule Resolved do
+    @moduledoc "An immutable, cache-addressable, replayable Transform schedule."
+    @enforce_keys [:format, :sequence, :bytecode, :text, :choices, :constraints, :digest]
+    defstruct [
+      :format,
+      :sequence,
+      :bytecode,
+      :text,
+      :choices,
+      :constraints,
+      :digest,
+      :solver_metadata
+    ]
+
+    @type t() :: %__MODULE__{
+            format: pos_integer(),
+            sequence: String.t(),
+            bytecode: binary(),
+            text: String.t(),
+            choices: map(),
+            constraints: [Constraint.t()],
+            digest: String.t(),
+            solver_metadata: term()
+          }
+  end
+
+  @type input() ::
+          MLIR.Module.t()
+          | MLIR.Operation.t()
+          | binary()
+          | {:text, binary()}
+          | {:bytecode, binary()}
+          | Resolved.t()
+
+  @doc "Returns the entry-point symbol carried by a resolved schedule."
+  def sequence(%Resolved{sequence: sequence}), do: sequence
+  def sequence(_input), do: @default_sequence
+
+  @doc "Discovers Tune choices and SMT constraints without executing the schedule."
+  @spec analyze(input(), keyword()) :: {:ok, Analysis.t()} | {:error, Transform.Error.t()}
+  def analyze(input, opts \\ []) do
+    with_analysis_module(input, opts, fn module, sequence ->
+      case analyze_module(module, sequence) do
+        {:ok, analysis, _entries} -> {:ok, analysis}
+        {:error, error} -> {:error, error}
+      end
+    end)
+  end
+
+  @doc "Returns exported SMT constraints even when no solver is configured."
+  @spec constraints(input(), keyword()) ::
+          {:ok, [Constraint.t()]} | {:error, Transform.Error.t()}
+  def constraints(input, opts \\ []) do
+    with {:ok, %Analysis{constraints: constraints}} <- analyze(input, opts) do
+      {:ok, constraints}
+    end
+  end
+
+  @doc """
+  Enumerates active Tune choices in stable IR and option order.
+
+  Existing selections remain fixed. Choices nested in an alternatives region
+  are included only when that region is selected by the candidate. Arbitrary
+  non-array knob domains remain inspectable but require an explicit resolver.
+  """
+  @spec enumerate(input(), keyword()) :: {:ok, [map()]} | {:error, Transform.Error.t()}
+  def enumerate(input, opts \\ []) do
+    max_candidates = Keyword.get(opts, :max_candidates, @default_max_candidates)
+
+    if is_integer(max_candidates) and max_candidates > 0 do
+      with {:ok, %Analysis{} = analysis} <- analyze(input, opts) do
+        enumerate_choices(analysis.choices, max_candidates)
+      end
+    else
+      {:error, invalid_error(":max_candidates must be a positive integer")}
+    end
+  end
+
+  @doc "Resolves active Tune choices from a map, function, or resolver behaviour."
+  @spec resolve(input(), map() | function() | module() | {module(), term()}, keyword()) ::
+          {:ok, Resolved.t()} | {:error, Transform.Error.t()}
+  def resolve(input, resolver, opts \\ []) do
+    with_analysis_module(input, opts, fn module, sequence ->
+      with {:ok, analysis, entries} <- analyze_module(module, sequence),
+           {:ok, selections, _resolver_state} <- resolve_entries(entries, resolver),
+           active_constraints <- active_constraints(analysis.constraints, selections),
+           {:ok, solver_metadata} <-
+             solve_constraints(active_constraints, selections, Keyword.get(opts, :solver)),
+           :ok <- rewrite_entries(entries, selections, MLIR.context(module)) do
+        bytecode = MLIR.Bytecode.write!(module)
+        text = MLIR.to_string(module, generic: false)
+
+        {:ok,
+         %Resolved{
+           format: @format,
+           sequence: sequence,
+           bytecode: bytecode,
+           text: text,
+           choices: selections,
+           constraints: active_constraints,
+           digest: digest(bytecode),
+           solver_metadata: solver_metadata
+         }}
+      end
+    end)
+  end
+
+  @doc "Bang variant of `resolve/3`."
+  @spec resolve!(input(), map() | function() | module() | {module(), term()}, keyword()) ::
+          Resolved.t()
+  def resolve!(input, resolver, opts \\ []) do
+    case resolve(input, resolver, opts) do
+      {:ok, resolved} -> resolved
+      {:error, error} -> raise error
+    end
+  end
+
+  @doc "Serializes a resolved schedule as replayable MLIR bytecode or text."
+  @spec serialize(Resolved.t(), :bytecode | :text) :: binary()
+  def serialize(%Resolved{bytecode: bytecode}, :bytecode), do: bytecode
+  def serialize(%Resolved{text: text}, :text), do: text
+
+  @doc "Returns the stable identity included in incremental compilation cache keys."
+  @spec cache_identity(Resolved.t() | binary()) :: tuple()
+  def cache_identity(%Resolved{format: format, digest: digest, sequence: sequence}) do
+    {:beaver_transform_schedule, format, sequence, digest}
+  end
+
+  def cache_identity(schedule) when is_binary(schedule) do
+    {:beaver_transform_schedule, @format, @default_sequence, digest(schedule)}
+  end
+
+  @doc false
+  def snapshot(input, opts \\ []) do
+    with_analysis_module(input, opts, fn module, sequence ->
+      {:ok, {MLIR.Bytecode.write!(module), sequence}}
+    end)
+  end
+
+  @doc false
+  def with_module(input, %MLIR.Context{} = context, fun) when is_function(fun, 1) do
+    with {:ok, bytes} <- source_bytes(input),
+         {:ok, module} <- parse_module(bytes, context) do
+      try do
+        case MLIR.verify(module) do
+          {:ok, _module} -> fun.(module)
+          :null -> {:error, invalid_error("parsed transform module is null")}
+          {:error, diagnostics} -> {:error, invalid_error(:verification_failed, diagnostics)}
+        end
+      after
+        MLIR.Module.destroy(module)
+      end
+    end
+  rescue
+    exception in [ArgumentError] ->
+      {:error, invalid_error(Exception.message(exception))}
+  end
+
+  @doc false
+  def find_sequence(%MLIR.Module{} = module, sequence) when is_binary(sequence) do
+    module
+    |> operations()
+    |> Enum.find(fn operation ->
+      MLIR.Operation.name(operation) == "transform.named_sequence" and
+        attribute_value(operation, "sym_name") == sequence
+    end)
+    |> case do
+      nil -> {:error, invalid_error({:sequence_not_found, sequence})}
+      operation -> {:ok, operation}
+    end
+  end
+
+  defp with_analysis_module(input, opts, fun) do
+    sequence = Keyword.get(opts, :sequence, sequence(input))
+
+    case input_context(input, opts) do
+      {:borrowed, context} ->
+        with_module(input, context, &fun.(&1, sequence))
+
+      :owned ->
+        context = MLIR.Context.create()
+
+        try do
+          with_module(input, context, &fun.(&1, sequence))
+        after
+          MLIR.Context.destroy(context)
+        end
+    end
+  end
+
+  defp input_context(input, opts) do
+    case Keyword.get(opts, :ctx) do
+      %MLIR.Context{} = context -> {:borrowed, context}
+      nil -> source_context(input)
+    end
+  end
+
+  defp source_context(%MLIR.Module{} = module), do: {:borrowed, MLIR.context(module)}
+  defp source_context(%MLIR.Operation{} = operation), do: {:borrowed, MLIR.context(operation)}
+  defp source_context(_input), do: :owned
+
+  defp source_bytes(%Resolved{bytecode: bytecode}), do: {:ok, bytecode}
+
+  defp source_bytes({format, bytes}) when format in [:text, :bytecode] and is_binary(bytes),
+    do: {:ok, bytes}
+
+  defp source_bytes(bytes) when is_binary(bytes), do: {:ok, bytes}
+  defp source_bytes(%MLIR.Module{} = module), do: {:ok, MLIR.Bytecode.write!(module)}
+
+  defp source_bytes(%MLIR.Operation{} = operation) do
+    case enclosing_module(operation) do
+      nil ->
+        text =
+          "module attributes {transform.with_named_sequence} {\n" <>
+            MLIR.to_string(operation, generic: false) <> "\n}"
+
+        {:ok, text}
+
+      module_operation ->
+        {:ok, MLIR.Bytecode.write!(module_operation)}
+    end
+  end
+
+  defp source_bytes(input), do: {:error, invalid_error({:unsupported_schedule_input, input})}
+
+  defp parse_module(bytes, context) do
+    case MLIR.Module.create(bytes, ctx: context) do
+      {:ok, module} -> {:ok, module}
+      {:error, diagnostics} -> {:error, invalid_error(:parse_failed, diagnostics)}
+    end
+  end
+
+  defp enclosing_module(operation) do
+    if MLIR.Operation.name(operation) == "builtin.module",
+      do: operation,
+      else: enclosing_module_parent(MLIR.Operation.parent(operation))
+  end
+
+  defp enclosing_module_parent(operation) do
+    cond do
+      MLIR.null?(operation) -> nil
+      MLIR.Operation.name(operation) == "builtin.module" -> operation
+      true -> enclosing_module_parent(MLIR.Operation.parent(operation))
+    end
+  end
+
+  defp analyze_module(module, sequence) do
+    with {:ok, root} <- find_sequence(module, sequence) do
+      {_operation, {choices, constraints, entries}} =
+        scan_operation(root, [], [], {[], [], []})
+
+      choices = Enum.reverse(choices)
+      constraints = Enum.reverse(constraints)
+      entries = Enum.reverse(entries)
+
+      case duplicate_choice_names(choices) do
+        [] ->
+          {:ok, %Analysis{sequence: sequence, choices: choices, constraints: constraints},
+           entries}
+
+        duplicates ->
+          {:error, invalid_error({:duplicate_choice_names, duplicates})}
+      end
+    end
+  end
+
+  defp scan_operation(operation, path, guards, {choices, constraints, entries} = acc) do
+    case MLIR.Operation.name(operation) do
+      "transform.tune.knob" ->
+        {choice, option_attributes} = knob_choice(operation, path, guards)
+
+        acc =
+          {[choice | choices], constraints, [{choice, operation, option_attributes} | entries]}
+
+        scan_children(operation, path, guards, acc)
+
+      "transform.tune.alternatives" ->
+        choice = alternatives_choice(operation, path, guards)
+        acc = {[choice | choices], constraints, [{choice, operation, []} | entries]}
+        scan_alternatives(operation, path, guards, choice.name, acc)
+
+      "transform.smt.constrain_params" ->
+        constraint = %Constraint{
+          ir: MLIR.to_string(operation, generic: true),
+          path: path,
+          guards: guards,
+          operands: Enum.count(Beaver.Walker.operands(operation)),
+          results: Enum.count(Beaver.Walker.results(operation))
+        }
+
+        scan_children(operation, path, guards, {choices, [constraint | constraints], entries})
+
+      _other ->
+        scan_children(operation, path, guards, acc)
+    end
+  end
+
+  defp scan_children(operation, path, guards, acc) do
+    operation
+    |> Beaver.Walker.regions()
+    |> Enum.with_index()
+    |> Enum.reduce(acc, fn {region, region_index}, acc ->
+      scan_region(region, path ++ [{:region, region_index}], guards, acc)
+    end)
+    |> then(&{operation, &1})
+  end
+
+  defp scan_alternatives(operation, path, guards, choice_name, acc) do
+    operation
+    |> Beaver.Walker.regions()
+    |> Enum.with_index()
+    |> Enum.reduce(acc, fn {region, region_index}, acc ->
+      scan_region(
+        region,
+        path ++ [{:region, region_index}],
+        guards ++ [{choice_name, region_index}],
+        acc
+      )
+    end)
+    |> then(&{operation, &1})
+  end
+
+  defp scan_region(region, path, guards, acc) do
+    region
+    |> Beaver.Walker.blocks()
+    |> Enum.with_index()
+    |> Enum.reduce(acc, fn {block, block_index}, acc ->
+      block
+      |> Beaver.Walker.operations()
+      |> Enum.with_index()
+      |> Enum.reduce(acc, fn {operation, operation_index}, acc ->
+        {_operation, acc} =
+          scan_operation(
+            operation,
+            path ++ [{:block, block_index}, {:operation, operation_index}],
+            guards,
+            acc
+          )
+
+        acc
+      end)
+    end)
+  end
+
+  defp knob_choice(operation, path, guards) do
+    name = required_attribute_value!(operation, "name")
+    options_attribute = required_attribute!(operation, "options")
+    selected_attribute = optional_attribute(operation, "selected")
+
+    if MLIR.Attribute.array?(options_attribute) do
+      option_attributes = Enum.to_list(options_attribute)
+
+      options =
+        option_attributes
+        |> Enum.with_index()
+        |> Enum.map(fn {attribute, index} -> option(attribute, index) end)
+
+      selected = if selected_attribute, do: public_attribute_value(selected_attribute)
+
+      {%Choice{
+         name: name,
+         kind: :knob,
+         options: options,
+         selected: selected,
+         domain: MLIR.to_string(options_attribute),
+         path: path,
+         guards: guards,
+         enumerable?: true
+       }, option_attributes}
+    else
+      {%Choice{
+         name: name,
+         kind: :knob,
+         options: [],
+         selected: selected_attribute && public_attribute_value(selected_attribute),
+         domain: MLIR.to_string(options_attribute),
+         path: path,
+         guards: guards,
+         enumerable?: false
+       }, []}
+    end
+  end
+
+  defp alternatives_choice(operation, path, guards) do
+    name = required_attribute_value!(operation, "name")
+    count = Enum.count(Beaver.Walker.regions(operation))
+    parameter_selected? = not Enum.empty?(Beaver.Walker.operands(operation))
+
+    selected =
+      cond do
+        parameter_selected? ->
+          :parameter
+
+        attribute = optional_attribute(operation, "selected_region_attr") ->
+          MLIR.Attribute.value(attribute)
+
+        true ->
+          nil
+      end
+
+    %Choice{
+      name: name,
+      kind: :alternatives,
+      options:
+        for(index <- 0..(count - 1), do: %Option{index: index, value: index, mlir: "#{index}"}),
+      selected: selected,
+      domain: "regions:#{count}",
+      path: path,
+      guards: guards,
+      enumerable?: not parameter_selected?
+    }
+  end
+
+  defp option(attribute, index) do
+    %Option{
+      index: index,
+      value: public_attribute_value(attribute),
+      mlir: MLIR.to_string(attribute)
+    }
+  end
+
+  defp public_attribute_value(attribute) do
+    value = MLIR.Attribute.value(attribute)
+    if is_nil(value), do: MLIR.to_string(attribute), else: value
+  end
+
+  defp required_attribute!(operation, name) do
+    case optional_attribute(operation, name) do
+      nil -> raise ArgumentError, "#{MLIR.Operation.name(operation)} is missing #{name}"
+      attribute -> attribute
+    end
+  end
+
+  defp required_attribute_value!(operation, name) do
+    operation |> required_attribute!(name) |> MLIR.Attribute.value()
+  end
+
+  defp optional_attribute(operation, name) do
+    case MLIR.Operation.fetch(operation, name) do
+      {:ok, attribute} -> attribute
+      :error -> nil
+    end
+  end
+
+  defp attribute_value(operation, name) do
+    case optional_attribute(operation, name) do
+      nil -> nil
+      attribute -> MLIR.Attribute.value(attribute)
+    end
+  end
+
+  defp duplicate_choice_names(choices) do
+    choices
+    |> Enum.frequencies_by(& &1.name)
+    |> Enum.filter(fn {_name, count} -> count > 1 end)
+    |> Enum.map(&elem(&1, 0))
+    |> Enum.sort()
+  end
+
+  defp enumerate_choices(choices, max_candidates) do
+    Enum.reduce_while(choices, {:ok, [%{}]}, fn choice, {:ok, candidates} ->
+      enumerate_choice(choice, candidates, max_candidates)
+    end)
+  end
+
+  defp enumerate_choice(%Choice{selected: :parameter}, candidates, _max_candidates),
+    do: {:cont, {:ok, candidates}}
+
+  defp enumerate_choice(choice, candidates, max_candidates) do
+    cond do
+      not active_for_any?(choice, candidates) ->
+        {:cont, {:ok, candidates}}
+
+      not choice.enumerable? and is_nil(choice.selected) ->
+        error = invalid_error({:non_enumerable_choice, choice.name, choice.domain})
+        {:halt, {:error, error}}
+
+      true ->
+        expand_choice(choice, candidates, max_candidates)
+    end
+  end
+
+  defp expand_choice(choice, candidates, max_candidates) do
+    values =
+      if is_nil(choice.selected),
+        do: Enum.map(choice.options, & &1.value),
+        else: [choice.selected]
+
+    candidates =
+      Enum.flat_map(candidates, fn candidate ->
+        if active?(choice.guards, candidate) do
+          Enum.map(values, &Map.put(candidate, choice.name, &1))
+        else
+          [candidate]
+        end
+      end)
+
+    if length(candidates) > max_candidates do
+      error = invalid_error({:candidate_limit_exceeded, max_candidates, choice.name})
+      {:halt, {:error, error}}
+    else
+      {:cont, {:ok, candidates}}
+    end
+  end
+
+  defp active_for_any?(choice, candidates), do: Enum.any?(candidates, &active?(choice.guards, &1))
+
+  defp active?(guards, selections) do
+    Enum.all?(guards, fn {name, selected_region} ->
+      Map.get(selections, name) == selected_region
+    end)
+  end
+
+  defp resolve_entries(entries, resolver) do
+    {resolver, state} = resolver_and_state(resolver)
+
+    Enum.reduce_while(entries, {:ok, %{}, state}, fn entry, accumulator ->
+      resolve_entry(entry, accumulator, resolver)
+    end)
+  end
+
+  defp resolve_entry(
+         {%Choice{selected: :parameter}, _operation, _attributes},
+         {:ok, selections, state},
+         _resolver
+       ),
+       do: {:cont, {:ok, selections, state}}
+
+  defp resolve_entry({choice, _operation, _attributes}, {:ok, selections, state}, resolver) do
+    if active?(choice.guards, selections) do
+      resolve_active_choice(choice, selections, resolver, state)
+    else
+      {:cont, {:ok, selections, state}}
+    end
+  end
+
+  defp resolve_active_choice(choice, selections, resolver, state) do
+    case resolve_choice(resolver, choice, state) do
+      {:ok, value, state} ->
+        record_selection(choice, value, selections, state)
+
+      {:unresolved, state} when not is_nil(choice.selected) ->
+        {:cont, {:ok, Map.put(selections, choice.name, choice.selected), state}}
+
+      {:unresolved, _state} ->
+        {:halt, {:error, invalid_error({:unresolved_choice, choice.name})}}
+
+      {:error, reason, _state} ->
+        {:halt, {:error, invalid_error({:resolver_failed, choice.name, reason})}}
+    end
+  rescue
+    exception ->
+      reason = {:resolver_exception, choice.name, Exception.message(exception)}
+      {:halt, {:error, invalid_error(reason)}}
+  catch
+    kind, reason ->
+      reason = {:resolver_failure, choice.name, kind, reason}
+      {:halt, {:error, invalid_error(reason)}}
+  end
+
+  defp record_selection(choice, value, selections, state) do
+    case validate_selection(choice, value) do
+      {:ok, normalized} ->
+        {:cont, {:ok, Map.put(selections, choice.name, normalized), state}}
+
+      {:error, reason} ->
+        {:halt, {:error, invalid_error(reason)}}
+    end
+  end
+
+  defp resolver_and_state({module, state}) when is_atom(module), do: {{:module, module}, state}
+  defp resolver_and_state(module) when is_atom(module), do: {{:module, module}, nil}
+  defp resolver_and_state(resolver), do: {resolver, nil}
+
+  defp resolve_choice(resolver, choice, state) when is_map(resolver) do
+    case map_fetch_choice(resolver, choice.name) do
+      {:ok, value} -> {:ok, value, state}
+      :error -> {:unresolved, state}
+    end
+  end
+
+  defp resolve_choice(resolver, choice, state) when is_function(resolver, 1) do
+    normalize_resolver_result(resolver.(choice), state)
+  end
+
+  defp resolve_choice(resolver, choice, state) when is_function(resolver, 2) do
+    normalize_resolver_result(resolver.(choice, state), state)
+  end
+
+  defp resolve_choice({:module, module}, choice, state) do
+    normalize_resolver_result(module.resolve(choice, state), state)
+  end
+
+  defp normalize_resolver_result({:ok, value, state}, _old_state), do: {:ok, value, state}
+  defp normalize_resolver_result({:ok, value}, state), do: {:ok, value, state}
+  defp normalize_resolver_result({:error, reason, state}, _old_state), do: {:error, reason, state}
+  defp normalize_resolver_result({:error, reason}, state), do: {:error, reason, state}
+  defp normalize_resolver_result({:unresolved, state}, _old_state), do: {:unresolved, state}
+  defp normalize_resolver_result(:unresolved, state), do: {:unresolved, state}
+  defp normalize_resolver_result(value, state), do: {:ok, value, state}
+
+  defp map_fetch_choice(map, name) do
+    case Map.fetch(map, name) do
+      {:ok, value} ->
+        {:ok, value}
+
+      :error ->
+        map_fetch_atom_choice(map, name)
+    end
+  end
+
+  defp map_fetch_atom_choice(map, name) do
+    Enum.find_value(map, :error, fn
+      {key, value} when is_atom(key) -> atom_choice(key, value, name)
+      _entry -> nil
+    end)
+  end
+
+  defp atom_choice(key, value, name) do
+    if Atom.to_string(key) == name, do: {:ok, value}
+  end
+
+  defp validate_selection(%Choice{kind: :alternatives, options: options, name: name}, value) do
+    value = if match?(%Option{}, value), do: value.value, else: value
+
+    if is_integer(value) and Enum.any?(options, &(&1.value == value)) do
+      {:ok, value}
+    else
+      {:error, {:invalid_alternative, name, value}}
+    end
+  end
+
+  defp validate_selection(%Choice{kind: :knob, enumerable?: true} = choice, {:option, index})
+       when is_integer(index) do
+    case Enum.at(choice.options, index) do
+      nil -> {:error, {:invalid_knob_option, choice.name, index}}
+      option -> {:ok, option.value}
+    end
+  end
+
+  defp validate_selection(%Choice{kind: :knob, enumerable?: true} = choice, %Option{} = option) do
+    validate_selection(choice, {:option, option.index})
+  end
+
+  defp validate_selection(%Choice{kind: :knob, enumerable?: true} = choice, value) do
+    case Enum.find(choice.options, fn option -> option.value == value or option.mlir == value end) do
+      nil -> {:error, {:invalid_knob_option, choice.name, value}}
+      option -> {:ok, option.value}
+    end
+  end
+
+  defp validate_selection(%Choice{kind: :knob, enumerable?: false}, value)
+       when is_binary(value),
+       do: {:ok, value}
+
+  defp validate_selection(%Choice{name: name}, value),
+    do: {:error, {:invalid_knob_option, name, value}}
+
+  defp rewrite_entries(entries, selections, context) do
+    Enum.reduce_while(entries, :ok, fn entry, :ok ->
+      rewrite_entry(entry, selections, context)
+    end)
+  end
+
+  defp rewrite_entry({choice, operation, option_attributes}, selections, context) do
+    if active?(choice.guards, selections) and Map.has_key?(selections, choice.name) do
+      value = Map.fetch!(selections, choice.name)
+
+      case selection_attribute(choice, value, option_attributes, context) do
+        {:ok, attribute_name, attribute} ->
+          MLIR.CAPI.mlirOperationSetAttributeByName(
+            operation,
+            MLIR.StringRef.create(attribute_name),
+            attribute
+          )
+
+          {:cont, :ok}
+
+        {:error, reason} ->
+          {:halt, {:error, invalid_error(reason)}}
+      end
+    else
+      {:cont, :ok}
+    end
+  end
+
+  defp selection_attribute(%Choice{kind: :alternatives}, value, _options, context) do
+    {:ok, "selected_region_attr", MLIR.Attribute.integer(MLIR.Type.i64(ctx: context), value)}
+  end
+
+  defp selection_attribute(%Choice{kind: :knob, enumerable?: true} = choice, value, attrs, _ctx) do
+    case Enum.find_index(choice.options, fn option ->
+           option.value == value or option.mlir == value
+         end) do
+      nil -> {:error, {:invalid_knob_option, choice.name, value}}
+      index -> {:ok, "selected", Enum.at(attrs, index)}
+    end
+  end
+
+  defp selection_attribute(%Choice{kind: :knob, enumerable?: false}, value, _attrs, context) do
+    {:ok, "selected", MLIR.Attribute.get(value, ctx: context)}
+  rescue
+    exception in [ArgumentError] ->
+      {:error, {:invalid_attribute, value, Exception.message(exception)}}
+  end
+
+  defp active_constraints(constraints, selections) do
+    Enum.filter(constraints, &active?(&1.guards, selections))
+  end
+
+  defp solve_constraints([], _selections, _solver), do: {:ok, nil}
+  defp solve_constraints(_constraints, _selections, nil), do: {:ok, nil}
+
+  defp solve_constraints(constraints, selections, solver) do
+    {solver, state} = solver_and_state(solver)
+
+    solver
+    |> call_solver(constraints, selections, state)
+    |> normalize_solver_result()
+  rescue
+    exception -> {:error, constraint_error({:solver_exception, Exception.message(exception)})}
+  catch
+    kind, reason -> {:error, constraint_error({:solver_failure, kind, reason})}
+  end
+
+  defp call_solver(fun, constraints, selections, _state) when is_function(fun, 2),
+    do: fun.(constraints, selections)
+
+  defp call_solver(fun, constraints, selections, state) when is_function(fun, 3),
+    do: fun.(constraints, selections, state)
+
+  defp call_solver({:module, module}, constraints, selections, state),
+    do: module.solve(constraints, selections, state)
+
+  defp normalize_solver_result(:ok), do: {:ok, nil}
+  defp normalize_solver_result({:ok, metadata}), do: {:ok, metadata}
+  defp normalize_solver_result({:ok, metadata, _new_state}), do: {:ok, metadata}
+  defp normalize_solver_result({:error, reason}), do: {:error, constraint_error(reason)}
+
+  defp normalize_solver_result({:error, reason, _new_state}),
+    do: {:error, constraint_error(reason)}
+
+  defp normalize_solver_result(other),
+    do: {:error, constraint_error({:invalid_solver_result, other})}
+
+  defp solver_and_state({module, state}) when is_atom(module), do: {{:module, module}, state}
+  defp solver_and_state(module) when is_atom(module), do: {{:module, module}, nil}
+  defp solver_and_state(solver), do: {solver, nil}
+
+  defp operations(module) do
+    {_module, operations} =
+      Beaver.Walker.prewalk(module, [], fn
+        %MLIR.Operation{} = operation, acc -> {operation, [operation | acc]}
+        entity, acc -> {entity, acc}
+      end)
+
+    Enum.reverse(operations)
+  end
+
+  defp invalid_error(reason, diagnostics \\ []) do
+    %Transform.Error{
+      kind: :invalid_schedule,
+      reason: reason,
+      diagnostics: MLIR.Diagnostic.process(diagnostics)
+    }
+  end
+
+  defp constraint_error(reason) do
+    %Transform.Error{kind: :constraint_failure, reason: reason}
+  end
+
+  defp digest(bytes) do
+    :crypto.hash(:sha256, bytes) |> Base.encode16(case: :lower)
+  end
+end

--- a/lib/beaver/mlir/transform/solver.ex
+++ b/lib/beaver/mlir/transform/solver.ex
@@ -1,0 +1,16 @@
+defmodule Beaver.MLIR.Transform.Solver do
+  @moduledoc """
+  Optional adapter for inspecting or validating `transform.smt.constrain_params`.
+
+  Beaver deliberately does not choose an SMT implementation. An adapter gets
+  the exported constraint IR and the already resolved Tune selections. It may
+  return deterministic metadata for recording alongside the resolved schedule.
+  The adapter does not need to mutate MLIR objects.
+  """
+
+  alias Beaver.MLIR.Transform.Schedule.Constraint
+
+  @callback solve([Constraint.t()], selections :: map(), state :: term()) ::
+              {:ok, metadata :: term(), new_state :: term()}
+              | {:error, reason :: term(), new_state :: term()}
+end

--- a/lib/beaver/mlir/transform/tuner.ex
+++ b/lib/beaver/mlir/transform/tuner.ex
@@ -1,0 +1,499 @@
+defmodule Beaver.MLIR.Transform.Tuner do
+  @moduledoc """
+  Bounded, deterministic BEAM evaluation of resolved Transform schedules.
+
+  Candidate order is the order returned by `Schedule.enumerate/2`, independent
+  of task completion order. Timeouts kill the individual task. Cancellation is
+  shared through an explicit token and can also be observed by cooperative
+  evaluator callbacks.
+
+  Searches emit `[:beaver, :mlir, :compilation, :autotuning, :start | :stop]`
+  and each candidate emits the corresponding
+  `[:beaver, :mlir, :compilation, :autotuning, :candidate, :start | :stop]`
+  events. Candidate metadata can be passed to `Beaver.MLIR.ActionTracing` to
+  correlate lower-level MLIR actions with the schedule that caused them.
+  """
+
+  alias Beaver.MLIR
+  alias MLIR.Transform
+  alias Transform.Schedule
+
+  defmodule Evaluator do
+    @moduledoc "Optional behaviour for schedule benchmark/evaluation adapters."
+
+    @callback evaluate(Schedule.Resolved.t(), context :: map(), state :: term()) ::
+                term()
+  end
+
+  defmodule Cancellation do
+    @moduledoc "An explicit, process-independent cancellation token."
+    @enforce_keys [:state]
+    defstruct [:state]
+
+    @type t() :: %__MODULE__{state: reference()}
+
+    @spec new() :: t()
+    def new do
+      state = :atomics.new(1, signed: false)
+      %__MODULE__{state: state}
+    end
+
+    @spec cancel(t()) :: :ok
+    def cancel(%__MODULE__{state: state}) do
+      :ok = :atomics.put(state, 1, 1)
+    end
+
+    @spec cancelled?(t()) :: boolean()
+    def cancelled?(%__MODULE__{state: state}), do: :atomics.get(state, 1) == 1
+  end
+
+  defmodule Candidate do
+    @moduledoc "A deterministic candidate evaluation record."
+    @enforce_keys [:index, :choices, :status, :duration]
+    defstruct [:index, :choices, :status, :schedule, :value, :metadata, :reason, :duration]
+
+    @type status() ::
+            :ok
+            | :evaluation_failure
+            | :invalid_schedule
+            | :constraint_failure
+            | :timeout
+            | :cancelled
+
+    @type t() :: %__MODULE__{
+            index: non_neg_integer(),
+            choices: map(),
+            status: status(),
+            schedule: Schedule.Resolved.t() | nil,
+            value: term(),
+            metadata: term(),
+            reason: term(),
+            duration: integer()
+          }
+  end
+
+  defmodule Result do
+    @moduledoc "Ordered records and runtime configuration from one tuning search."
+    @enforce_keys [:candidates, :cancellation, :max_concurrency, :timeout]
+    defstruct [:candidates, :cancellation, :max_concurrency, :timeout]
+
+    @type t() :: %__MODULE__{
+            candidates: [Candidate.t()],
+            cancellation: Cancellation.t(),
+            max_concurrency: pos_integer(),
+            timeout: non_neg_integer() | :infinity
+          }
+  end
+
+  @type evaluator() :: function() | module() | {module(), term()}
+
+  @doc """
+  Resolves and evaluates every candidate with bounded concurrency.
+
+  An evaluator may return a bare value, `{:ok, value}`,
+  `{:ok, value, metadata}`, or `{:error, reason}`. Beaver records these values
+  without imposing a scoring or winner-selection policy.
+  """
+  @spec search(Schedule.input(), evaluator(), keyword()) ::
+          {:ok, Result.t()} | {:error, Transform.Error.t()}
+  def search(schedule, evaluator, opts \\ []) do
+    with :ok <- validate_options(opts),
+         {:ok, {snapshot, sequence}} <- Schedule.snapshot(schedule, opts),
+         {:ok, choices} <- candidate_choices({:bytecode, snapshot}, sequence, opts) do
+      max_concurrency = Keyword.get(opts, :max_concurrency, System.schedulers_online())
+      timeout = Keyword.get(opts, :timeout, 60_000)
+      cancellation = Keyword.get(opts, :cancellation, Cancellation.new())
+
+      runtime = %{
+        evaluator: evaluator_and_state(evaluator),
+        cancellation: cancellation,
+        solver: Keyword.get(opts, :solver),
+        telemetry_opts: opts
+      }
+
+      started = System.monotonic_time()
+
+      search_metadata = %{
+        sequence: sequence,
+        candidate_count: length(choices),
+        max_concurrency: max_concurrency,
+        timeout: timeout
+      }
+
+      MLIR.Telemetry.emit([:autotuning, :start], %{}, search_metadata, opts)
+
+      records =
+        evaluate_candidates(
+          choices,
+          snapshot,
+          sequence,
+          runtime,
+          max_concurrency,
+          timeout
+        )
+
+      result = %Result{
+        candidates: records,
+        cancellation: cancellation,
+        max_concurrency: max_concurrency,
+        timeout: timeout
+      }
+
+      MLIR.Telemetry.emit(
+        [:autotuning, :stop],
+        %{duration: System.monotonic_time() - started, candidate_count: length(records)},
+        Map.put(search_metadata, :status_counts, Enum.frequencies_by(records, & &1.status)),
+        opts
+      )
+
+      {:ok, result}
+    end
+  end
+
+  defp evaluate_candidates(
+         choices,
+         snapshot,
+         sequence,
+         runtime,
+         max_concurrency,
+         timeout
+       ) do
+    indexed = Enum.with_index(choices, fn choices, index -> {index, choices} end)
+
+    indexed
+    |> Task.async_stream(
+      &evaluate_candidate(&1, snapshot, sequence, runtime),
+      max_concurrency: max_concurrency,
+      ordered: true,
+      timeout: timeout,
+      on_timeout: :kill_task
+    )
+    |> Enum.zip(indexed)
+    |> Enum.map(&candidate_record(&1, sequence, timeout, runtime.telemetry_opts))
+  end
+
+  defp candidate_record(
+         {{:ok, %Candidate{} = candidate}, _indexed},
+         _sequence,
+         _timeout,
+         _telemetry_opts
+       ),
+       do: candidate
+
+  defp candidate_record(
+         {{:exit, reason}, {index, choices}},
+         sequence,
+         timeout,
+         telemetry_opts
+       ) do
+    status = if timeout_exit?(reason), do: :timeout, else: :evaluation_failure
+
+    candidate = %Candidate{
+      index: index,
+      choices: choices,
+      status: status,
+      reason: if(status == :timeout, do: :timeout, else: reason),
+      duration: timeout_duration(timeout)
+    }
+
+    emit_candidate_stop(candidate, sequence, telemetry_opts)
+    candidate
+  end
+
+  @doc "Bang variant of `search/3`."
+  @spec search!(Schedule.input(), evaluator(), keyword()) :: Result.t()
+  def search!(schedule, evaluator, opts \\ []) do
+    case search(schedule, evaluator, opts) do
+      {:ok, result} -> result
+      {:error, error} -> raise error
+    end
+  end
+
+  @doc "Passes successful records to an application-defined selection function."
+  @spec select(Result.t(), ([Candidate.t()] -> term())) :: term()
+  def select(%Result{candidates: candidates}, selector) when is_function(selector, 1) do
+    candidates
+    |> Enum.filter(&(&1.status == :ok))
+    |> selector.()
+  end
+
+  defp candidate_choices(schedule, sequence, opts) do
+    case Keyword.fetch(opts, :candidates) do
+      {:ok, candidates} when is_list(candidates) ->
+        if Enum.all?(candidates, &is_map/1) do
+          {:ok, candidates}
+        else
+          {:error,
+           %Transform.Error{
+             kind: :invalid_schedule,
+             reason: {:invalid_candidates, candidates}
+           }}
+        end
+
+      {:ok, candidates} ->
+        {:error,
+         %Transform.Error{
+           kind: :invalid_schedule,
+           reason: {:invalid_candidates, candidates}
+         }}
+
+      :error ->
+        Schedule.enumerate(schedule,
+          sequence: sequence,
+          max_candidates: Keyword.get(opts, :max_candidates, 10_000)
+        )
+    end
+  end
+
+  defp evaluate_candidate(
+         {index, choices},
+         snapshot,
+         sequence,
+         runtime
+       ) do
+    started = System.monotonic_time()
+
+    MLIR.Telemetry.emit(
+      [:autotuning, :candidate, :start],
+      %{},
+      candidate_metadata(index, choices, sequence),
+      runtime.telemetry_opts
+    )
+
+    candidate =
+      try do
+        if Cancellation.cancelled?(runtime.cancellation) do
+          candidate(index, choices, :cancelled, started, reason: :cancelled)
+        else
+          resolve_and_evaluate(index, choices, snapshot, sequence, runtime, started)
+        end
+      rescue
+        exception ->
+          candidate(index, choices, :evaluation_failure, started,
+            reason: Exception.format(:error, exception, __STACKTRACE__)
+          )
+      catch
+        kind, reason ->
+          candidate(index, choices, :evaluation_failure, started,
+            reason: Exception.format(kind, reason, __STACKTRACE__)
+          )
+      end
+
+    emit_candidate_stop(candidate, sequence, runtime.telemetry_opts)
+    candidate
+  end
+
+  defp resolve_and_evaluate(
+         index,
+         choices,
+         snapshot,
+         sequence,
+         runtime,
+         started
+       ) do
+    case Schedule.resolve({:bytecode, snapshot}, choices,
+           sequence: sequence,
+           solver: runtime.solver
+         ) do
+      {:ok, resolved} ->
+        continue_evaluation(index, choices, resolved, sequence, runtime, started)
+
+      {:error, %Transform.Error{} = error} ->
+        candidate(index, choices, error_status(error), started, reason: error)
+    end
+  end
+
+  defp continue_evaluation(
+         index,
+         choices,
+         resolved,
+         sequence,
+         runtime,
+         started
+       ) do
+    if Cancellation.cancelled?(runtime.cancellation) do
+      candidate(index, choices, :cancelled, started,
+        schedule: resolved,
+        reason: :cancelled
+      )
+    else
+      evaluate_resolved(index, choices, resolved, sequence, runtime, started)
+    end
+  end
+
+  defp evaluate_resolved(
+         index,
+         choices,
+         resolved,
+         sequence,
+         runtime,
+         started
+       ) do
+    context = %{
+      index: index,
+      choices: choices,
+      cancellation: runtime.cancellation,
+      cancelled?: fn -> Cancellation.cancelled?(runtime.cancellation) end,
+      telemetry: Keyword.get(runtime.telemetry_opts, :telemetry),
+      telemetry_metadata:
+        candidate_metadata(index, choices, sequence)
+        |> Map.put(:transform_schedule_digest, resolved.digest)
+    }
+
+    case call_evaluator(runtime.evaluator, resolved, context) do
+      {:ok, value, metadata} ->
+        candidate(index, choices, :ok, started,
+          schedule: resolved,
+          value: value,
+          metadata: metadata
+        )
+
+      {:error, reason} ->
+        candidate(index, choices, :evaluation_failure, started,
+          schedule: resolved,
+          reason: reason
+        )
+    end
+  end
+
+  defp evaluator_and_state({module, state}) when is_atom(module), do: {{:module, module}, state}
+  defp evaluator_and_state(module) when is_atom(module), do: {{:module, module}, nil}
+  defp evaluator_and_state(evaluator), do: {evaluator, nil}
+
+  defp call_evaluator({evaluator, state}, resolved, _context) when is_function(evaluator, 1) do
+    normalize_evaluation(evaluator.(resolved), state)
+  end
+
+  defp call_evaluator({evaluator, state}, resolved, context) when is_function(evaluator, 2) do
+    normalize_evaluation(evaluator.(resolved, context), state)
+  end
+
+  defp call_evaluator({{:module, module}, state}, resolved, context) do
+    normalize_evaluation(module.evaluate(resolved, context, state), state)
+  end
+
+  defp normalize_evaluation({:ok, value, metadata}, _state), do: {:ok, value, metadata}
+  defp normalize_evaluation({:ok, value}, state), do: {:ok, value, state}
+  defp normalize_evaluation({:error, reason}, _state), do: {:error, reason}
+  defp normalize_evaluation(value, state), do: {:ok, value, state}
+
+  defp candidate(index, choices, status, started, fields) do
+    struct!(
+      Candidate,
+      Keyword.merge(
+        [
+          index: index,
+          choices: choices,
+          status: status,
+          duration: System.monotonic_time() - started
+        ],
+        fields
+      )
+    )
+  end
+
+  defp error_status(%Transform.Error{kind: :constraint_failure}), do: :constraint_failure
+  defp error_status(%Transform.Error{}), do: :invalid_schedule
+
+  defp timeout_exit?(:timeout), do: true
+  defp timeout_exit?({:timeout, _}), do: true
+  defp timeout_exit?(_reason), do: false
+
+  defp timeout_duration(:infinity), do: 0
+  defp timeout_duration(timeout), do: System.convert_time_unit(timeout, :millisecond, :native)
+
+  defp candidate_metadata(index, choices, sequence) do
+    %{candidate_index: index, choices: choices, sequence: sequence}
+  end
+
+  defp emit_candidate_stop(candidate, sequence, telemetry_opts) do
+    metadata =
+      candidate_metadata(candidate.index, candidate.choices, sequence)
+      |> Map.put(:status, candidate.status)
+      |> maybe_put_schedule_digest(candidate.schedule)
+
+    MLIR.Telemetry.emit(
+      [:autotuning, :candidate, :stop],
+      %{duration: candidate.duration},
+      metadata,
+      telemetry_opts
+    )
+  end
+
+  defp maybe_put_schedule_digest(metadata, %Schedule.Resolved{digest: digest}),
+    do: Map.put(metadata, :transform_schedule_digest, digest)
+
+  defp maybe_put_schedule_digest(metadata, _schedule), do: metadata
+
+  defp validate_options(opts) do
+    if Keyword.keyword?(opts) do
+      with :ok <- validate_supported_options(opts),
+           :ok <- validate_max_concurrency(opts),
+           :ok <- validate_timeout(opts),
+           :ok <- validate_cancellation(opts) do
+        validate_telemetry(opts)
+      end
+    else
+      invalid_options("tuner options must be a keyword list")
+    end
+  end
+
+  defp validate_supported_options(opts) do
+    supported = [
+      :sequence,
+      :ctx,
+      :candidates,
+      :max_candidates,
+      :max_concurrency,
+      :timeout,
+      :cancellation,
+      :solver,
+      :telemetry
+    ]
+
+    case Keyword.keys(opts) -- supported do
+      [] -> :ok
+      unsupported -> invalid_options("unsupported tuner options: #{inspect(unsupported)}")
+    end
+  end
+
+  defp validate_max_concurrency(opts) do
+    case Keyword.get(opts, :max_concurrency, System.schedulers_online()) do
+      value when is_integer(value) and value > 0 -> :ok
+      _value -> invalid_options(":max_concurrency must be a positive integer")
+    end
+  end
+
+  defp validate_timeout(opts) do
+    case Keyword.get(opts, :timeout, 60_000) do
+      :infinity -> :ok
+      value when is_integer(value) and value >= 0 -> :ok
+      _value -> invalid_options(":timeout must be a non-negative integer or :infinity")
+    end
+  end
+
+  defp validate_cancellation(opts) do
+    case Keyword.get(opts, :cancellation) do
+      nil ->
+        :ok
+
+      %Cancellation{} ->
+        :ok
+
+      value ->
+        invalid_options(":cancellation must be a Cancellation token, got: #{inspect(value)}")
+    end
+  end
+
+  defp validate_telemetry(opts) do
+    case Keyword.get(opts, :telemetry) do
+      nil -> :ok
+      callback when is_function(callback, 3) -> :ok
+      _value -> invalid_options(":telemetry must be a three-argument function")
+    end
+  end
+
+  defp invalid_options(reason) do
+    {:error, %Transform.Error{kind: :invalid_schedule, reason: reason}}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -56,6 +56,7 @@ defmodule Beaver.MixProject do
       extras: [
         "guides/your-first-beaver-compiler.livemd",
         "guides/incremental-compilation-runtime.md",
+        "guides/transform-autotuning.md",
         "guides/slang.md",
         "guides/dialect-conversion.md",
         "guides/action-tracing.md",

--- a/native/include/mlir-c/Beaver/CAPIPolicy.h
+++ b/native/include/mlir-c/Beaver/CAPIPolicy.h
@@ -10,6 +10,7 @@ typedef enum {
   BeaverCapiPolicyDiagnostics__mlirTypeParseGet,
   BeaverCapiPolicyDiagnostics__mlirModuleCreateParse,
   BeaverCapiPolicyDiagnostics__mlirExecutionEngineCreate,
+  BeaverCapiPolicyDiagnostics__mlirTransformApplyNamedSequence,
 
   BeaverCapiPolicyDirtyCPUAndIO__mlirExecutionEngineInvokePacked,
 

--- a/test/capi_manifest_test.exs
+++ b/test/capi_manifest_test.exs
@@ -73,6 +73,12 @@ defmodule Beaver.MLIR.CAPI.ManifestTest do
 
     assert %{params: [:context | _], dirty: :dirty_cpu} =
              Enum.find(declarations, &(&1.wrapper_name == :mlirOperationVerifyWithDiagnostics))
+
+    assert %{params: [:context | _], dirty: :dirty_cpu} =
+             Enum.find(
+               declarations,
+               &(&1.wrapper_name == :mlirTransformApplyNamedSequenceWithDiagnostics)
+             )
   end
 
   test "callback-heavy declarations remain in the callback bridge manifest" do

--- a/test/transform_schedule_test.exs
+++ b/test/transform_schedule_test.exs
@@ -1,0 +1,379 @@
+defmodule Beaver.MLIR.Transform.ScheduleTest do
+  use ExUnit.Case, async: true
+
+  alias Beaver.MLIR
+  alias MLIR.Transform.{Schedule, Tuner}
+
+  @payload """
+  module {
+    func.func @fold_me() -> i32 {
+      %zero = arith.constant 0 : i32
+      %one = arith.constant 1 : i32
+      %sum = arith.addi %one, %zero : i32
+      return %sum : i32
+    }
+  }
+  """
+
+  @canonicalize_schedule """
+  module attributes {transform.with_named_sequence} {
+    transform.named_sequence @__transform_main(%root: !transform.any_op) {
+      transform.apply_patterns to %root {
+        transform.apply_patterns.canonicalization
+      } : !transform.any_op
+      transform.yield
+    }
+  }
+  """
+
+  @tune_schedule """
+  module attributes {transform.with_named_sequence} {
+    transform.named_sequence @__transform_main(%root: !transform.any_op) {
+      %tile = transform.tune.knob<"tile"> options = [8, 16] -> !transform.any_param
+      transform.tune.alternatives<"vectorize"> {
+        transform.yield
+      }, {
+        transform.yield
+      }
+      transform.yield
+    }
+  }
+  """
+
+  @conditional_schedule """
+  module attributes {transform.with_named_sequence} {
+    transform.named_sequence @__transform_main(%root: !transform.any_op) {
+      transform.tune.alternatives<"route"> {
+        %fast = transform.tune.knob<"fast_tile"> options = [8, 16] -> !transform.any_param
+        transform.yield
+      }, {
+        %slow = transform.tune.knob<"slow_tile"> options = [32, 64] -> !transform.any_param
+        transform.yield
+      }
+      transform.yield
+    }
+  }
+  """
+
+  @constraint_schedule """
+  module attributes {transform.with_named_sequence} {
+    transform.named_sequence @__transform_main(%root: !transform.any_op) {
+      %tile = transform.param.constant 42 -> !transform.param<i64>
+      transform.smt.constrain_params(%tile) : (!transform.param<i64>) -> () {
+        ^bb0(%symbol: !smt.int):
+        %zero = smt.int.constant 0
+        %in_range = smt.int.cmp le %zero, %symbol
+        smt.assert %in_range
+      }
+      transform.yield
+    }
+  }
+  """
+
+  setup do
+    context = MLIR.Context.create()
+    on_exit(fn -> MLIR.Context.destroy(context) end)
+    %{ctx: context}
+  end
+
+  test "named sequence execution accepts operation, module, text, and bytecode", %{ctx: ctx} do
+    schedule_module = MLIR.Module.create!(@canonicalize_schedule, ctx: ctx)
+    {:ok, sequence_operation} = Schedule.find_sequence(schedule_module, "__transform_main")
+    bytecode = MLIR.Bytecode.write!(schedule_module)
+
+    try do
+      for schedule <- [@canonicalize_schedule, bytecode, schedule_module, sequence_operation] do
+        payload = MLIR.Module.create!(@payload, ctx: ctx)
+
+        try do
+          assert {:ok, %MLIR.Transform.Result{diagnostics: []}} =
+                   MLIR.Transform.apply_named_sequence(payload, schedule,
+                     expensive_checks: false,
+                     enforce_single_top_level_transform_op: false
+                   )
+
+          rendered = MLIR.to_string(payload)
+          refute rendered =~ "arith.addi"
+          refute rendered =~ "arith.constant 0"
+        after
+          MLIR.Module.destroy(payload)
+        end
+      end
+    after
+      MLIR.Module.destroy(schedule_module)
+    end
+  end
+
+  test "transform handle and parameter type helpers are context-aware", %{ctx: ctx} do
+    assert MLIR.to_string(MLIR.Transform.any_op_type(ctx: ctx)) == "!transform.any_op"
+    assert MLIR.to_string(MLIR.Transform.any_value_type(ctx: ctx)) == "!transform.any_value"
+    assert MLIR.to_string(MLIR.Transform.any_param_type(ctx: ctx)) == "!transform.any_param"
+
+    assert MLIR.to_string(MLIR.Transform.operation_type("func.func", ctx: ctx)) ==
+             "!transform.op<\"func.func\">"
+
+    assert MLIR.to_string(MLIR.Transform.param_type(MLIR.Type.i64(ctx: ctx))) ==
+             "!transform.param<i64>"
+  end
+
+  test "execution errors keep portable diagnostics and distinct failure classes", %{ctx: ctx} do
+    payload = MLIR.Module.create!(@payload, ctx: ctx)
+
+    try do
+      assert {:error, %MLIR.Transform.Error{kind: :invalid_schedule}} =
+               MLIR.Transform.execute(payload, "not mlir")
+
+      silenceable = """
+      module attributes {transform.with_named_sequence} {
+        transform.named_sequence @__transform_main(%root: !transform.any_op) {
+          %func = transform.cast %root : !transform.any_op to !transform.op<"func.func">
+          transform.yield
+        }
+      }
+      """
+
+      assert {:error,
+              %MLIR.Transform.Error{
+                kind: :silenceable_failure,
+                diagnostics: [{:error, location, _, _}]
+              }} = MLIR.Transform.execute(payload, silenceable)
+
+      assert is_binary(location)
+
+      assert {:error, %MLIR.Transform.Error{kind: :definite_failure}} =
+               MLIR.Transform.execute(payload, @tune_schedule)
+    after
+      MLIR.Module.destroy(payload)
+    end
+  end
+
+  test "Tune choices enumerate conditionally and resolve to replayable IR", %{ctx: ctx} do
+    assert {:ok, analysis} = Schedule.analyze(@conditional_schedule)
+    assert Enum.map(analysis.choices, & &1.name) == ["route", "fast_tile", "slow_tile"]
+
+    assert {:ok,
+            [
+              %{"route" => 0, "fast_tile" => 8},
+              %{"route" => 0, "fast_tile" => 16},
+              %{"route" => 1, "slow_tile" => 32},
+              %{"route" => 1, "slow_tile" => 64}
+            ]} = Schedule.enumerate(@conditional_schedule)
+
+    resolved =
+      Schedule.resolve!(@conditional_schedule, %{"route" => 1, "slow_tile" => 64})
+
+    assert resolved.choices == %{"route" => 1, "slow_tile" => 64}
+    assert resolved.text =~ ~s(selected_region = 1)
+    assert resolved.text =~ ~s(transform.tune.knob<"slow_tile"> = 64)
+    assert String.starts_with?(Schedule.serialize(resolved, :bytecode), "ML\xEFR")
+
+    replay = Schedule.resolve!(@conditional_schedule, %{"route" => 1, "slow_tile" => 64})
+    assert Schedule.cache_identity(resolved) == Schedule.cache_identity(replay)
+
+    payload = MLIR.Module.create!(@payload, ctx: ctx)
+
+    try do
+      assert {:ok, %MLIR.Transform.Result{}} = MLIR.Transform.execute(payload, resolved)
+
+      assert {:ok, %MLIR.Transform.Result{}} =
+               MLIR.Transform.execute(payload, Schedule.serialize(resolved, :bytecode))
+    after
+      MLIR.Module.destroy(payload)
+    end
+  end
+
+  test "knob values preserve common Elixir scalar types" do
+    schedule = """
+    module attributes {transform.with_named_sequence} {
+      transform.named_sequence @__transform_main(%root: !transform.any_op) {
+        %coin = transform.tune.knob<"coin"> options = [true, false] -> !transform.any_param
+        %animal = transform.tune.knob<"animal"> options = ["cat", unit] -> !transform.any_param
+        transform.yield
+      }
+    }
+    """
+
+    assert {:ok, candidates} = Schedule.enumerate(schedule)
+
+    assert candidates == [
+             %{"animal" => "cat", "coin" => true},
+             %{"animal" => :unit, "coin" => true},
+             %{"animal" => "cat", "coin" => false},
+             %{"animal" => :unit, "coin" => false}
+           ]
+  end
+
+  test "SMT constraints remain inspectable and accept an optional solver adapter" do
+    assert {:ok, [constraint]} = Schedule.constraints(@constraint_schedule)
+    assert constraint.ir =~ ~s("transform.smt.constrain_params")
+    assert constraint.operands == 1
+    assert constraint.results == 0
+
+    solver = fn constraints, selections ->
+      assert length(constraints) == 1
+      assert selections == %{}
+      {:ok, %{solver: :test, satisfiable: true}}
+    end
+
+    assert {:ok, resolved} = Schedule.resolve(@constraint_schedule, %{}, solver: solver)
+    assert resolved.constraints == [constraint]
+    assert resolved.solver_metadata == %{solver: :test, satisfiable: true}
+
+    assert {:error, %MLIR.Transform.Error{kind: :constraint_failure}} =
+             Schedule.resolve(@constraint_schedule, %{},
+               solver: fn _, _ -> {:error, :unsatisfiable} end
+             )
+  end
+
+  test "candidate evaluation is bounded, deterministic, cancellable, and timed out" do
+    evaluator = fn resolved ->
+      tile = resolved.choices["tile"]
+      Process.sleep(if(tile == 8, do: 15, else: 1))
+      {:ok, tile * 2, %{tile: tile}}
+    end
+
+    assert {:ok, result} =
+             Tuner.search(@tune_schedule, evaluator, max_concurrency: 2, timeout: 1_000)
+
+    assert result.max_concurrency == 2
+
+    assert Enum.map(result.candidates, & &1.choices) == [
+             %{"tile" => 8, "vectorize" => 0},
+             %{"tile" => 8, "vectorize" => 1},
+             %{"tile" => 16, "vectorize" => 0},
+             %{"tile" => 16, "vectorize" => 1}
+           ]
+
+    assert Enum.all?(result.candidates, &(&1.status == :ok))
+
+    assert %Tuner.Candidate{value: 32} =
+             Tuner.select(result, &Enum.max_by(&1, fn candidate -> candidate.value end))
+
+    assert {:ok, failed} =
+             Tuner.search(@tune_schedule, fn _ -> {:error, :benchmark_failed} end,
+               candidates: [%{"tile" => 8, "vectorize" => 0}]
+             )
+
+    assert [%Tuner.Candidate{status: :evaluation_failure, reason: :benchmark_failed}] =
+             failed.candidates
+
+    assert {:ok, timed_out} =
+             Tuner.search(@tune_schedule, fn _ -> Process.sleep(50) end,
+               max_concurrency: 2,
+               timeout: 1
+             )
+
+    assert Enum.all?(timed_out.candidates, &(&1.status == :timeout))
+
+    cancellation = Tuner.Cancellation.new()
+    :ok = Tuner.Cancellation.cancel(cancellation)
+
+    assert {:ok, cancelled} =
+             Tuner.search(@tune_schedule, fn _ -> flunk("must not run") end,
+               cancellation: cancellation
+             )
+
+    assert Enum.all?(cancelled.candidates, &(&1.status == :cancelled))
+  end
+
+  test "autotuning telemetry correlates a candidate with MLIR action tracing", %{ctx: ctx} do
+    parent = self()
+
+    telemetry = fn event, measurements, metadata ->
+      send(parent, {:autotuning_telemetry, event, measurements, metadata})
+    end
+
+    choices = %{"tile" => 8, "vectorize" => 0}
+
+    evaluator = fn _resolved, candidate_context ->
+      session =
+        MLIR.ActionTracing.attach(ctx,
+          telemetry: telemetry,
+          metadata: candidate_context.telemetry_metadata
+        )
+
+      module = MLIR.Module.create!("module {}", ctx: ctx)
+
+      try do
+        module |> Beaver.Composer.append("canonicalize") |> Beaver.Composer.run!()
+        assert MLIR.ActionTracing.drain(session) != []
+        {:ok, candidate_context.index}
+      after
+        MLIR.ActionTracing.detach(session)
+        MLIR.Module.destroy(module)
+      end
+    end
+
+    assert {:ok, result} =
+             Tuner.search(@tune_schedule, evaluator,
+               candidates: [choices],
+               max_concurrency: 1,
+               telemetry: telemetry
+             )
+
+    assert [%Tuner.Candidate{status: :ok, schedule: %{digest: digest}}] = result.candidates
+
+    assert_receive {:autotuning_telemetry, [:beaver, :mlir, :compilation, :autotuning, :start],
+                    %{}, %{candidate_count: 1}}
+
+    assert_receive {:autotuning_telemetry,
+                    [:beaver, :mlir, :compilation, :autotuning, :candidate, :start], %{},
+                    %{candidate_index: 0, choices: ^choices}}
+
+    assert_receive {:autotuning_telemetry, [:beaver, :mlir, :compilation, :action, :stop],
+                    %{duration: action_duration},
+                    %{candidate_index: 0, choices: ^choices, transform_schedule_digest: ^digest}}
+
+    assert is_integer(action_duration) and action_duration >= 0
+
+    assert_receive {:autotuning_telemetry,
+                    [:beaver, :mlir, :compilation, :autotuning, :candidate, :stop],
+                    %{duration: candidate_duration},
+                    %{candidate_index: 0, status: :ok, transform_schedule_digest: ^digest}}
+
+    assert is_integer(candidate_duration) and candidate_duration >= 0
+
+    assert_receive {:autotuning_telemetry, [:beaver, :mlir, :compilation, :autotuning, :stop],
+                    %{candidate_count: 1}, %{status_counts: %{ok: 1}}}
+  end
+
+  test "resolved schedules participate in incremental compilation cache identity" do
+    cache = start_supervised!({MLIR.CompilationCache.Memory, []})
+    cache = {:memory, cache}
+    resolved = Schedule.resolve!(@canonicalize_schedule, %{})
+
+    first =
+      MLIR.CompilationRuntime.compile!(@payload,
+        cache: cache,
+        transform_schedule: resolved
+      )
+
+    second =
+      MLIR.CompilationRuntime.compile!(@payload,
+        cache: cache,
+        transform_schedule: resolved
+      )
+
+    assert first.cache == :miss
+    assert second.cache == :hit
+    assert first.metadata.transform_schedule == Schedule.cache_identity(resolved)
+    assert first.metadata.transform_options == %{}
+
+    changed =
+      MLIR.CompilationRuntime.compile!(@payload,
+        cache: cache,
+        transform_schedule: resolved,
+        transform_options: [expensive_checks: false]
+      )
+
+    assert changed.cache == :miss
+
+    assert_raise ArgumentError, ":transform_options must be a keyword list", fn ->
+      MLIR.CompilationRuntime.compile!(@payload,
+        cache: cache,
+        transform_schedule: resolved,
+        transform_options: %{expensive_checks: false}
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- execute named Transform dialect sequences against MLIR payloads with configurable verification and structured diagnostics
- analyze, enumerate, resolve, serialize, and replay Tune dialect schedules and inspect SMT constraints
- add deterministic bounded-concurrency autotuning with cancellation, timeout handling, and compilation cache integration
- emit search/candidate telemetry and propagate candidate metadata into MLIR Action Tracing, correlating pass and rewrite actions with the selected schedule
- document tiling/vectorization and telemetry-driven autotuning workflows with async test coverage

Closes #464
Builds on the Action Tracing support merged in #481.

## Validation

- `mix test --warnings-as-errors --exclude vulkan --exclude todo`
  - 238 passed, 8 excluded
- targeted Transform + Action Tracing integration tests
  - 16 passed
- `mix credo`
- `mix format --check-formatted`
- `zig fmt --check native build.zig`
- `git diff --check`