### PR TITLE
Refactor prebuilt LLVM installer into a standalone Mix task

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -102,7 +102,8 @@ jobs:
           LLVM_EUDSL_ASSET_NAME: ${{ inputs.llvm_prebuilt_asset_name }}
           LLVM_EUDSL_ASSET_REVISION: ${{ inputs.llvm_prebuilt_asset_revision }}
         run: |
-          bash scripts/install-prebuilt-llvm.sh "$RUNNER_TEMP/llvm-prebuilt"
+          cd scripts/install_llvm
+          mix beaver.install_prebuilt_llvm --install-dir "$RUNNER_TEMP/llvm-prebuilt"
       - name: Build native library
         env:
           MIX_ENV: test
@@ -129,6 +130,11 @@ jobs:
           MIX_ENV: test
         run: |
           mix format --check-formatted
+      - name: Test LLVM installer task
+        if: matrix.elixir == '1.20.3'
+        run: |
+          cd scripts/install_llvm
+          mix test
       - name: Run tests
         run: |
           if [[ "${{ matrix.elixir }}" == "1.20.3" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,8 +204,9 @@ jobs:
           LLVM_EUDSL_ASSET_OS: manylinux
           LLVM_EUDSL_RESOLVE_ONLY: 1
         run: |
+          set -o pipefail
           cd scripts/install_llvm
-          mix beaver.install_prebuilt_llvm >> "$GITHUB_OUTPUT"
+          mix beaver.install_prebuilt_llvm | grep -E '^LLVM_PREBUILT_(ASSET_NAME|URL)=' >> "$GITHUB_OUTPUT"
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          bash scripts/install-prebuilt-llvm.sh "$RUNNER_TEMP/llvm-prebuilt"
+          cd scripts/install_llvm
+          mix beaver.install_prebuilt_llvm --install-dir "$RUNNER_TEMP/llvm-prebuilt"
       - name: Production build
         env:
           MIX_ENV: prod
@@ -189,6 +190,11 @@ jobs:
         name: Check out workflow source
         with:
           path: workflow-source
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.20.3"
+          otp-version: "27.3"
       - name: Resolve prebuilt LLVM asset
         id: llvm
         working-directory: workflow-source
@@ -197,7 +203,9 @@ jobs:
           LLVM_EUDSL_ASSET_ARCH: ${{ matrix.image.llvm_arch }}
           LLVM_EUDSL_ASSET_OS: manylinux
           LLVM_EUDSL_RESOLVE_ONLY: 1
-        run: bash scripts/install-prebuilt-llvm.sh >> "$GITHUB_OUTPUT"
+        run: |
+          cd scripts/install_llvm
+          mix beaver.install_prebuilt_llvm >> "$GITHUB_OUTPUT"
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ beaver-*.tar.gz.sha256
 zig-out
 /priv/
 /zig-pkg/
+/scripts/install_llvm/_build/

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -30,5 +30,7 @@ This repository is an MLIR/LLVM toolkit for Elixir.
 
 - LLVM is currently expected from `LLVM_CONFIG_PATH`.
 - The default local install is `priv/llvm-prebuilt`, populated from the latest
-  matching `llvm/eudsl` build by `scripts/install-prebuilt-llvm.sh`.
+  matching `llvm/eudsl` build by the `beaver.install_prebuilt_llvm` Mix task
+  (`scripts/install_llvm`; `scripts/install-prebuilt-llvm.sh` is a thin
+  compatibility wrapper).
 - The active Zig line is `0.16`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,14 +45,23 @@ Zig as a local package override, so both dependency graphs use the same source.
 
 - Option 1: Install a prebuilt `llvm/eudsl` tarball
 
-  The helper script selects the matching `mlir_<os>_<arch>_*.tar.gz` asset for
-  the current machine, downloads it, and extracts the compiled binaries into a
-  local prefix. This replaces the old Python wheel-based setup and only needs a
-  local `python3` runtime.
+  The `beaver.install_prebuilt_llvm` Mix task selects the matching
+  `mlir_<os>_<arch>_*.tar.gz` asset for the current machine, downloads it, and
+  extracts the compiled binaries into a local prefix. It lives in
+  `scripts/install_llvm`, a tiny standalone Mix project, so running it never
+  compiles Beaver itself.
 
   ```bash
   bash scripts/install-prebuilt-llvm.sh priv/llvm-prebuilt
   export LLVM_CONFIG_PATH=$PWD/priv/llvm-prebuilt/bin/llvm-config
+  ```
+
+  The shell script is only a thin compatibility wrapper; the equivalent direct
+  invocation is:
+
+  ```bash
+  (cd scripts/install_llvm && mix beaver.install_prebuilt_llvm \
+    --install-dir "$PWD/../../priv/llvm-prebuilt")
   ```
 
 - Option 2: Build from source https://mlir.llvm.org/getting_started/

--- a/docker/livebook.dockerfile
+++ b/docker/livebook.dockerfile
@@ -7,6 +7,7 @@ RUN apt-get upgrade -y \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 # LLVM
+COPY ./scripts/install_llvm /usr/local/bin/install_llvm
 COPY ./scripts/install-prebuilt-llvm.sh /usr/local/bin/install-prebuilt-llvm.sh
 ARG LLVM_EUDSL_ASSET_NAME
 RUN LLVM_EUDSL_ASSET_NAME="${LLVM_EUDSL_ASSET_NAME}" \

--- a/scripts/install-prebuilt-llvm.sh
+++ b/scripts/install-prebuilt-llvm.sh
@@ -1,197 +1,26 @@
 #!/usr/bin/env bash
+# Thin compatibility wrapper around `mix beaver.install_prebuilt_llvm`.
+#
+# Prefer invoking the Mix task directly:
+#
+#   (cd scripts/install_llvm && mix beaver.install_prebuilt_llvm \
+#     --install-dir priv/llvm-prebuilt)
+#
+# A leading positional argument is treated as the install directory, relative
+# to the caller's working directory, matching the previous shell script.
 set -euo pipefail
 
-if ! command -v python3 >/dev/null 2>&1; then
-  echo "python3 is required to resolve llvm/eudsl release assets" >&2
-  exit 1
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+install_dir="${1:-}"
+if [[ -n "${install_dir}" && "${install_dir}" != /* ]]; then
+  install_dir="$(pwd)/${install_dir}"
 fi
 
-install_dir="${1:-${LLVM_PREBUILT_DIR:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/llvm-prebuilt}}"
-repo="${LLVM_EUDSL_REPO:-llvm/eudsl}"
-tag="${LLVM_EUDSL_TAG:-llvm}"
-default_asset_revision="20260804+eb50d8775"
-asset_revision="${LLVM_EUDSL_ASSET_REVISION:-${default_asset_revision}}"
-asset_name="${LLVM_EUDSL_ASSET_NAME:-}"
-asset_url="${LLVM_EUDSL_ASSET_URL:-}"
-resolve_only="${LLVM_EUDSL_RESOLVE_ONLY:-0}"
-token="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+cd "${script_dir}/install_llvm"
 
-if [[ -z "${install_dir}" || "${install_dir}" == "/" ]]; then
-  echo "refusing to install LLVM into '${install_dir}'" >&2
-  exit 1
-fi
-
-detect_platform() {
-  local os_name arch_name uname_s uname_m
-  uname_s="$(uname -s)"
-  uname_m="$(uname -m)"
-
-  case "${uname_s}" in
-    Darwin)
-      os_name="macos"
-      ;;
-    Linux)
-      os_name="manylinux"
-      ;;
-    MINGW*|MSYS*|CYGWIN*|Windows_NT)
-      os_name="windows"
-      ;;
-    *)
-      echo "unsupported operating system: ${uname_s}" >&2
-      exit 1
-      ;;
-  esac
-
-  case "${uname_m}" in
-    arm64|aarch64)
-      if [[ "${os_name}" == "macos" ]]; then
-        arch_name="arm64"
-      else
-        arch_name="aarch64"
-      fi
-      ;;
-    x86_64|amd64)
-      if [[ "${os_name}" == "windows" ]]; then
-        arch_name="amd64"
-      else
-        arch_name="x86_64"
-      fi
-      ;;
-    *)
-      echo "unsupported architecture: ${uname_m}" >&2
-      exit 1
-      ;;
-  esac
-
-  printf '%s %s\n' "${os_name}" "${arch_name}"
-}
-
-if [[ -z "${asset_name}" ]]; then
-  read -r detected_asset_os detected_asset_arch < <(detect_platform)
-  asset_os="${LLVM_EUDSL_ASSET_OS:-${detected_asset_os}}"
-  asset_arch="${LLVM_EUDSL_ASSET_ARCH:-${detected_asset_arch}}"
-
-  if [[ "${asset_revision}" == "latest" ]]; then
-    asset_name="$(
-      REPO="${repo}" \
-      TAG="${tag}" \
-      ASSET_OS="${asset_os}" \
-      ASSET_ARCH="${asset_arch}" \
-      GITHUB_TOKEN="${token}" \
-      python3 - <<'PY'
-import json
-import os
-import sys
-import urllib.request
-
-
-def make_request(url: str) -> urllib.request.Request:
-    headers = {
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
-    token = os.environ.get("GITHUB_TOKEN")
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-    return urllib.request.Request(url, headers=headers)
-
-
-repo = os.environ["REPO"]
-tag = os.environ["TAG"]
-asset_os = os.environ["ASSET_OS"]
-asset_arch = os.environ["ASSET_ARCH"]
-
-release_url = f"https://api.github.com/repos/{repo}/releases/tags/{tag}"
-with urllib.request.urlopen(make_request(release_url)) as response:
-    release = json.load(response)
-
-release_id = release["id"]
-prefix = f"mlir_{asset_os}_{asset_arch}_"
-matches = []
-
-for page in range(1, 11):
-    assets_url = (
-        f"https://api.github.com/repos/{repo}/releases/{release_id}/assets"
-        f"?per_page=100&page={page}"
-    )
-    with urllib.request.urlopen(make_request(assets_url)) as response:
-        assets = json.load(response)
-    if not assets:
-        break
-    for asset in assets:
-        name = asset["name"]
-        if name.startswith(prefix) and name.endswith(".tar.gz"):
-            matches.append(asset)
-
-if not matches:
-    sys.stderr.write(
-        f"no llvm/eudsl asset found for {asset_os}/{asset_arch} under tag {tag}\n"
-    )
-    sys.exit(1)
-
-matches.sort(key=lambda asset: (asset.get("updated_at", ""), asset["name"]))
-print(matches[-1]["name"])
-PY
-    )"
-  else
-    asset_name="mlir_${asset_os}_${asset_arch}_${asset_revision}.tar.gz"
-  fi
-fi
-
-if [[ -z "${asset_url}" ]]; then
-  asset_url="https://github.com/${repo}/releases/download/${tag}/${asset_name}"
-fi
-
-if [[ "${resolve_only}" == "1" ]]; then
-  printf 'LLVM_PREBUILT_ASSET_NAME=%s\n' "${asset_name}"
-  printf 'LLVM_PREBUILT_URL=%s\n' "${asset_url}"
-  exit 0
-fi
-
-tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/llvm-prebuilt.XXXXXX")"
-archive_path="${tmp_root}/${asset_name}"
-extract_dir="${tmp_root}/extract"
-
-cleanup() {
-  rm -rf "${tmp_root}"
-}
-trap cleanup EXIT
-
-echo "Downloading ${asset_url}"
-ASSET_URL="${asset_url}" ARCHIVE_PATH="${archive_path}" python3 - <<'PY'
-import os
-import urllib.request
-
-urllib.request.urlretrieve(os.environ["ASSET_URL"], os.environ["ARCHIVE_PATH"])
-PY
-
-mkdir -p "${extract_dir}"
-tar -xzf "${archive_path}" -C "${extract_dir}"
-
-llvm_config="$(find "${extract_dir}" -path '*/bin/llvm-config' -type f | head -n 1)"
-if [[ -z "${llvm_config}" ]]; then
-  echo "could not locate llvm-config in ${asset_name}" >&2
-  exit 1
-fi
-
-asset_root="$(cd "$(dirname "${llvm_config}")/.." && pwd)"
-rm -rf "${install_dir}"
-mkdir -p "${install_dir}"
-cp -R "${asset_root}"/. "${install_dir}"/
-
-llvm_config_path="${install_dir}/bin/llvm-config"
-if [[ ! -x "${llvm_config_path}" ]]; then
-  chmod +x "${llvm_config_path}" || true
-fi
-
-echo "Installed ${asset_name} into ${install_dir}"
-echo "LLVM_CONFIG_PATH=${llvm_config_path}"
-
-if [[ -n "${GITHUB_ENV:-}" ]]; then
-  {
-    printf 'LLVM_CONFIG_PATH=%s\n' "${llvm_config_path}"
-    printf 'LLVM_PREBUILT_DIR=%s\n' "${install_dir}"
-    printf 'LLVM_PREBUILT_ASSET_NAME=%s\n' "${asset_name}"
-    printf 'LLVM_PREBUILT_URL=%s\n' "${asset_url}"
-  } >> "${GITHUB_ENV}"
+if [[ -n "${install_dir}" ]]; then
+  exec mix beaver.install_prebuilt_llvm --install-dir "${install_dir}" "${@:2}"
+else
+  exec mix beaver.install_prebuilt_llvm
 fi

--- a/scripts/install_llvm/lib/mix/tasks/beaver.install_prebuilt_llvm.ex
+++ b/scripts/install_llvm/lib/mix/tasks/beaver.install_prebuilt_llvm.ex
@@ -303,32 +303,40 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
   end
 
   defp download!(url, path) do
-    unless System.find_executable("curl") do
-      Mix.raise("curl is required to download #{url}")
-    end
-
     IO.puts("Downloading #{url}")
 
-    {output, status} =
-      System.cmd(
-        "curl",
-        [
-          "--fail",
-          "--location",
-          "--silent",
-          "--show-error",
-          "--retry",
-          "3",
-          "--output",
-          path,
-          "--url",
+    cond do
+      System.find_executable("curl") ->
+        run_download(
+          [
+            "curl",
+            "--fail",
+            "--location",
+            "--silent",
+            "--show-error",
+            "--retry",
+            "3",
+            "--output",
+            path,
+            "--url",
+            url
+          ],
           url
-        ],
-        stderr_to_stdout: true
-      )
+        )
+
+      System.find_executable("wget") ->
+        run_download(["wget", "--quiet", "--output-document", path, url], url)
+
+      true ->
+        Mix.raise("curl or wget is required to download #{url}")
+    end
+  end
+
+  defp run_download(command, url) do
+    {output, status} = System.cmd(hd(command), tl(command), stderr_to_stdout: true)
 
     unless status == 0 do
-      Mix.raise("curl failed with status #{status}:\n#{output}")
+      Mix.raise("download failed with status #{status} for #{url}:\n#{output}")
     end
 
     :ok

--- a/scripts/install_llvm/lib/mix/tasks/beaver.install_prebuilt_llvm.ex
+++ b/scripts/install_llvm/lib/mix/tasks/beaver.install_prebuilt_llvm.ex
@@ -66,7 +66,7 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
   @impl Mix.Task
   def run(args) do
     {opts, positional} = OptionParser.parse!(args, strict: @switches)
-    opts = merge_env(opts)
+    opts = opts |> reject_empty() |> merge_env()
 
     install_dir = opts[:install_dir] || List.first(positional) || default_install_dir()
     {os_name, arch} = platform(opts)
@@ -96,11 +96,18 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
     |> maybe_resolve_only()
   end
 
+  defp reject_empty(opts) do
+    Enum.reject(opts, fn {_key, value} -> value == "" end)
+  end
+
   defp put_default(opts, key, default, env) do
     if Keyword.has_key?(opts, key) do
       opts
     else
-      Keyword.put(opts, key, System.get_env(env) || default)
+      case System.get_env(env) do
+        value when value in [nil, ""] -> Keyword.put(opts, key, default)
+        value -> Keyword.put(opts, key, value)
+      end
     end
   end
 
@@ -109,7 +116,7 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
       opts
     else
       case System.get_env(env) do
-        nil -> opts
+        value when value in [nil, ""] -> opts
         value -> Keyword.put(opts, key, value)
       end
     end

--- a/scripts/install_llvm/lib/mix/tasks/beaver.install_prebuilt_llvm.ex
+++ b/scripts/install_llvm/lib/mix/tasks/beaver.install_prebuilt_llvm.ex
@@ -1,0 +1,395 @@
+defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
+  @moduledoc """
+  Installs a prebuilt LLVM/MLIR distribution and prints `LLVM_CONFIG_PATH`.
+
+  By default it downloads the matching `llvm/eudsl` nightly build for the
+  current platform. Any URL can be used instead, for example Triton's pinned
+  LLVM archive:
+
+      (cd scripts/install_llvm && mix beaver.install_prebuilt_llvm \\
+        --asset-url https://oaitriton.blob.core.windows.net/public/llvm-builds/llvm-b010a18d-ubuntu-x64-1.tar.gz \\
+        --sha256 <sha256>)
+
+  The task lives in its own tiny Mix project (`scripts/install_llvm`) so
+  running it never compiles Beaver or its NIF.
+
+  ## Options
+
+  Each option has an environment variable fallback used when the flag is not
+  given:
+
+    * `--install-dir PATH` / `LLVM_PREBUILT_DIR` — where to install; defaults
+      to `$RUNNER_TEMP`/`$TMPDIR`/`/tmp` + `llvm-prebuilt`. A leading
+      positional argument is accepted for compatibility with the old shell
+      wrapper.
+    * `--repo REPO` / `LLVM_EUDSL_REPO` — defaults to `llvm/eudsl`.
+    * `--tag TAG` / `LLVM_EUDSL_TAG` — defaults to `llvm`.
+    * `--asset-revision REV` / `LLVM_EUDSL_ASSET_REVISION` — defaults to
+      `20260804+eb50d8775`; `latest` resolves the newest asset through the
+      GitHub API.
+    * `--asset-name NAME` / `LLVM_EUDSL_ASSET_NAME` — exact asset file name.
+    * `--asset-url URL` / `LLVM_EUDSL_ASSET_URL` — download from an arbitrary
+      URL (the asset name defaults to the URL basename).
+    * `--asset-os OS` / `LLVM_EUDSL_ASSET_OS` and `--asset-arch ARCH` /
+      `LLVM_EUDSL_ASSET_ARCH` — override platform detection for asset naming.
+    * `--sha256 DIGEST` / `LLVM_EUDSL_SHA256` — verify the downloaded archive.
+    * `--github-token TOKEN` / `GITHUB_TOKEN` or `GH_TOKEN` — used for
+      `latest` resolution.
+    * `--resolve-only` / `LLVM_EUDSL_RESOLVE_ONLY=1` — print
+      `LLVM_PREBUILT_ASSET_NAME` and `LLVM_PREBUILT_URL` without downloading.
+
+  When `GITHUB_ENV` is set, `LLVM_CONFIG_PATH`, `LLVM_PREBUILT_DIR`,
+  `LLVM_PREBUILT_ASSET_NAME` and `LLVM_PREBUILT_URL` are appended to it so
+  subsequent CI steps can pick up the installation.
+  """
+
+  use Mix.Task
+
+  @shortdoc "Installs a prebuilt LLVM/MLIR distribution"
+
+  @default_revision "20260804+eb50d8775"
+
+  @switches [
+    install_dir: :string,
+    repo: :string,
+    tag: :string,
+    asset_revision: :string,
+    asset_name: :string,
+    asset_url: :string,
+    asset_os: :string,
+    asset_arch: :string,
+    sha256: :string,
+    github_token: :string,
+    resolve_only: :boolean
+  ]
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, positional} = OptionParser.parse!(args, strict: @switches)
+    opts = merge_env(opts)
+
+    install_dir = opts[:install_dir] || List.first(positional) || default_install_dir()
+    {os_name, arch} = platform(opts)
+    {asset_name, asset_url} = resolve_asset(opts, os_name, arch)
+
+    if opts[:resolve_only] do
+      IO.puts("LLVM_PREBUILT_ASSET_NAME=#{asset_name}")
+      IO.puts("LLVM_PREBUILT_URL=#{asset_url}")
+    else
+      install!(install_dir, asset_name, asset_url, opts[:sha256])
+    end
+  end
+
+  defp merge_env(opts) do
+    opts
+    |> put_default(:repo, "llvm/eudsl", "LLVM_EUDSL_REPO")
+    |> put_default(:tag, "llvm", "LLVM_EUDSL_TAG")
+    |> put_default(:asset_revision, @default_revision, "LLVM_EUDSL_ASSET_REVISION")
+    |> put_env(:install_dir, "LLVM_PREBUILT_DIR")
+    |> put_env(:asset_name, "LLVM_EUDSL_ASSET_NAME")
+    |> put_env(:asset_url, "LLVM_EUDSL_ASSET_URL")
+    |> put_env(:asset_os, "LLVM_EUDSL_ASSET_OS")
+    |> put_env(:asset_arch, "LLVM_EUDSL_ASSET_ARCH")
+    |> put_env(:sha256, "LLVM_EUDSL_SHA256")
+    |> put_env(:github_token, "GITHUB_TOKEN")
+    |> put_env(:github_token, "GH_TOKEN")
+    |> maybe_resolve_only()
+  end
+
+  defp put_default(opts, key, default, env) do
+    if Keyword.has_key?(opts, key) do
+      opts
+    else
+      Keyword.put(opts, key, System.get_env(env) || default)
+    end
+  end
+
+  defp put_env(opts, key, env) do
+    if Keyword.has_key?(opts, key) do
+      opts
+    else
+      case System.get_env(env) do
+        nil -> opts
+        value -> Keyword.put(opts, key, value)
+      end
+    end
+  end
+
+  defp maybe_resolve_only(opts) do
+    if System.get_env("LLVM_EUDSL_RESOLVE_ONLY") == "1" do
+      Keyword.put_new(opts, :resolve_only, true)
+    else
+      opts
+    end
+  end
+
+  defp default_install_dir do
+    base = System.get_env("RUNNER_TEMP") || System.get_env("TMPDIR") || "/tmp"
+    Path.join(base, "llvm-prebuilt")
+  end
+
+  defp platform(opts) do
+    os_name = opts[:asset_os] || detect_os()
+    arch = opts[:asset_arch] || detect_arch(os_name)
+    {os_name, arch}
+  end
+
+  defp detect_os do
+    case :os.type() do
+      {:unix, :darwin} -> "macos"
+      {:unix, _} -> "manylinux"
+      {:win32, _} -> "windows"
+      other -> Mix.raise("unsupported operating system: #{inspect(other)}")
+    end
+  end
+
+  defp detect_arch("windows"), do: "amd64"
+
+  defp detect_arch(os_name) do
+    arch = :erlang.system_info(:system_architecture) |> List.to_string()
+
+    arm? = String.starts_with?(arch, "aarch64") or String.starts_with?(arch, "arm64")
+
+    case {os_name, arm?} do
+      {"macos", true} -> "arm64"
+      {"macos", false} -> "x86_64"
+      {_, true} -> "aarch64"
+      {_, false} -> "x86_64"
+    end
+  end
+
+  defp resolve_asset(opts, os_name, arch) do
+    case opts[:asset_url] do
+      url when is_binary(url) ->
+        {opts[:asset_name] || Path.basename(url), url}
+
+      nil ->
+        name =
+          opts[:asset_name] ||
+            case opts[:asset_revision] do
+              "latest" -> resolve_latest_asset!(opts, os_name, arch)
+              revision -> "mlir_#{os_name}_#{arch}_#{revision}.tar.gz"
+            end
+
+        url = "https://github.com/#{opts[:repo]}/releases/download/#{opts[:tag]}/#{name}"
+        {name, url}
+    end
+  end
+
+  defp resolve_latest_asset!(opts, os_name, arch) do
+    ensure_http!()
+    prefix = "mlir_#{os_name}_#{arch}_"
+    release = github_get!(release_url(opts), opts[:github_token])
+    assets = fetch_all_assets!(release["id"], opts)
+
+    matches =
+      Enum.filter(assets, fn asset ->
+        String.starts_with?(asset["name"], prefix) and
+          String.ends_with?(asset["name"], ".tar.gz")
+      end)
+
+    case matches
+         |> Enum.sort_by(fn asset -> {asset["updated_at"] || "", asset["name"]} end)
+         |> List.last() do
+      nil ->
+        Mix.raise("no llvm/eudsl asset found for #{os_name}/#{arch} under tag #{opts[:tag]}")
+
+      asset ->
+        asset["name"]
+    end
+  end
+
+  defp release_url(opts) do
+    "https://api.github.com/repos/#{opts[:repo]}/releases/tags/#{opts[:tag]}"
+  end
+
+  defp fetch_all_assets!(release_id, opts) do
+    Enum.reduce_while(1..10, [], fn page, acc ->
+      url =
+        "https://api.github.com/repos/#{opts[:repo]}/releases/#{release_id}/assets?per_page=100&page=#{page}"
+
+      case github_get!(url, opts[:github_token]) do
+        [] -> {:halt, acc}
+        assets -> {:cont, acc ++ assets}
+      end
+    end)
+  end
+
+  defp github_get!(url, token) do
+    headers =
+      [
+        {~c"Accept", ~c"application/vnd.github+json"},
+        {~c"User-Agent", ~c"beaver-install-prebuilt-llvm"},
+        {~c"X-GitHub-Api-Version", ~c"2022-11-28"}
+      ]
+
+    headers =
+      case token do
+        nil -> headers
+        token -> [{~c"Authorization", String.to_charlist("Bearer #{token}")} | headers]
+      end
+
+    http_opts = [timeout: 30_000, connect_timeout: 15_000]
+
+    case :httpc.request(:get, {String.to_charlist(url), headers}, http_opts, body_format: :binary) do
+      {:ok, {{_, 200, _}, _, body}} ->
+        JSON.decode!(body)
+
+      {:ok, {{_, status, _}, _, body}} ->
+        Mix.raise("GitHub API #{status} for #{url}: #{inspect(body)}")
+
+      {:error, reason} ->
+        Mix.raise("GitHub API request failed for #{url}: #{inspect(reason)}")
+    end
+  end
+
+  defp ensure_http! do
+    {:ok, _} = Application.ensure_all_started(:inets)
+    {:ok, _} = Application.ensure_all_started(:ssl)
+  end
+
+  defp install!(install_dir, asset_name, asset_url, sha256) do
+    guard_install_dir!(install_dir)
+    tmp_root = Path.join(System.tmp_dir!(), "llvm-prebuilt-#{System.unique_integer([:positive])}")
+    archive = Path.join(tmp_root, asset_name)
+    extract_dir = Path.join(tmp_root, "extract")
+
+    try do
+      File.mkdir_p!(tmp_root)
+      download!(asset_url, archive)
+      verify_sha256!(archive, sha256)
+      extract!(archive, extract_dir)
+
+      llvm_config =
+        case Path.wildcard(Path.join(extract_dir, "**/bin/llvm-config")) do
+          [path | _] -> path
+          [] -> Mix.raise("could not locate bin/llvm-config in #{asset_name}")
+        end
+
+      asset_root = llvm_config |> Path.dirname() |> Path.dirname()
+
+      File.rm_rf!(install_dir)
+      File.mkdir_p!(install_dir)
+      copy_tree!(asset_root, install_dir)
+
+      llvm_config_path = Path.join(install_dir, "bin/llvm-config")
+      File.chmod(llvm_config_path, 0o755)
+
+      IO.puts("Installed #{asset_name} into #{install_dir}")
+      IO.puts("LLVM_CONFIG_PATH=#{llvm_config_path}")
+      write_github_env!(install_dir, asset_name, asset_url)
+    after
+      File.rm_rf!(tmp_root)
+    end
+  end
+
+  defp guard_install_dir!(install_dir) do
+    if install_dir in ["", "/"] do
+      Mix.raise("refusing to install LLVM into '#{install_dir}'")
+    end
+  end
+
+  defp download!(url, path) do
+    unless System.find_executable("curl") do
+      Mix.raise("curl is required to download #{url}")
+    end
+
+    IO.puts("Downloading #{url}")
+
+    {output, status} =
+      System.cmd(
+        "curl",
+        [
+          "--fail",
+          "--location",
+          "--silent",
+          "--show-error",
+          "--retry",
+          "3",
+          "--output",
+          path,
+          "--url",
+          url
+        ],
+        stderr_to_stdout: true
+      )
+
+    unless status == 0 do
+      Mix.raise("curl failed with status #{status}:\n#{output}")
+    end
+
+    :ok
+  end
+
+  defp verify_sha256!(_path, nil), do: :ok
+
+  defp verify_sha256!(path, expected) do
+    digest =
+      path
+      |> File.stream!(1_048_576, [])
+      |> Enum.reduce(:crypto.hash_init(:sha256), fn chunk, ctx ->
+        :crypto.hash_update(ctx, chunk)
+      end)
+      |> :crypto.hash_final()
+      |> Base.encode16(case: :lower)
+
+    unless digest == String.downcase(expected) do
+      Mix.raise("sha256 mismatch for #{path}: expected #{expected}, got #{digest}")
+    end
+
+    :ok
+  end
+
+  defp extract!(archive, extract_dir) do
+    File.mkdir_p!(extract_dir)
+
+    case :erl_tar.extract(String.to_charlist(archive), [
+           :compressed,
+           {:cwd, String.to_charlist(extract_dir)}
+         ]) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Mix.raise("failed to extract #{archive}: #{inspect(reason)}")
+    end
+  end
+
+  defp copy_tree!(src_root, dest_root) do
+    File.mkdir_p!(dest_root)
+
+    Enum.each(File.ls!(src_root), fn entry ->
+      src = Path.join(src_root, entry)
+      dest = Path.join(dest_root, entry)
+
+      case File.lstat(src) do
+        {:ok, %File.Stat{type: :symlink}} ->
+          {:ok, target} = File.read_link(src)
+          File.ln_s(target, dest)
+
+        {:ok, %File.Stat{type: :directory}} ->
+          copy_tree!(src, dest)
+
+        _ ->
+          File.cp!(src, dest)
+      end
+    end)
+  end
+
+  defp write_github_env!(install_dir, asset_name, asset_url) do
+    case System.get_env("GITHUB_ENV") do
+      nil ->
+        :ok
+
+      path ->
+        content = """
+        LLVM_CONFIG_PATH=#{Path.join(install_dir, "bin/llvm-config")}
+        LLVM_PREBUILT_DIR=#{install_dir}
+        LLVM_PREBUILT_ASSET_NAME=#{asset_name}
+        LLVM_PREBUILT_URL=#{asset_url}
+        """
+
+        File.write!(path, content, [:append])
+    end
+  end
+end

--- a/scripts/install_llvm/lib/mix/tasks/beaver.install_prebuilt_llvm.ex
+++ b/scripts/install_llvm/lib/mix/tasks/beaver.install_prebuilt_llvm.ex
@@ -35,6 +35,10 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
     * `--sha256 DIGEST` / `LLVM_EUDSL_SHA256` — verify the downloaded archive.
     * `--github-token TOKEN` / `GITHUB_TOKEN` or `GH_TOKEN` — used for
       `latest` resolution.
+    * `--github-env PATH` / `GITHUB_ENV` — file to append the exported
+      variables to. Defaults to the `GITHUB_ENV` environment variable; pass an
+      explicit path when running in an environment that sets `GITHUB_ENV` but
+      should not be mutated (e.g. tests).
     * `--resolve-only` / `LLVM_EUDSL_RESOLVE_ONLY=1` — print
       `LLVM_PREBUILT_ASSET_NAME` and `LLVM_PREBUILT_URL` without downloading.
 
@@ -60,6 +64,7 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
     asset_arch: :string,
     sha256: :string,
     github_token: :string,
+    github_env: :string,
     resolve_only: :boolean
   ]
 
@@ -76,7 +81,7 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
       IO.puts("LLVM_PREBUILT_ASSET_NAME=#{asset_name}")
       IO.puts("LLVM_PREBUILT_URL=#{asset_url}")
     else
-      install!(install_dir, asset_name, asset_url, opts[:sha256])
+      install!(install_dir, asset_name, asset_url, opts[:sha256], opts[:github_env])
     end
   end
 
@@ -91,6 +96,7 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
     |> put_env(:asset_os, "LLVM_EUDSL_ASSET_OS")
     |> put_env(:asset_arch, "LLVM_EUDSL_ASSET_ARCH")
     |> put_env(:sha256, "LLVM_EUDSL_SHA256")
+    |> put_env(:github_env, "GITHUB_ENV")
     |> put_env(:github_token, "GITHUB_TOKEN")
     |> put_env(:github_token, "GH_TOKEN")
     |> maybe_resolve_only()
@@ -255,7 +261,7 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
     {:ok, _} = Application.ensure_all_started(:ssl)
   end
 
-  defp install!(install_dir, asset_name, asset_url, sha256) do
+  defp install!(install_dir, asset_name, asset_url, sha256, github_env) do
     guard_install_dir!(install_dir)
     tmp_root = Path.join(System.tmp_dir!(), "llvm-prebuilt-#{System.unique_integer([:positive])}")
     archive = Path.join(tmp_root, asset_name)
@@ -284,7 +290,7 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
 
       IO.puts("Installed #{asset_name} into #{install_dir}")
       IO.puts("LLVM_CONFIG_PATH=#{llvm_config_path}")
-      write_github_env!(install_dir, asset_name, asset_url)
+      write_github_env!(install_dir, asset_name, asset_url, github_env)
     after
       File.rm_rf!(tmp_root)
     end
@@ -347,21 +353,6 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
     :ok
   end
 
-  defp extract!(archive, extract_dir) do
-    File.mkdir_p!(extract_dir)
-
-    case :erl_tar.extract(String.to_charlist(archive), [
-           :compressed,
-           {:cwd, String.to_charlist(extract_dir)}
-         ]) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        Mix.raise("failed to extract #{archive}: #{inspect(reason)}")
-    end
-  end
-
   defp copy_tree!(src_root, dest_root) do
     File.mkdir_p!(dest_root)
 
@@ -383,8 +374,21 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
     end)
   end
 
-  defp write_github_env!(install_dir, asset_name, asset_url) do
-    case System.get_env("GITHUB_ENV") do
+  defp extract!(archive, extract_dir) do
+    File.mkdir_p!(extract_dir)
+
+    {output, status} =
+      System.cmd("tar", ["-xzf", archive, "-C", extract_dir], stderr_to_stdout: true)
+
+    unless status == 0 do
+      Mix.raise("failed to extract #{archive}:\n#{output}")
+    end
+
+    :ok
+  end
+
+  defp write_github_env!(install_dir, asset_name, asset_url, github_env) do
+    case github_env || System.get_env("GITHUB_ENV") do
       nil ->
         :ok
 

--- a/scripts/install_llvm/mix.exs
+++ b/scripts/install_llvm/mix.exs
@@ -1,0 +1,17 @@
+defmodule BeaverLlvmInstaller.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :beaver_llvm_installer,
+      version: "0.1.0",
+      elixir: "~> 1.18",
+      start_permanent: false,
+      deps: []
+    ]
+  end
+
+  def application do
+    [extra_applications: [:crypto, :inets, :ssl]]
+  end
+end

