### PR TITLE
Extract and test README code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Elixir could actually be a good fit as a MLIR front end. Elixir has SSA, pattern
 
 To build a piece of IR in Beaver:
 
+<!-- beaver:test:dsl -->
 ```elixir
 Func.func some_func(function_type: Type.function([], [Type.i(32)])) do
   region do
@@ -41,12 +42,12 @@ end
 
 And a small example to showcase what it is like to define and run a pass in Beaver (with some monad magic):
 
+<!-- beaver:test:pass -->
 ```elixir
 defmodule ToyPass do
   @moduledoc false
   use Beaver
-  alias MLIR.Dialect.{Func, TOSA}
-  require Func
+  alias MLIR.Dialect.TOSA
   import Beaver.Pattern
   use MLIR.Pass, on: "builtin.module"
 
@@ -186,14 +187,19 @@ Because Erlang/Elixir is SSA by its nature, in Beaver a MLIR Op's creation is ve
 
 One example:
 
+<!-- beaver:test:module -->
 ```elixir
 module do
-  v2 = Arith.constant(1) >>> ~t<i32>
+  _v2 = Arith.constant(value: ~a{1 : i32}) >>> ~t<i32>
 end
-# module/1 is a macro, it will transformed the SSA `v2= Arith.constant..` to:
+```
+
+`module/1` is a macro; it transforms the SSA expression above to:
+
+```elixir
 v2 =
  %Beaver.SSA{}
-  |> Beaver.SSA.put_arguments(value: ~a{1})
+  |> Beaver.SSA.put_arguments(value: ~a{1 : i32})
   |> Beaver.SSA.put_ip(Beaver.Env.block())
   |> Beaver.SSA.put_ctx(Beaver.Env.context())
   |> Beaver.SSA.put_results(~t<i32>)

--- a/test/readme_test.exs
+++ b/test/readme_test.exs
@@ -1,0 +1,130 @@
+defmodule ReadmeTest do
+  use Beaver.Case, async: true
+
+  alias Beaver.MLIR
+
+  @moduletag :smoke
+
+  @readme Path.expand("../README.md", __DIR__)
+
+  test "README SSA DSL example", %{ctx: ctx} do
+    code = block!("dsl")
+    mod = compile_module!(dsl_module_source(code))
+    assert %MLIR.Module{} = result = mod.build(ctx)
+    assert MLIR.to_string(result) =~ "func.func @some_func"
+  end
+
+  test "README pass example", %{ctx: ctx} do
+    code = block!("pass")
+    pass_mod = unique_mod("ReadmePass")
+
+    [pass_source, pipeline] = String.split(code, "\nuse Beaver\n", parts: 2)
+
+    pass_source =
+      pass_source
+      |> String.replace("ToyPass", Atom.to_string(pass_mod))
+
+    compile_module!(pass_source)
+
+    pipeline =
+      pipeline
+      |> String.replace("import MLIR.Transform\n", "")
+      |> String.replace("ctx = MLIR.Context.create()\n", "")
+      |> String.replace("ToyPass", Atom.to_string(pass_mod))
+
+    runner = compile_module!(pass_runner_module_source(pipeline))
+    assert %MLIR.Module{} = result = runner.run(ctx)
+
+    ir = MLIR.to_string(result)
+    assert ir =~ "func.func @tosa_add"
+    assert ir =~ "tosa.sub"
+    refute ir =~ "tosa.add"
+  end
+
+  test "README module macro example", %{ctx: ctx} do
+    code = block!("module")
+    mod = compile_module!(module_macro_module_source(code))
+    assert %MLIR.Module{} = result = mod.build(ctx)
+    assert MLIR.to_string(result) =~ "arith.constant"
+  end
+
+  defp block!(marker) do
+    pattern = ~r/<!--\s*beaver:test:#{marker}\s*-->[\s\S]*?```elixir\n(.*?)```/s
+
+    case Regex.run(pattern, File.read!(@readme), capture: :all_but_first) do
+      [code] -> code
+      _ -> raise "missing beaver:test:#{marker} block in README"
+    end
+  end
+
+  defp dsl_module_source(code) do
+    mod = unique_mod("ReadmeDsl")
+
+    """
+    defmodule #{mod} do
+      use Beaver
+      alias Beaver.MLIR.{Attribute, Type}
+      alias Beaver.MLIR.Dialect.{Func, Arith, CF}
+      require Func
+
+      def build(ctx) do
+        mlir ctx: ctx do
+          module do
+            #{indent(code, 10)}
+          end
+        end
+      end
+    end
+    """
+  end
+
+  defp pass_runner_module_source(pipeline) do
+    mod = unique_mod("ReadmePassRunner")
+
+    """
+    defmodule #{mod} do
+      use Beaver
+      import MLIR.Transform
+
+      def run(ctx) do
+        #{indent(pipeline, 8)}
+      end
+    end
+    """
+  end
+
+  defp module_macro_module_source(code) do
+    mod = unique_mod("ReadmeModuleMacro")
+
+    """
+    defmodule #{mod} do
+      use Beaver
+      alias Beaver.MLIR.Dialect.Arith
+
+      def build(ctx) do
+        mlir ctx: ctx do
+          #{indent(code, 10)}
+        end
+      end
+    end
+    """
+  end
+
+  defp compile_module!(source) do
+    case Code.compile_string(source) do
+      [{module, _bytecode} | _] -> module
+      _ -> raise "failed to compile README snippet module"
+    end
+  end
+
+  defp unique_mod(prefix) do
+    Module.concat([__MODULE__, "#{prefix}#{System.unique_integer([:positive])}"])
+  end
+
+  defp indent(code, spaces) do
+    code
+    |> String.trim_trailing()
+    |> String.split("\n")
+    |> Enum.map_join("\n", &(String.duplicate(" ", spaces) <> &1))
+  end
+end


### PR DESCRIPTION
Turns the runnable Elixir blocks in `README.md` into tests, so docs examples can't drift from working code.

## What

- `test/readme_test.exs` reads `README.md` at test time, extracts the fenced blocks marked with `<!-- beaver:test:dsl -->`, `<!-- beaver:test:pass -->` and `<!-- beaver:test:module -->` (invisible HTML comments), wraps each in a uniquely-named module, compiles it, and asserts the IR it builds:
  - SSA DSL example → `func.func` with blocks + control flow,
  - ToyPass example → compiles the pass from the README, runs it on a `tosa.add` module through a canonicalize pipeline, asserts `tosa.sub` and no `tosa.add`,
  - module macro example → `arith.constant` IR.
- If a marked block disappears or becomes unrunnable, the test fails loudly.

## README fixes surfaced by the tests

- `Arith.constant(1)` is not a valid positional argument; the example now uses `Arith.constant(value: ~a{1 : i32})` (and the expansion comment matches).
- `ToyPass` aliased/required `Func` without using it; the README now matches `test/support/toy_pass.ex` (`alias MLIR.Dialect.TOSA` only).
- Split the "module macro" example into a runnable snippet and a separate illustrative expansion block.

## Validation

- `mix test --warnings-as-errors --exclude vulkan --exclude todo` → 244 passed
- `mix format --check-formatted`, `mix credo` clean