### PR TITLE
Add Triton core prebuilt build pipeline

### DIFF
--- a/.github/workflows/triton-prebuilt.yml
+++ b/.github/workflows/triton-prebuilt.yml
@@ -1,0 +1,97 @@
+name: Build Triton prebuilt
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: triton-prebuilt-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  KINDA_REF: "cd9dfbf1734f1ee09a544c18a97840d247983257"
+  TRITON_REF: "882eb72e1858bfd588fafa4677b86ce00e9da872"
+
+jobs:
+  build:
+    name: triton-prebuilt-${{ matrix.os }}-${{ matrix.arch }}
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu
+            arch: x86_64
+            runs-on: ubuntu-22.04
+          - os: macos
+            arch: arm64
+            runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+        name: Check out Beaver
+
+      - uses: actions/checkout@v4
+        name: Check out Triton
+        with:
+          repository: triton-lang/triton
+          path: third_party/triton
+          ref: ${{ env.TRITON_REF }}
+
+      - uses: actions/checkout@v4
+        name: Check out paired Kinda
+        with:
+          repository: beaver-lodge/kinda
+          path: kinda
+          ref: ${{ env.KINDA_REF }}
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27.3"
+          elixir-version: "1.20.3"
+
+      - name: Set up Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+
+      - uses: seanmiddleditch/gha-setup-ninja@master
+
+      - name: Install Triton-pinned LLVM prebuilt
+        run: |
+          cd scripts/install_llvm
+          mix beaver.install_prebuilt_llvm --triton --install-dir "$RUNNER_TEMP/llvm-prebuilt"
+
+      - name: Build Triton core libraries
+        env:
+          TRITON_SOURCE_DIR: ${{ github.workspace }}/third_party/triton
+          LLVM_SYSPATH: ${{ runner.temp }}/llvm-prebuilt
+          TRITON_PREBUILT_OUTPUT_DIR: ${{ runner.temp }}/triton-out
+          TRITON_CACHE_PATH: ${{ runner.temp }}/triton-cache
+        run: |
+          bash scripts/build-triton-prebuilt.sh
+
+      - name: Package Triton prebuilt
+        run: |
+          cd "$RUNNER_TEMP/triton-out"
+          tar czf "$RUNNER_TEMP/triton-${{ env.TRITON_REF }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz" .
+          ls -lh "$RUNNER_TEMP"/*.tar.gz
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: triton-${{ env.TRITON_REF }}-${{ matrix.os }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/triton-*.tar.gz
+
+      - name: Publish release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="triton-prebuilt-${{ env.TRITON_REF }}"
+          asset="$RUNNER_TEMP/triton-${{ env.TRITON_REF }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz"
+          gh release create "${tag}" --repo beaver-lodge/beaver \
+            --title "Triton core prebuilt @ ${{ env.TRITON_REF }}" \
+            --notes "Core Triton dialects/passes/conversions built against the Triton-pinned LLVM." \
+            || true
+          gh release upload "${tag}" "${asset}" --repo beaver-lodge/beaver --clobber

--- a/scripts/build-triton-prebuilt.sh
+++ b/scripts/build-triton-prebuilt.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Builds Triton's core compiler libraries (dialects, passes, conversions) as a
+# relocatable prebuilt for Beaver. Compiled on CI so the developer machine only
+# downloads and links; no LLVM source build, no Python module, no GPU backend.
+set -euo pipefail
+
+triton_dir="${TRITON_SOURCE_DIR:?TRITON_SOURCE_DIR is required}"
+llvm_syspath="${LLVM_SYSPATH:?LLVM_SYSPATH is required}"
+output_dir="${TRITON_PREBUILT_OUTPUT_DIR:?TRITON_PREBUILT_OUTPUT_DIR is required}"
+llvm_config="${llvm_syspath}/bin/llvm-config"
+mlir_dir="$("${llvm_config}" --libdir)/cmake/mlir"
+llvm_dir="$("${llvm_config}" --libdir)/cmake/llvm"
+ccache="${TRITON_BUILD_WITH_CCACHE:-ON}"
+
+build_dir="$(mktemp -d "${TMPDIR:-/tmp}/triton-build.XXXXXX")"
+cleanup() {
+  rm -rf "${build_dir}"
+}
+trap cleanup EXIT
+
+echo "Configuring Triton at ${triton_dir} against ${llvm_syspath}"
+cmake -S "${triton_dir}" -B "${build_dir}" -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DTRITON_BUILD_PYTHON_MODULE=OFF \
+  -DTRITON_BUILD_UT=OFF \
+  -DTRITON_BUILD_PROTON=OFF \
+  -DTRITON_BUILD_WITH_CCACHE="${ccache}" \
+  -DTRITON_CACHE_PATH="${TRITON_CACHE_PATH:-${HOME}/.triton}" \
+  -DLLVM_SYSPATH="${llvm_syspath}" \
+  -DMLIR_DIR="${mlir_dir}" \
+  -DLLVM_DIR="${llvm_dir}"
+
+# Core dialect/pass/conversion libraries. These are OBJECT libraries in
+# Triton; the archive step below bundles their objects into one library.
+core_targets=(
+  TritonIR
+  TritonGPUIR
+  TritonNvidiaGPUIR
+  TritonInstrumentIR
+  GluonIR
+  TritonTransforms
+  TritonGPUTransforms
+  TritonNvidiaGPUTransforms
+  TritonInstrumentTransforms
+  GluonTransforms
+  TritonToTritonGPU
+  TritonGPUToLLVM
+  TritonInstrumentToLLVM
+  TritonLLVMIR
+  TritonAnalysis
+  TritonTools
+)
+
+echo "Building ${#core_targets[@]} Triton core targets"
+ninja -C "${build_dir}" "${core_targets[@]}"
+
+mkdir -p "${output_dir}/lib" "${output_dir}/include"
+
+echo "Bundling Triton object libraries"
+mapfile -t objects < <(find "${build_dir}/lib" -path '*CMakeFiles/*.dir/*.o')
+if ((${#objects[@]} == 0)); then
+  echo "no Triton object files found under ${build_dir}/lib" >&2
+  exit 1
+fi
+
+case "$(uname -s)" in
+  Darwin)
+    libtool -static -o "${output_dir}/lib/libtriton_core.a" "${objects[@]}"
+    ;;
+  Linux)
+    ar rcs "${output_dir}/lib/libtriton_core.a" "${objects[@]}"
+    ;;
+  *)
+    echo "unsupported platform for Triton prebuilt archive" >&2
+    exit 1
+    ;;
+esac
+
+echo "Copying Triton headers"
+cp -R "${triton_dir}/include"/. "${output_dir}/include"/
+cp -R "${build_dir}/include"/. "${output_dir}/include"/
+
+echo "Triton prebuilt at ${output_dir}"
+find "${output_dir}" -maxdepth 2 -type d | head -20

--- a/scripts/build-triton-prebuilt.sh
+++ b/scripts/build-triton-prebuilt.sh
@@ -57,9 +57,11 @@ ninja -C "${build_dir}" "${core_targets[@]}"
 mkdir -p "${output_dir}/lib" "${output_dir}/include"
 
 echo "Bundling Triton object libraries"
-mapfile -t objects < <(find "${build_dir}/lib" -path '*CMakeFiles/*.dir/*.o')
+mapfile -t objects < <(
+  find "${build_dir}/lib" "${build_dir}/third_party" -path '*CMakeFiles/*.dir/*.o' 2>/dev/null
+)
 if ((${#objects[@]} == 0)); then
-  echo "no Triton object files found under ${build_dir}/lib" >&2
+  echo "no Triton object files found under ${build_dir}" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Part of #491. Triton's core compiler libraries (dialects/passes/conversions) have no official prebuilt distribution, and building them locally is heavy. This adds a workflow that compiles them on GitHub Actions (ubuntu x64 + macOS arm64) against the Triton-pinned LLVM and publishes `libtriton_core.a` + headers as a release asset, so developer machines only download and link.

- `scripts/build-triton-prebuilt.sh`: configures Triton with `TRITON_BUILD_PYTHON_MODULE=OFF` (core only, no GPU backends), builds the core object libraries, bundles them into `libtriton_core.a`, copies source + tablegen'd headers.
- `.github/workflows/triton-prebuilt.yml`: `workflow_dispatch`; installs the Triton-pinned LLVM via `beaver.install_prebuilt_llvm --triton`, builds, uploads artifact + publishes release asset `triton-prebuilt-<triton-sha>-<os>-<arch>.tar.gz`.

Verified locally: Triton CMake configures cleanly against the Triton-pinned LLVM with these options, `TritonIR` builds, and the object→archive bundling works.