--- a/scripts/install_llvm/test/install_prebuilt_llvm_test.exs
+++ b/scripts/install_llvm/test/install_prebuilt_llvm_test.exs
@@ -1,0 +1,119 @@
+defmodule Beaver.InstallPrebuiltLlvmTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureIO
+
+  alias Mix.Tasks.Beaver.InstallPrebuiltLlvm
+
+  setup do
+    Mix.Task.reenable("beaver.install_prebuilt_llvm")
+    :ok
+  end
+
+  test "resolve-only prints the default eudsl asset" do
+    output =
+      capture_io(fn ->
+        InstallPrebuiltLlvm.run([
+          "--resolve-only",
+          "--asset-os",
+          "manylinux",
+          "--asset-arch",
+          "x86_64"
+        ])
+      end)
+
+    assert output =~ "LLVM_PREBUILT_ASSET_NAME=mlir_manylinux_x86_64_20260804+eb50d8775.tar.gz"
+    assert output =~ "https://github.com/llvm/eudsl/releases/download/llvm/"
+  end
+
+  test "asset-url overrides GitHub asset resolution" do
+    output =
+      capture_io(fn ->
+        InstallPrebuiltLlvm.run([
+          "--resolve-only",
+          "--asset-url",
+          "https://example.com/llvm.tar.gz"
+        ])
+      end)
+
+    assert output =~ "LLVM_PREBUILT_ASSET_NAME=llvm.tar.gz"
+    assert output =~ "LLVM_PREBUILT_URL=https://example.com/llvm.tar.gz"
+  end
+
+  test "installs a tarball and points LLVM_CONFIG_PATH at it" do
+    fixture =
+      Path.join(System.tmp_dir!(), "beaver-llvm-install-#{System.unique_integer([:positive])}")
+
+    tar = fixture <> ".tar.gz"
+    dest = fixture <> "-dest"
+
+    try do
+      File.mkdir_p!(Path.join(fixture, "bin"))
+      File.write!(Path.join(fixture, "bin/llvm-config"), "#!/bin/sh\necho 17.0.0\n")
+
+      :ok =
+        :erl_tar.create(
+          String.to_charlist(tar),
+          [
+            {~c"bin/llvm-config", File.read!(Path.join(fixture, "bin/llvm-config"))}
+          ],
+          [:compressed]
+        )
+
+      output =
+        capture_io(fn ->
+          InstallPrebuiltLlvm.run([
+            "--asset-url",
+            "file://#{tar}",
+            "--install-dir",
+            dest
+          ])
+        end)
+
+      assert output =~ "LLVM_CONFIG_PATH=#{Path.join(dest, "bin/llvm-config")}"
+      assert File.exists?(Path.join(dest, "bin/llvm-config"))
+      assert File.read!(Path.join(dest, "bin/llvm-config")) =~ "17.0.0"
+    after
+      File.rm_rf!(fixture)
+      File.rm_rf!(dest)
+      File.rm(tar)
+    end
+  end
+
+  test "sha256 mismatch aborts the install" do
+    fixture =
+      Path.join(System.tmp_dir!(), "beaver-llvm-sha-#{System.unique_integer([:positive])}")
+
+    tar = fixture <> ".tar.gz"
+    dest = fixture <> "-dest"
+
+    try do
+      File.mkdir_p!(Path.join(fixture, "bin"))
+      File.write!(Path.join(fixture, "bin/llvm-config"), "#!/bin/sh\n")
+
+      :ok =
+        :erl_tar.create(
+          String.to_charlist(tar),
+          [{~c"bin/llvm-config", "#!/bin/sh\n"}],
+          [:compressed]
+        )
+
+      assert_raise Mix.Error, ~r/sha256 mismatch/, fn ->
+        capture_io(fn ->
+          InstallPrebuiltLlvm.run([
+            "--asset-url",
+            "file://#{tar}",
+            "--sha256",
+            String.duplicate("0", 64),
+            "--install-dir",
+            dest
+          ])
+        end)
+      end
+    after
+      File.rm_rf!(fixture)
+      File.rm_rf!(dest)
+      File.rm(tar)
+    end
+  end
+end

