### PR TITLE
Adopt upstream Ptr dialect for ENIF lowering

### DIFF
--- a/bench/enif_add.ex
+++ b/bench/enif_add.ex
@@ -33,20 +33,22 @@ defmodule AddENIF do
       module do
         env_t = ENIF.Type.env()
         term_t = ENIF.Type.term()
+        ptr_t = Ptr.type()
+        generic_space = Ptr.generic_space()
 
         Func.func add(function_type: Type.function([env_t, term_t, term_t], [term_t])) do
           region do
             block _(env >>> env_t, left >>> term_t, right >>> term_t) do
               left_ptr =
                 MemRef.alloca(operand_segment_sizes: :infer) >>>
-                  Type.memref!([], Type.i64(ctx: ctx), memory_space: ~a{#ptr.generic_space})
+                  Type.memref!([], Type.i64(ctx: ctx), memory_space: generic_space)
 
               right_ptr =
                 MemRef.alloca(operand_segment_sizes: :infer) >>>
-                  Type.memref!([], Type.i64(ctx: ctx), memory_space: ~a{#ptr.generic_space})
+                  Type.memref!([], Type.i64(ctx: ctx), memory_space: generic_space)
 
-              left_ptr_arg = Ptr.to_ptr(left_ptr) >>> ~t{!ptr.ptr<#ptr.generic_space>}
-              right_ptr_arg = Ptr.to_ptr(right_ptr) >>> ~t{!ptr.ptr<#ptr.generic_space>}
+              left_ptr_arg = Ptr.to_ptr(left_ptr) >>> ptr_t
+              right_ptr_arg = Ptr.to_ptr(right_ptr) >>> ptr_t
               ENIF.get_int64(env, left, left_ptr_arg) >>> :infer
               ENIF.get_int64(env, right, right_ptr_arg) >>> :infer
               left = MemRef.load(left_ptr) >>> Type.i64()

--- a/bench/enif_string_as_memref.ex
+++ b/bench/enif_string_as_memref.ex
@@ -20,6 +20,8 @@ defmodule ENIFStringAsMemRef do
       module do
         env_t = ENIF.Type.env()
         term_t = ENIF.Type.term()
+        ptr_t = Ptr.type()
+        generic_space = Ptr.generic_space()
 
         Func.func original_str(function_type: Type.function([env_t, term_t], [term_t])) do
           region do
@@ -64,9 +66,9 @@ defmodule ENIFStringAsMemRef do
 
               term_ptr =
                 MemRef.alloca(operand_segment_sizes: :infer) >>>
-                  Type.memref!([], ENIF.Type.term(ctx: ctx), memory_space: ~a{#ptr.generic_space})
+                  Type.memref!([], ENIF.Type.term(ctx: ctx), memory_space: generic_space)
 
-              term_ptr_arg = Ptr.to_ptr(term_ptr) >>> ~t{!ptr.ptr<#ptr.generic_space>}
+              term_ptr_arg = Ptr.to_ptr(term_ptr) >>> ptr_t
               # assign the term and return the pointer to binary data
               m = ENIF.make_new_binary_as_memref(env, size, term_ptr_arg) >>> :infer
               MemRef.copy(source: msg, target: m) >>> []
@@ -82,9 +84,9 @@ defmodule ENIFStringAsMemRef do
 
               term_ptr =
                 MemRef.alloca(operand_segment_sizes: :infer) >>>
-                  Type.memref!([], ENIF.Type.term(ctx: ctx), memory_space: ~a{#ptr.generic_space})
+                  Type.memref!([], ENIF.Type.term(ctx: ctx), memory_space: generic_space)
 
-              term_ptr_arg = Ptr.to_ptr(term_ptr) >>> ~t{!ptr.ptr<#ptr.generic_space>}
+              term_ptr_arg = Ptr.to_ptr(term_ptr) >>> ptr_t
               m2 = ENIF.make_new_binary_as_memref(env, size, term_ptr_arg) >>> :infer
               MemRef.copy(source: m1, target: m2) >>> []
               b = MemRef.load(term_ptr) >>> ENIF.Type.term()

--- a/guides/enif-pointer-interop.md
+++ b/guides/enif-pointer-interop.md
@@ -1,0 +1,95 @@
+# ENIF pointer interoperability
+
+Beaver uses MLIR's upstream Ptr dialect as the IR-level pointer abstraction.
+This keeps pointer intent visible until the LLVM boundary without treating a
+BEAM resource as if it were an SSA value.
+
+## Three representations
+
+The interop boundary has three distinct representations:
+
+1. A `Beaver.Native.OpaquePtr` or another `Beaver.Native` resource is a
+   host-side owner or handle. It is managed by the BEAM/NIF runtime and does
+   not belong in MLIR IR.
+2. A `!ptr.ptr` value is a native pointer inside MLIR. ENIF pointer signatures
+   use `!ptr.ptr<#ptr.generic_space>` so `convert-to-llvm` can map the generic
+   ABI pointer to LLVM address space 0.
+3. A memref carries pointer metadata and ownership-independent shape
+   information. It should stay a memref until an external function actually
+   requires a C pointer.
+
+These representations must cross explicit operations or runtime boundaries;
+they are not interchangeable casts.
+
+## ENIF out-parameters
+
+Allocate typed storage as a memref, then use `ptr.to_ptr` at the call boundary:
+
+```elixir
+alias Beaver.MLIR.Dialect.{MemRef, Ptr}
+
+generic_space = Ptr.generic_space()
+ptr_type = Ptr.type()
+
+storage =
+  MemRef.alloca(operand_segment_sizes: :infer) >>>
+    Type.memref!([], Type.i64(ctx: ctx), memory_space: generic_space)
+
+argument = Ptr.to_ptr(storage) >>> ptr_type
+ENIF.get_int64(env, term, argument) >>> :infer
+value = MemRef.load(storage) >>> Type.i64()
+```
+
+The memref owns the storage semantics. `ptr.to_ptr` exposes only its aligned
+data pointer to the ENIF call. Do not reconstruct a memref from a raw ENIF
+pointer unless the pointer's metadata, lifetime, and ownership contract are
+available explicitly.
+
+## Null and raw addresses
+
+Use typed Ptr attributes rather than routing through an LLVM zero and an
+`unrealized_conversion_cast`:
+
+```elixir
+ptr_type = Ptr.type()
+null = Ptr.constant(value: Ptr.null(type: ptr_type)) >>> ptr_type
+address = Ptr.constant(value: Ptr.address(0x1000, type: ptr_type)) >>> ptr_type
+```
+
+An address constant does not acquire ownership or extend a lifetime. It is
+valid only when the native side guarantees that the address is meaningful for
+the complete use interval.
+
+## Loads, stores, arithmetic, and address spaces
+
+For values that are already native pointers, use upstream `ptr.load`,
+`ptr.store`, `ptr.ptr_add`, and `ptr.ptr_diff`. Vector pointer values can use
+the upstream masked load/store and gather/scatter operations.
+
+When Ptr operations remain inside an `llvm.func` until LLVM IR translation,
+make the target address space explicit:
+
+```elixir
+generic_llvm_pointer = Ptr.type(memory_space: {:llvm, 0})
+shared_llvm_pointer = Ptr.type(memory_space: {:llvm, 3})
+```
+
+This distinction makes lowering inspectable:
+
+```text
+ENIF/memref ABI path:
+  memref<..., #ptr.generic_space>
+    -> ptr.to_ptr
+    -> !ptr.ptr<#ptr.generic_space>
+    -> convert-to-llvm
+    -> !llvm.ptr                         (address space 0)
+
+Direct LLVM translation path:
+  !ptr.ptr<#llvm.address_space<N>>
+    -> MLIR LLVM translation
+    -> LLVM ptr addrspace(N)
+```
+
+Resource handles and `ERL_NIF_TERM` values are not raw addresses. Keep them in
+their declared integer/resource representation and cross into native pointer
+IR only through an API whose ownership and lifetime contract is explicit.

--- a/lib/beaver/enif.ex
+++ b/lib/beaver/enif.ex
@@ -19,6 +19,11 @@ defmodule Beaver.ENIF do
   this ensures the stability of the ABI and clarity of semantics.
   For instance, we should not generate IR to reinterpret a binary buffer to `memref<?xi8>` directly.
   Instead, we provide a function `inspect_binary_as_memref/1` to perform the conversion explicitly.
+  - `!ptr.ptr` is the IR-level native pointer representation. A
+  `Beaver.Native.OpaquePtr` or another BEAM resource remains a host-side owner or handle and must
+  cross only an explicit invocation or supplemental-function boundary; it is not an SSA value.
+  - Use `ptr.to_ptr` to pass memref-backed out-parameter storage to ENIF. Use a typed
+  `ptr.constant #ptr.null` for nullable C arguments instead of an unrealized cast from LLVM IR.
   - These functions and existing ENIF functions will be defined as an MLIR dialect in the future once IRDL is mature enough.
 
   ### Provided Functions

--- a/lib/beaver/mlir/dialect/ptr.ex
+++ b/lib/beaver/mlir/dialect/ptr.ex
@@ -1,0 +1,107 @@
+defmodule Beaver.MLIR.Dialect.Ptr do
+  @moduledoc """
+  Operations and construction helpers for MLIR's upstream Ptr dialect.
+
+  Ptr values model native pointers in IR. They are distinct from
+  `Beaver.Native.OpaquePtr` and other BEAM resources, which own or reference
+  host-side native data outside MLIR.
+
+  Use `type/1` with the generic memory space at high-level ABI boundaries such
+  as ENIF calls. Use an explicit LLVM address space when Ptr operations remain
+  in an `llvm.func` until LLVM IR translation:
+
+      Ptr.type()
+      Ptr.type(memory_space: {:llvm, 3})
+
+  `null/1` and `address/2` return typed attributes suitable for
+  `ptr.constant`.
+  """
+
+  alias Beaver.Deferred
+  alias Beaver.MLIR
+  alias Beaver.MLIR.{Attribute, Dialect, Type}
+
+  use Dialect, dialect: "ptr", ops: Dialect.Registry.ops("ptr")
+
+  @type memory_space ::
+          :generic
+          | non_neg_integer()
+          | {:llvm, non_neg_integer()}
+          | Deferred.attribute()
+
+  @doc "Return the upstream Ptr generic-memory-space attribute."
+  @spec generic_space(keyword()) :: Deferred.attribute()
+  def generic_space(opts \\ []) do
+    Attribute.get("#ptr.generic_space", opts)
+  end
+
+  @doc "Return an LLVM address-space attribute for a non-negative address-space number."
+  @spec llvm_address_space(non_neg_integer(), keyword()) :: Deferred.attribute()
+  def llvm_address_space(address_space, opts \\ [])
+
+  def llvm_address_space(address_space, opts)
+      when is_integer(address_space) and address_space >= 0 do
+    Attribute.get("#llvm.address_space<#{address_space}>", opts)
+  end
+
+  def llvm_address_space(address_space, _opts) do
+    raise ArgumentError,
+          "address space must be a non-negative integer, got: #{inspect(address_space)}"
+  end
+
+  @doc """
+  Return a `!ptr.ptr` type.
+
+  The default is `#ptr.generic_space`. Pass either an address-space number or
+  `{:llvm, address_space}` to make the LLVM address space explicit.
+  """
+  @spec type(keyword()) :: Deferred.type()
+  def type(opts \\ []) do
+    memory_space = Keyword.get(opts, :memory_space, :generic)
+
+    Deferred.from_opts(opts, fn ctx ->
+      memory_space = memory_space |> materialize_memory_space(ctx) |> MLIR.to_string()
+      Type.get("!ptr.ptr<#{memory_space}>", ctx: ctx)
+    end)
+  end
+
+  @doc "Return a typed `#ptr.null` attribute for `ptr.constant`."
+  @spec null(keyword()) :: Deferred.attribute()
+  def null(opts \\ []) do
+    constant_attribute("#ptr.null", opts)
+  end
+
+  @doc "Return a typed `#ptr.address` attribute for `ptr.constant`."
+  @spec address(non_neg_integer(), keyword()) :: Deferred.attribute()
+  def address(value, opts \\ [])
+
+  def address(value, opts) when is_integer(value) and value >= 0 do
+    constant_attribute("#ptr.address<#{value}>", opts)
+  end
+
+  def address(value, _opts) do
+    raise ArgumentError, "pointer address must be a non-negative integer, got: #{inspect(value)}"
+  end
+
+  defp constant_attribute(source, opts) do
+    pointer_type =
+      Keyword.get_lazy(opts, :type, fn ->
+        type(memory_space: Keyword.get(opts, :memory_space, :generic))
+      end)
+
+    Deferred.from_opts(opts, fn ctx ->
+      pointer_type = Deferred.create(pointer_type, ctx)
+      Attribute.get("#{source} : #{MLIR.to_string(pointer_type)}", ctx: ctx)
+    end)
+  end
+
+  defp materialize_memory_space(:generic, ctx), do: generic_space(ctx: ctx)
+
+  defp materialize_memory_space({:llvm, address_space}, ctx),
+    do: llvm_address_space(address_space, ctx: ctx)
+
+  defp materialize_memory_space(address_space, ctx) when is_integer(address_space),
+    do: llvm_address_space(address_space, ctx: ctx)
+
+  defp materialize_memory_space(memory_space, ctx), do: Deferred.create(memory_space, ctx)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -60,6 +60,7 @@ defmodule Beaver.MixProject do
         "guides/slang.md",
         "guides/dialect-conversion.md",
         "guides/action-tracing.md",
+        "guides/enif-pointer-interop.md",
         "CONTRIBUTING.md",
         "README.md"
       ],

--- a/test/enif_test.exs
+++ b/test/enif_test.exs
@@ -55,6 +55,17 @@ defmodule EnifTest do
   end
 
   test "enif send message", %{ctx: ctx} do
+    source =
+      ENIFSendMsg.create(ctx)
+      |> Beaver.ENIF.declare_external_functions()
+      |> MLIR.verify!()
+
+    source_ir = MLIR.to_string(source)
+    assert source_ir =~ "ptr.to_ptr"
+    assert source_ir =~ "ptr.constant #ptr.null"
+    refute source_ir =~ "builtin.unrealized_conversion_cast"
+    MLIR.Module.destroy(source)
+
     ENIFSendMsg.init(ctx)
     |> tap(fn %ENIFSupport{engine: e} ->
       invoker = &Beaver.ENIF.invoke(e, "send", [&1, &2])

--- a/test/ptr_test.exs
+++ b/test/ptr_test.exs
@@ -1,0 +1,135 @@
+defmodule PtrTest do
+  use Beaver.Case, async: true
+  use Beaver
+
+  alias Beaver.MLIR
+  alias MLIR.Dialect.{Func, Ptr}
+  require Func
+
+  @moduletag :smoke
+
+  @llvm_ptr_module """
+  module {
+    llvm.func @ptr_load_store(%ptr: !ptr.ptr<#llvm.address_space<0>>, %value: i64) -> i64 {
+      ptr.store %value, %ptr : i64, !ptr.ptr<#llvm.address_space<0>>
+      %loaded = ptr.load %ptr : !ptr.ptr<#llvm.address_space<0>> -> i64
+      llvm.return %loaded : i64
+    }
+
+    llvm.func @_mlir_ciface_ptr_load_store(%ptr: !ptr.ptr<#llvm.address_space<0>>, %value: i64) -> i64 attributes {llvm.emit_c_interface} {
+      %result = llvm.call @ptr_load_store(%ptr, %value) : (!ptr.ptr<#llvm.address_space<0>>, i64) -> i64
+      llvm.return %result : i64
+    }
+
+    llvm.func @ptr_distance(%ptr: !ptr.ptr<#llvm.address_space<0>>, %offset: i64) -> i64 {
+      %next = ptr.ptr_add %ptr, %offset : !ptr.ptr<#llvm.address_space<0>>, i64
+      %distance = ptr.ptr_diff %next, %ptr : !ptr.ptr<#llvm.address_space<0>> -> i64
+      llvm.return %distance : i64
+    }
+
+    llvm.func @_mlir_ciface_ptr_distance(%ptr: !ptr.ptr<#llvm.address_space<0>>, %offset: i64) -> i64 attributes {llvm.emit_c_interface} {
+      %result = llvm.call @ptr_distance(%ptr, %offset) : (!ptr.ptr<#llvm.address_space<0>>, i64) -> i64
+      llvm.return %result : i64
+    }
+
+    llvm.func @constant_distance() -> i64 {
+      %null = ptr.constant #ptr.null : !ptr.ptr<#llvm.address_space<0>>
+      %address = ptr.constant #ptr.address<0x10> : !ptr.ptr<#llvm.address_space<0>>
+      %distance = ptr.ptr_diff %address, %null : !ptr.ptr<#llvm.address_space<0>> -> i64
+      llvm.return %distance : i64
+    }
+
+    llvm.func @_mlir_ciface_constant_distance() -> i64 attributes {llvm.emit_c_interface} {
+      %result = llvm.call @constant_distance() : () -> i64
+      llvm.return %result : i64
+    }
+
+    llvm.func @vector_memory(
+        %ptr: !ptr.ptr<#llvm.address_space<3>>,
+        %ptrs: vector<4x!ptr.ptr<#llvm.address_space<3>>>,
+        %mask: vector<4xi1>,
+        %value: vector<4xf32>) -> vector<4xf32> {
+      %loaded = ptr.masked_load %ptr, %mask, %value alignment = 4 : !ptr.ptr<#llvm.address_space<3>> -> vector<4xf32>
+      ptr.masked_store %loaded, %ptr, %mask alignment = 4 : vector<4xf32>, !ptr.ptr<#llvm.address_space<3>>
+      %gathered = ptr.gather %ptrs, %mask, %value alignment = 4 : vector<4x!ptr.ptr<#llvm.address_space<3>>> -> vector<4xf32>
+      ptr.scatter %gathered, %ptrs, %mask alignment = 4 : vector<4xf32>, vector<4x!ptr.ptr<#llvm.address_space<3>>>
+      llvm.return %gathered : vector<4xf32>
+    }
+  }
+  """
+
+  test "constructs Ptr types and typed constants", %{ctx: ctx} do
+    assert Ptr.generic_space(ctx: ctx) |> MLIR.to_string() == "#ptr.generic_space"
+    assert Ptr.llvm_address_space(3, ctx: ctx) |> MLIR.to_string() == "#llvm.address_space<3>"
+    assert Ptr.type(ctx: ctx) |> MLIR.to_string() == "!ptr.ptr<#ptr.generic_space>"
+
+    assert Ptr.type(memory_space: {:llvm, 3}, ctx: ctx) |> MLIR.to_string() ==
+             "!ptr.ptr<#llvm.address_space<3>>"
+
+    assert Ptr.null(ctx: ctx) |> MLIR.to_string() ==
+             "#ptr.null : !ptr.ptr<#ptr.generic_space>"
+
+    assert Ptr.address(4096, memory_space: {:llvm, 1}, ctx: ctx) |> MLIR.to_string() ==
+             "#ptr.address<4096> : !ptr.ptr<#llvm.address_space<1>>"
+
+    assert_raise ArgumentError, fn -> Ptr.address(-1, ctx: ctx) end
+    assert_raise ArgumentError, fn -> Ptr.llvm_address_space(-1, ctx: ctx) end
+  end
+
+  test "constructs ptr.constant through the Beaver DSL", %{ctx: ctx} do
+    ptr_type = Ptr.type()
+
+    module =
+      mlir ctx: ctx do
+        module do
+          Func.func constants(function_type: Type.function([], [ptr_type, ptr_type])) do
+            region do
+              block _() do
+                null = Ptr.constant(value: Ptr.null(type: ptr_type)) >>> :infer
+                address = Ptr.constant(value: Ptr.address(0x1000, type: ptr_type)) >>> :infer
+                Func.return(null, address) >>> []
+              end
+            end
+          end
+        end
+      end
+      |> MLIR.verify!()
+
+    ir = MLIR.to_string(module)
+    assert ir =~ "ptr.constant #ptr.null"
+    assert ir =~ "ptr.constant #ptr.address<4096>"
+  end
+
+  test "executes scalar Ptr operations and translates shaped operations", %{ctx: ctx} do
+    MLIR.Context.register_translations(ctx)
+    module = MLIR.Module.create!(@llvm_ptr_module, ctx: ctx) |> MLIR.verify!()
+    engine = MLIR.ExecutionEngine.create!(module)
+
+    try do
+      storage = Beaver.Native.I64.make(1)
+      address = storage |> Beaver.Native.opaque_ptr() |> Beaver.Native.to_term()
+      pointer_argument = Beaver.Native.USize.make(address)
+      value = Beaver.Native.I64.make(42)
+      result = Beaver.Native.I64.make(0)
+
+      MLIR.ExecutionEngine.invoke!(engine, "ptr_load_store", [pointer_argument, value], result)
+      assert Beaver.Native.to_term(storage) == 42
+      assert Beaver.Native.to_term(result) == 42
+
+      offset = Beaver.Native.I64.make(24)
+      distance = Beaver.Native.I64.make(0)
+      MLIR.ExecutionEngine.invoke!(engine, "ptr_distance", [pointer_argument, offset], distance)
+      assert Beaver.Native.to_term(distance) == 24
+
+      constant_distance = Beaver.Native.I64.make(0)
+      MLIR.ExecutionEngine.invoke!(engine, "constant_distance", [], constant_distance)
+      assert Beaver.Native.to_term(constant_distance) == 16
+
+      assert %Beaver.Native.OpaquePtr{} =
+               MLIR.ExecutionEngine.lookup(engine, "vector_memory")
+    after
+      MLIR.ExecutionEngine.destroy(engine)
+      MLIR.Module.destroy(module)
+    end
+  end
+end

--- a/test/support/enif_send_msg.ex
+++ b/test/support/enif_send_msg.ex
@@ -2,7 +2,7 @@ defmodule ENIFSendMsg do
   @moduledoc false
   alias Beaver.ENIF
   use Beaver
-  alias MLIR.Dialect.{Func, Ptr, MemRef, LLVM, Builtin}
+  alias MLIR.Dialect.{Func, Ptr, MemRef}
   require Func
   use ENIFSupport
 
@@ -13,19 +13,18 @@ defmodule ENIFSendMsg do
         env_t = ENIF.Type.env(ctx: ctx)
         term_t = ENIF.Type.term()
         pid_t = ENIF.Type.pid(ctx: ctx)
+        ptr_t = Ptr.type()
+        generic_space = Ptr.generic_space()
 
         Func.func send(function_type: Type.function([env_t, term_t, term_t], [term_t])) do
           region do
             block _(env >>> env_t, pid_term >>> term_t, msg >>> term_t) do
               pid_ptr =
                 MemRef.alloca(operand_segment_sizes: :infer) >>>
-                  Type.memref!([1], pid_t, memory_space: ~a{#ptr.generic_space})
+                  Type.memref!([1], pid_t, memory_space: generic_space)
 
-              pid = Ptr.to_ptr(pid_ptr) >>> ~t{!ptr.ptr<#ptr.generic_space>}
-              null_env = LLVM.mlir_zero() >>> Type.llvm_pointer()
-
-              null_env =
-                Builtin.unrealized_conversion_cast(null_env) >>> ~t{!ptr.ptr<#ptr.generic_space>}
+              pid = Ptr.to_ptr(pid_ptr) >>> ptr_t
+              null_env = Ptr.constant(value: Ptr.null(type: ptr_t)) >>> ptr_t
 
               ENIF.get_local_pid(env, pid_term, pid) >>> :infer
               ENIF.send(env, pid, null_env, msg) >>> :infer


### PR DESCRIPTION
## Summary

- add first-class helpers for upstream Ptr types, generic/LLVM memory spaces, and typed null/raw-address constants
- migrate ENIF pointer examples to explicit `ptr.to_ptr` and `ptr.constant #ptr.null` boundaries
- document the distinction between Ptr SSA values, memrefs, and BEAM-owned native resources
- cover scalar load/store, pointer arithmetic/difference, and shaped masked/gather/scatter translation

## Why

The ENIF examples already used parts of the upstream Ptr dialect, but pointer types and attributes were still assembled through sigils and nullable arguments crossed an `unrealized_conversion_cast` from an LLVM zero. That obscured the ABI boundary and left address-space lowering untested.

This change keeps memref-backed storage as a memref until `ptr.to_ptr`, represents null and raw addresses with typed Ptr attributes, and makes LLVM address spaces explicit for operations translated directly from `llvm.func`.

## Impact

Native-extension code can construct Ptr types and constants without textual sigils, and the documented boundary prevents BEAM resources or ENIF handles from being treated as MLIR SSA pointers.

Closes #483.

## Validation

- `mix format --check-formatted`
- `mix test --warnings-as-errors --exclude vulkan --exclude todo` — 241 passed, 8 excluded
- `mix credo` — no issues