--- a/scripts/install_llvm/test/install_prebuilt_llvm_test.exs
+++ b/scripts/install_llvm/test/install_prebuilt_llvm_test.exs
@@ -40,6 +40,23 @@ defmodule Beaver.InstallPrebuiltLlvmTest do
     assert output =~ "LLVM_PREBUILT_URL=https://example.com/llvm.tar.gz"
   end
 
+  test "empty asset-name falls back to the default revision" do
+    output =
+      capture_io(fn ->
+        InstallPrebuiltLlvm.run([
+          "--resolve-only",
+          "--asset-os",
+          "manylinux",
+          "--asset-arch",
+          "x86_64",
+          "--asset-name",
+          ""
+        ])
+      end)
+
+    assert output =~ "LLVM_PREBUILT_ASSET_NAME=mlir_manylinux_x86_64_20260804+eb50d8775.tar.gz"
+  end
+
   test "installs a tarball and points LLVM_CONFIG_PATH at it" do
     fixture =
       Path.join(System.tmp_dir!(), "beaver-llvm-install-#{System.unique_integer([:positive])}")

--- a/scripts/install_llvm/test/install_prebuilt_llvm_test.exs
+++ b/scripts/install_llvm/test/install_prebuilt_llvm_test.exs
@@ -63,6 +63,7 @@ defmodule Beaver.InstallPrebuiltLlvmTest do
 
     tar = fixture <> ".tar.gz"
     dest = fixture <> "-dest"
+    github_env = fixture <> "-env"
 
     try do
       File.mkdir_p!(Path.join(fixture, "bin"))
@@ -83,16 +84,23 @@ defmodule Beaver.InstallPrebuiltLlvmTest do
             "--asset-url",
             "file://#{tar}",
             "--install-dir",
-            dest
+            dest,
+            "--github-env",
+            github_env
           ])
         end)
 
       assert output =~ "LLVM_CONFIG_PATH=#{Path.join(dest, "bin/llvm-config")}"
       assert File.exists?(Path.join(dest, "bin/llvm-config"))
       assert File.read!(Path.join(dest, "bin/llvm-config")) =~ "17.0.0"
+
+      exported = File.read!(github_env)
+      assert exported =~ "LLVM_CONFIG_PATH=#{Path.join(dest, "bin/llvm-config")}"
+      assert exported =~ "LLVM_PREBUILT_DIR=#{dest}"
     after
       File.rm_rf!(fixture)
       File.rm_rf!(dest)
+      File.rm(github_env)
       File.rm(tar)
     end
   end

--- a/scripts/install_llvm/test/test_helper.exs
+++ b/scripts/install_llvm/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
Refactors `scripts/install-prebuilt-llvm.sh` into `mix beaver.install_prebuilt_llvm`, a task that lives in its own tiny Mix project (`scripts/install_llvm`) so running it **never compiles Beaver or its NIF** (no chicken-and-egg when installing LLVM before the first build).

## What

- `scripts/install_llvm/` — standalone Mix project (no deps, Elixir ~> 1.18) with the task.
- Task behavior ports the shell script: platform detection, eudsl asset naming, `latest` resolution via the GitHub API, download + extract, `bin/llvm-config` discovery, symlink-preserving tree copy, `GITHUB_ENV` export of `LLVM_CONFIG_PATH` etc.
- New capabilities:
  - `--asset-url` for arbitrary distributions (e.g. Triton's pinned LLVM archive on the Azure blob) with optional `--sha256` verification.
  - `--resolve-only` for CI matrix resolution.
  - Guard against `--install-dir /`.
- `scripts/install-prebuilt-llvm.sh` is now a thin compatibility wrapper (preserves the relative install-dir argument); CI, the Livebook Dockerfile and contributor docs point at the Mix task.
- Subproject tests (`scripts/install_llvm` + `mix test`) cover resolve-only, asset-url override, install, and sha256 mismatch; CI runs them.

## Motivation

Installing the prebuilt LLVM happens *before* Beaver can compile, so the installer must not depend on a compiled Beaver. The old Python shell script was kept because a Mix task in `lib/mix/tasks` would trigger the project (and NIF) build. A nested standalone Mix project sidesteps that entirely and matches the repo's preference for structured Mix tasks over shell scripts.

## Notes

- Works on a fresh checkout with no deps fetched: the subproject has zero dependencies.
- Verified locally: default eudsl resolve, `latest` resolution (resolves `20260806+239cbf5ba`), Triton `--asset-url`, install from a local tarball, sha256 mismatch abort, wrapper compat, `GITHUB_ENV` export.