### PR TITLE
Add a scoped declarative Conversion Plan API

### DIFF
--- a/guides/dialect-conversion.md
+++ b/guides/dialect-conversion.md
@@ -1,12 +1,14 @@
 # Lowering a Slang dialect
 
 Beaver exposes MLIR's dialect conversion driver without requiring a native
-pass. The conversion target, type converter, and patterns below are all built
-in Elixir; the driver still runs on the context's native worker pool.
+pass. `Beaver.MLIR.Conversion.Plan` provides a declarative, inspectable, and
+scoped composition layer over conversion targets, type converters, materializations,
+and conversion patterns. The conversion pipeline is declared in Elixir, while
+the conversion driver runs on the context's native worker pool.
 
 This example defines a small Slang operation and lowers it to the `arith`
-dialect. The resulting IR can then use MLIR's standard `arith`-to-LLVM and
-`func`-to-LLVM passes.
+dialect using a `Conversion.Plan`. The resulting IR can then use MLIR's standard
+`arith`-to-LLVM and `func`-to-LLVM passes.
 
 ```elixir
 defmodule Counter do
@@ -34,77 +36,105 @@ module =
     ctx: ctx
   )
 
-target =
-  MLIR.ConversionTarget.create(ctx)
-  |> MLIR.ConversionTarget.add_legal_dialect("builtin")
-  |> MLIR.ConversionTarget.add_legal_dialect("func")
-  |> MLIR.ConversionTarget.add_legal_dialect("arith")
-  |> MLIR.ConversionTarget.add_illegal_dialect("counter")
+# Define a declarative, reusable conversion plan
+plan =
+  MLIR.Conversion.Plan.new(
+    mode: :full,
+    folding_mode: :after_patterns,
+    build_materializations: true
+  )
+  |> MLIR.Conversion.Plan.add_legal_dialect("builtin")
+  |> MLIR.Conversion.Plan.add_legal_dialect("func")
+  |> MLIR.Conversion.Plan.add_legal_dialect("arith")
+  |> MLIR.Conversion.Plan.add_illegal_dialect("counter")
+  |> MLIR.Conversion.Plan.add_conversion(fn type -> type end, version: "1.0")
+  |> MLIR.Conversion.Plan.add_conversion_pattern(
+    "counter.inc",
+    fn operation, [input], rewriter ->
+      context = MLIR.context(operation)
+      base = MLIR.ConversionPatternRewriter.as_base(rewriter)
+      type = MLIR.Value.type(input)
+      location = MLIR.Operation.location(operation)
 
-# Identity conversion keeps i32 unchanged. A callback may instead return a
-# list of types through add_1_to_n_conversion/2.
-converter = MLIR.TypeConverter.create(conversion: fn type -> type end)
-patterns = MLIR.RewritePatternSet.create(ctx)
+      one =
+        %Beaver.Changeset{name: "arith.constant", context: context, location: location}
+        |> Beaver.Changeset.add_argument(value: MLIR.Attribute.integer(type, 1))
+        |> Beaver.Changeset.add_result(type)
+        |> MLIR.Operation.create()
 
-MLIR.ConversionPattern.add(
-  patterns,
-  "counter.inc",
-  converter,
-  fn operation, [input], rewriter ->
-    base = MLIR.ConversionPatternRewriter.as_base(rewriter)
-    type = MLIR.Value.type(input)
-    location = MLIR.Operation.location(operation)
+      add =
+        %Beaver.Changeset{name: "arith.addi", context: context, location: location}
+        |> Beaver.Changeset.add_argument([input, MLIR.Operation.result(one, 0)])
+        |> Beaver.Changeset.add_result(type)
+        |> MLIR.Operation.create()
 
-    one =
-      %Beaver.Changeset{name: "arith.constant", context: ctx, location: location}
-      |> Beaver.Changeset.add_argument(value: MLIR.Attribute.integer(type, 1))
-      |> Beaver.Changeset.add_result(type)
-      |> MLIR.Operation.create()
+      MLIR.RewriterBase.set_insertion_point_before(base, operation)
+      MLIR.RewriterBase.insert(base, one)
+      MLIR.RewriterBase.insert(base, add)
+      MLIR.ConversionPatternRewriter.replace_op(rewriter, operation, add)
+      :ok
+    end,
+    version: "1.0"
+  )
 
-    add =
-      %Beaver.Changeset{name: "arith.addi", context: ctx, location: location}
-      |> Beaver.Changeset.add_argument([input, MLIR.Operation.result(one, 0)])
-      |> Beaver.Changeset.add_result(type)
-      |> MLIR.Operation.create()
+# Execute the plan. Native target, converter, and pattern set are allocated
+# and cleaned up automatically for the duration of the run.
+{:ok, ^module, _diagnostics} = MLIR.Conversion.Plan.run(plan, module)
 
-    MLIR.RewriterBase.set_insertion_point_before(base, operation)
-    MLIR.RewriterBase.insert(base, one)
-    MLIR.RewriterBase.insert(base, add)
-    MLIR.ConversionPatternRewriter.replace_op(rewriter, operation, add)
-    :ok
-  end,
-  ctx: ctx
+# The custom dialect is gone. Continue with upstream conversion passes.
+pass_manager = MLIR.CAPI.mlirPassManagerCreate(ctx)
+
+MLIR.CAPI.mlirPassManagerAddOwnedPass(
+  pass_manager,
+  MLIR.CAPI.mlirCreateConversionArithToLLVMConversionPass()
 )
 
-try do
-  {:ok, ^module, diagnostics} =
-    MLIR.Conversion.full(module, target, patterns,
-      folding_mode: :after_patterns,
-      build_materializations: true
-    )
+MLIR.CAPI.mlirPassManagerAddOwnedPass(
+  pass_manager,
+  MLIR.CAPI.mlirCreateConversionConvertFuncToLLVMPass()
+)
 
-  # The custom dialect is gone. Continue with upstream conversion passes.
-  pass_manager = MLIR.CAPI.mlirPassManagerCreate(ctx)
-
-  MLIR.CAPI.mlirPassManagerAddOwnedPass(
-    pass_manager,
-    MLIR.CAPI.mlirCreateConversionArithToLLVMConversionPass()
-  )
-
-  MLIR.CAPI.mlirPassManagerAddOwnedPass(
-    pass_manager,
-    MLIR.CAPI.mlirCreateConversionConvertFuncToLLVMPass()
-  )
-
-  {:ok, _pass_diagnostics} = MLIR.PassManager.run(pass_manager, module)
-  MLIR.PassManager.destroy(pass_manager)
-after
-  # Destroy the frozen/pattern set before its referenced converter. Passing a
-  # mutable set to Conversion.full/4 does this automatically.
-  MLIR.TypeConverter.destroy(converter)
-  MLIR.ConversionTarget.destroy(target)
-end
+{:ok, _pass_diagnostics} = MLIR.PassManager.run(pass_manager, module)
+MLIR.PassManager.destroy(pass_manager)
 ```
+
+## Plan Inspection and Callback Versioning
+
+`MLIR.Conversion.Plan.declaration/1` returns a deterministic map of plan metadata
+with function closures and runtime state omitted:
+
+```elixir
+decl = MLIR.Conversion.Plan.declaration(plan)
+# => %{
+#   mode: :full,
+#   timeout: 30000,
+#   folding_mode: :after_patterns,
+#   build_materializations: true,
+#   entries: [
+#     %{kind: :add_legal_dialect, dialect: "builtin"},
+#     ...,
+#     %{kind: :add_conversion, version: "1.0"},
+#     %{kind: :add_conversion_pattern, root: "counter.inc", benefit: 1, one_to_n: false, timeout: nil, version: "1.0"}
+#   ]
+# }
+```
+
+Callbacks registered with plan builders accept optional `:version` metadata.
+When `:version` is omitted, the callback is visibly marked `:unversioned`.
+Declaration metadata is only deterministic and reproducible across runs or processes
+when callback versions are explicitly specified.
+
+## Resource Ownership, Borrowing, and Timeout
+
+`Conversion.Plan` structs do not hold native resources; a single plan can be
+safely reused across multiple fresh `MLIR.Context` instances.
+
+When `Plan.run/2` or `Plan.run!/2` executes:
+
+1. Fresh native `MLIR.ConversionTarget`, `MLIR.TypeConverter`, and `MLIR.RewritePatternSet` objects are created.
+2. Target legality rules, conversions, materializations, and patterns are populated in declaration order.
+3. Conversion runs with the specified `:timeout` (default 30,000 ms).
+4. The mutable pattern set is transferred to `Conversion.apply/5`; its native worker releases the frozen set even if the caller terminates. On a normal or error return, the remaining resources are then released in reverse dependency order: pattern set, type converter, conversion target.
 
 ## Dynamic legality
 
@@ -112,13 +142,14 @@ Static legality applies to every instance of an operation or dialect. For an
 instance-dependent decision, register a callback:
 
 ```elixir
-target =
-  MLIR.ConversionTarget.add_dynamically_legal_op(
-    target,
+plan =
+  MLIR.Conversion.Plan.add_dynamically_legal_op(
+    plan,
     "counter.inc",
     fn operation ->
       if safe_to_keep?(operation), do: :legal, else: :no_opinion
-    end
+    end,
+    version: "1.0"
   )
 ```
 
@@ -126,22 +157,55 @@ Callbacks may return `:legal`, `:illegal`, or `:no_opinion`. Exceptions and
 `{:error, reason}` results are preserved in `Beaver.MLIR.Conversion.Error`
 rather than being flattened into a generic MLIR failure.
 
+## Native rewrite descriptors
+
+A plan can include descriptors produced by `Beaver.Pattern.Native.defrewrite/3`:
+
+```elixir
+plan =
+  MLIR.Conversion.Plan.add_pattern(
+    plan,
+    MyNativePatterns.lower_counter(),
+    version: "1.0"
+  )
+```
+
+This composes with the existing callback-backed Native DSL; `Conversion.Plan`
+does not introduce another matching language. Use `add_conversion_pattern/4`
+when a rewrite needs type-converted operand adaptors, and `add_pattern/3` for an
+ordinary Native descriptor. Declaration metadata records the descriptor name,
+root, benefit, and explicit version, but omits its callbacks and runtime state.
+
 ## 1:N conversion and materialization
 
-Use `TypeConverter.add_1_to_n_conversion/2` to return zero, one, or several
+Use `Plan.add_1_to_n_conversion/3` to return zero, one, or several
 target types. A conversion pattern created with `one_to_n: true` receives one
 list of converted values per original operand and can replace each result with
 a value range through
 `ConversionPatternRewriter.replace_op_with_multiple/3`.
 
-Source, target, and 1:N target materializations are registered with
-`add_source_materialization/2`, `add_target_materialization/2`, and
-`add_1_to_n_target_materialization/2`. Their rewriter, values, types, and
+Source, target, and 1:N target materializations are registered on the plan with
+`Plan.add_source_materialization/3`, `Plan.add_target_materialization/3`, and
+`Plan.add_1_to_n_target_materialization/3`. Their rewriter, values, types, and
 locations are scoped to the callback. Do not retain those handles after the
 callback returns.
 
-Targets and type converters are explicit native owners. The native conversion
-worker cleans up its `ConversionConfig` and any mutable pattern set frozen by
-`Conversion.apply/5`, even if the calling process terminates. Standalone
-targets and converters should use `ConversionTarget.with/3`,
-`TypeConverter.with/2`, or an equivalent `try/after` as shown above.
+## Low-Level Escape Hatch
+
+For advanced scenarios requiring manual resource lifecycle management, low-level
+APIs (`MLIR.ConversionTarget`, `MLIR.TypeConverter`, `MLIR.RewritePatternSet`, and
+`MLIR.Conversion.apply/5`) remain fully supported:
+
+```elixir
+target = MLIR.ConversionTarget.create(ctx)
+converter = MLIR.TypeConverter.create(conversion: fn type -> type end)
+patterns = MLIR.RewritePatternSet.create(ctx)
+MLIR.ConversionPattern.add(patterns, "counter.inc", converter, callback, ctx: ctx)
+
+try do
+  {:ok, ^module, _diagnostics} = MLIR.Conversion.full(module, target, patterns)
+after
+  MLIR.TypeConverter.destroy(converter)
+  MLIR.ConversionTarget.destroy(target)
+end
+```

--- a/lib/beaver/mlir/conversion.ex
+++ b/lib/beaver/mlir/conversion.ex
@@ -2,6 +2,8 @@ defmodule Beaver.MLIR.Conversion do
   @moduledoc """
   High-level, diagnostic-aware MLIR dialect conversion.
 
+  For a declarative, inspectable, and reusable pipeline, see `Beaver.MLIR.Conversion.Plan`.
+
   `apply/5` runs full or partial conversion outside BEAM scheduler threads and
   services callback-backed targets, type converters, and conversion patterns
   in the calling process. Mutable pattern sets are frozen and cleaned up

--- a/lib/beaver/mlir/conversion/plan.ex
+++ b/lib/beaver/mlir/conversion/plan.ex
@@ -1,0 +1,629 @@
+defmodule Beaver.MLIR.Conversion.Plan do
+  @moduledoc """
+  An inspectable, declarative, scoped composition layer for MLIR dialect conversion.
+
+  A conversion plan records target legality rules, type conversions, materializations,
+  and rewrite patterns into a reusable data structure. When executed via `run/2`
+  or `run!/2`, the plan materializes fresh conversion targets, type converters,
+  and pattern sets in declaration order for the target `MLIR.Context`.
+
+  ## Callbacks and Metadata
+
+  Callbacks registered with plan builders accept optional `:version` metadata.
+  `declaration/1` returns a deterministic map of plan configuration and step
+  metadata with function bodies and runtime state omitted. Unversioned callbacks
+  are marked as `:unversioned`. This metadata is only reproducible across runs
+  when callback versions are explicitly provided.
+
+  ## Ownership & Scoping
+
+  Plans do not hold native handles; they can be safely reused across multiple
+  MLIR contexts. During `run/2`, temporary native resources (`MLIR.ConversionTarget`,
+  `MLIR.TypeConverter`, `MLIR.RewritePatternSet`) are created and cleaned up.
+  In case of errors or caller termination, resources are cleaned up deterministically:
+  pattern destruction occurs before type converter destruction, which occurs before
+  conversion target destruction.
+  """
+
+  alias Beaver.MLIR
+  alias Beaver.Pattern.Native.Descriptor
+
+  defstruct mode: :full,
+            timeout: 30_000,
+            folding_mode: nil,
+            build_materializations: nil,
+            entries: []
+
+  @type mode() :: :full | :partial
+  @type option() ::
+          {:mode, mode()}
+          | {:timeout, non_neg_integer() | nil}
+          | {:folding_mode, :never | :before_patterns | :after_patterns | nil}
+          | {:build_materializations, boolean() | nil}
+
+  @type t() :: %__MODULE__{
+          mode: mode(),
+          timeout: non_neg_integer() | nil,
+          folding_mode: :never | :before_patterns | :after_patterns | nil,
+          build_materializations: boolean() | nil,
+          entries: [term()]
+        }
+
+  @doc """
+  Creates a new conversion plan.
+
+  Options:
+    * `:mode` - `:full` (default) or `:partial`.
+    * `:timeout` - Timeout in milliseconds for conversion and callbacks (default `30_000`).
+    * `:folding_mode` - `:never`, `:before_patterns`, `:after_patterns`, or `nil`.
+    * `:build_materializations` - boolean or `nil`.
+  """
+  @spec new(keyword()) :: t()
+  def new(opts \\ []) when is_list(opts) do
+    validate_plan_options!(opts)
+
+    mode = opts |> Keyword.get(:mode, :full) |> validate_mode!()
+    timeout = opts |> Keyword.get(:timeout, 30_000) |> validate_plan_timeout!()
+    folding_mode = opts |> Keyword.get(:folding_mode) |> validate_folding_mode!()
+
+    build_materializations =
+      opts
+      |> Keyword.get(:build_materializations)
+      |> validate_build_materializations!()
+
+    %__MODULE__{
+      mode: mode,
+      timeout: timeout,
+      folding_mode: folding_mode,
+      build_materializations: build_materializations,
+      entries: []
+    }
+  end
+
+  @spec add_legal_op(t(), String.Chars.t()) :: t()
+  def add_legal_op(%__MODULE__{} = plan, name) do
+    append_entry(plan, {:add_legal_op, to_string(name)})
+  end
+
+  @spec add_illegal_op(t(), String.Chars.t()) :: t()
+  def add_illegal_op(%__MODULE__{} = plan, name) do
+    append_entry(plan, {:add_illegal_op, to_string(name)})
+  end
+
+  @spec add_legal_dialect(t(), String.Chars.t()) :: t()
+  def add_legal_dialect(%__MODULE__{} = plan, name) do
+    append_entry(plan, {:add_legal_dialect, to_string(name)})
+  end
+
+  @spec add_illegal_dialect(t(), String.Chars.t()) :: t()
+  def add_illegal_dialect(%__MODULE__{} = plan, name) do
+    append_entry(plan, {:add_illegal_dialect, to_string(name)})
+  end
+
+  @spec add_dynamically_legal_op(
+          t(),
+          String.Chars.t(),
+          MLIR.ConversionTarget.legality_callback(),
+          keyword()
+        ) :: t()
+  def add_dynamically_legal_op(%__MODULE__{} = plan, name, callback, opts \\ [])
+      when is_function(callback, 1) do
+    opts = validate_callback_opts!(opts, [:version], "add_dynamically_legal_op")
+    append_entry(plan, {:add_dynamically_legal_op, to_string(name), callback, opts})
+  end
+
+  @spec add_dynamically_legal_dialect(
+          t(),
+          String.Chars.t(),
+          MLIR.ConversionTarget.legality_callback(),
+          keyword()
+        ) :: t()
+  def add_dynamically_legal_dialect(%__MODULE__{} = plan, name, callback, opts \\ [])
+      when is_function(callback, 1) do
+    opts = validate_callback_opts!(opts, [:version], "add_dynamically_legal_dialect")
+    append_entry(plan, {:add_dynamically_legal_dialect, to_string(name), callback, opts})
+  end
+
+  @spec mark_recursively_legal(
+          t(),
+          String.Chars.t(),
+          MLIR.ConversionTarget.legality_callback() | nil | keyword(),
+          keyword()
+        ) :: t()
+  def mark_recursively_legal(plan, name, callback_or_opts \\ nil, opts \\ [])
+
+  def mark_recursively_legal(%__MODULE__{} = plan, name, opts, []) when is_list(opts) do
+    opts = validate_callback_opts!(opts, [:version], "mark_recursively_legal")
+    append_entry(plan, {:mark_recursively_legal, to_string(name), nil, opts})
+  end
+
+  def mark_recursively_legal(%__MODULE__{} = plan, name, callback, opts)
+      when is_nil(callback) or is_function(callback, 1) do
+    opts = validate_callback_opts!(opts, [:version], "mark_recursively_legal")
+    append_entry(plan, {:mark_recursively_legal, to_string(name), callback, opts})
+  end
+
+  @spec mark_unknown_dynamically_legal(
+          t(),
+          MLIR.ConversionTarget.legality_callback(),
+          keyword()
+        ) :: t()
+  def mark_unknown_dynamically_legal(%__MODULE__{} = plan, callback, opts \\ [])
+      when is_function(callback, 1) do
+    opts = validate_callback_opts!(opts, [:version], "mark_unknown_dynamically_legal")
+    append_entry(plan, {:mark_unknown_dynamically_legal, callback, opts})
+  end
+
+  @spec add_conversion(
+          t(),
+          (MLIR.Type.t() -> MLIR.TypeConverter.conversion_result()),
+          keyword()
+        ) :: t()
+  def add_conversion(%__MODULE__{} = plan, callback, opts \\ [])
+      when is_function(callback, 1) do
+    opts = validate_callback_opts!(opts, [:version], "add_conversion")
+    append_entry(plan, {:add_conversion, callback, opts})
+  end
+
+  @spec add_1_to_n_conversion(
+          t(),
+          (MLIR.Type.t() -> MLIR.TypeConverter.one_to_n_result()),
+          keyword()
+        ) :: t()
+  def add_1_to_n_conversion(%__MODULE__{} = plan, callback, opts \\ [])
+      when is_function(callback, 1) do
+    opts = validate_callback_opts!(opts, [:version], "add_1_to_n_conversion")
+    append_entry(plan, {:add_1_to_n_conversion, callback, opts})
+  end
+
+  @spec add_source_materialization(t(), function(), keyword()) :: t()
+  def add_source_materialization(%__MODULE__{} = plan, callback, opts \\ [])
+      when is_function(callback, 4) do
+    opts = validate_callback_opts!(opts, [:version], "add_source_materialization")
+    append_entry(plan, {:add_source_materialization, callback, opts})
+  end
+
+  @spec add_target_materialization(t(), function(), keyword()) :: t()
+  def add_target_materialization(%__MODULE__{} = plan, callback, opts \\ [])
+      when is_function(callback, 5) do
+    opts = validate_callback_opts!(opts, [:version], "add_target_materialization")
+    append_entry(plan, {:add_target_materialization, callback, opts})
+  end
+
+  @spec add_1_to_n_target_materialization(t(), function(), keyword()) :: t()
+  def add_1_to_n_target_materialization(%__MODULE__{} = plan, callback, opts \\ [])
+      when is_function(callback, 5) do
+    opts = validate_callback_opts!(opts, [:version], "add_1_to_n_target_materialization")
+    append_entry(plan, {:add_1_to_n_target_materialization, callback, opts})
+  end
+
+  @spec add_conversion_pattern(
+          t(),
+          String.Chars.t(),
+          MLIR.ConversionPattern.callback(),
+          keyword()
+        ) :: t()
+  def add_conversion_pattern(%__MODULE__{} = plan, root_name, callback, opts \\ [])
+      when is_function(callback, 3) do
+    opts =
+      validate_callback_opts!(
+        opts,
+        [:version, :benefit, :one_to_n, :timeout],
+        "add_conversion_pattern"
+      )
+
+    benefit = Keyword.get(opts, :benefit, 1)
+
+    unless is_integer(benefit) and benefit >= 0 do
+      raise ArgumentError, ":benefit must be a non-negative integer, got: #{inspect(benefit)}"
+    end
+
+    one_to_n = Keyword.get(opts, :one_to_n, false)
+
+    unless is_boolean(one_to_n) do
+      raise ArgumentError, ":one_to_n must be boolean, got: #{inspect(one_to_n)}"
+    end
+
+    timeout = Keyword.get(opts, :timeout)
+
+    if timeout != nil and not (is_integer(timeout) and timeout >= 0) do
+      raise ArgumentError,
+            ":timeout must be a non-negative integer or nil, got: #{inspect(timeout)}"
+    end
+
+    append_entry(plan, {:add_conversion_pattern, to_string(root_name), callback, opts})
+  end
+
+  @spec add_pattern(t(), Descriptor.t(), keyword()) :: t()
+  def add_pattern(%__MODULE__{} = plan, %Descriptor{} = descriptor, opts \\ []) do
+    opts = validate_callback_opts!(opts, [:version], "add_pattern")
+    append_entry(plan, {:add_pattern, descriptor, opts})
+  end
+
+  @doc """
+  Returns deterministic metadata for the given plan.
+
+  Function bodies and runtime state are omitted. Callback entries include their
+  `:version` if explicitly provided, or `:unversioned` if omitted.
+
+  > Note: Declaration metadata is only deterministic and reproducible across processes
+  > or runs when all callback versions are explicitly specified.
+  """
+  @spec declaration(t()) :: map()
+  def declaration(%__MODULE__{} = plan) do
+    %{
+      mode: plan.mode,
+      timeout: plan.timeout,
+      folding_mode: plan.folding_mode,
+      build_materializations: plan.build_materializations,
+      entries: Enum.map(plan.entries, &entry_declaration/1)
+    }
+  end
+
+  @doc """
+  Executes the conversion plan on the given IR (`MLIR.Module` or `MLIR.Operation`).
+
+  Fresh `MLIR.ConversionTarget`, `MLIR.TypeConverter`, and `MLIR.RewritePatternSet`
+  instances are created for the duration of the conversion and cleaned up afterwards.
+  Returns `MLIR.Conversion.result()`.
+  """
+  @spec run(t(), MLIR.Conversion.conversion_ir()) :: MLIR.Conversion.result()
+  def run(%__MODULE__{} = plan, ir) do
+    context = MLIR.context(ir)
+
+    target_opts = if plan.timeout, do: [timeout: plan.timeout], else: []
+    target = MLIR.ConversionTarget.create(context, target_opts)
+
+    try do
+      converter_opts = if plan.timeout, do: [timeout: plan.timeout], else: []
+      converter = MLIR.TypeConverter.create(converter_opts)
+
+      try do
+        patterns = MLIR.RewritePatternSet.create(context)
+
+        populate_or_destroy!(
+          plan.entries,
+          context,
+          target,
+          converter,
+          patterns,
+          plan.timeout
+        )
+
+        conversion_opts =
+          [
+            timeout: plan.timeout,
+            folding_mode: plan.folding_mode,
+            build_materializations: plan.build_materializations
+          ]
+          |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+
+        # Conversion.apply/5 freezes the mutable set and transfers its ownership
+        # to the native worker. Do not rescue around this call and try to destroy
+        # the stale mutable handle: apply/5 already releases the owned frozen set
+        # if starting the worker fails, and the worker releases it on every exit.
+        MLIR.Conversion.apply(plan.mode, ir, target, patterns, conversion_opts)
+      after
+        MLIR.TypeConverter.destroy(converter)
+      end
+    after
+      MLIR.ConversionTarget.destroy(target)
+    end
+  end
+
+  @doc """
+  Executes the conversion plan on the given IR, returning the converted IR or raising `MLIR.Conversion.Error`.
+  """
+  @spec run!(t(), MLIR.Conversion.conversion_ir()) :: MLIR.Conversion.conversion_ir()
+  def run!(%__MODULE__{} = plan, ir) do
+    case run(plan, ir) do
+      {:ok, converted, _diagnostics} -> converted
+      {:error, %MLIR.Conversion.Error{} = error} -> raise error
+    end
+  end
+
+  defp append_entry(%__MODULE__{entries: entries} = plan, entry) do
+    %{plan | entries: entries ++ [entry]}
+  end
+
+  defp validate_plan_options!(opts) do
+    unless Keyword.keyword?(opts) do
+      raise ArgumentError, "Plan options must be a keyword list, got: #{inspect(opts)}"
+    end
+
+    case Keyword.keys(opts) -- [:mode, :timeout, :folding_mode, :build_materializations] do
+      [] -> :ok
+      unsupported -> raise ArgumentError, "unsupported Plan options: #{inspect(unsupported)}"
+    end
+  end
+
+  defp validate_mode!(mode) when mode in [:full, :partial], do: mode
+
+  defp validate_mode!(mode) do
+    raise ArgumentError, ":mode must be :full or :partial, got: #{inspect(mode)}"
+  end
+
+  defp validate_plan_timeout!(nil), do: nil
+  defp validate_plan_timeout!(timeout) when is_integer(timeout) and timeout >= 0, do: timeout
+
+  defp validate_plan_timeout!(timeout) do
+    raise ArgumentError,
+          ":timeout must be a non-negative integer or nil, got: #{inspect(timeout)}"
+  end
+
+  defp validate_folding_mode!(mode)
+       when mode in [nil, :never, :before_patterns, :after_patterns],
+       do: mode
+
+  defp validate_folding_mode!(mode) do
+    raise ArgumentError, "unsupported conversion folding mode: #{inspect(mode)}"
+  end
+
+  defp validate_build_materializations!(value) when is_boolean(value) or is_nil(value), do: value
+
+  defp validate_build_materializations!(value) do
+    raise ArgumentError,
+          "build_materializations must be boolean or nil, got: #{inspect(value)}"
+  end
+
+  defp validate_callback_opts!(opts, allowed, label) do
+    unless Keyword.keyword?(opts) do
+      raise ArgumentError, "#{label} options must be a keyword list, got: #{inspect(opts)}"
+    end
+
+    case Keyword.keys(opts) -- allowed do
+      [] ->
+        opts
+
+      unsupported ->
+        raise ArgumentError, "unsupported #{label} options: #{inspect(unsupported)}"
+    end
+  end
+
+  defp entry_declaration({:add_legal_op, name}), do: %{kind: :add_legal_op, op: name}
+  defp entry_declaration({:add_illegal_op, name}), do: %{kind: :add_illegal_op, op: name}
+
+  defp entry_declaration({:add_legal_dialect, name}),
+    do: %{kind: :add_legal_dialect, dialect: name}
+
+  defp entry_declaration({:add_illegal_dialect, name}),
+    do: %{kind: :add_illegal_dialect, dialect: name}
+
+  defp entry_declaration({:add_dynamically_legal_op, name, _cb, opts}) do
+    %{kind: :add_dynamically_legal_op, op: name, version: callback_version(opts)}
+  end
+
+  defp entry_declaration({:add_dynamically_legal_dialect, name, _cb, opts}) do
+    %{kind: :add_dynamically_legal_dialect, dialect: name, version: callback_version(opts)}
+  end
+
+  defp entry_declaration({:mark_recursively_legal, name, cb, opts}) do
+    base = %{kind: :mark_recursively_legal, op: name}
+
+    if cb != nil do
+      Map.put(base, :version, callback_version(opts))
+    else
+      base
+    end
+  end
+
+  defp entry_declaration({:mark_unknown_dynamically_legal, _cb, opts}) do
+    %{kind: :mark_unknown_dynamically_legal, version: callback_version(opts)}
+  end
+
+  defp entry_declaration({:add_conversion, _cb, opts}) do
+    %{kind: :add_conversion, version: callback_version(opts)}
+  end
+
+  defp entry_declaration({:add_1_to_n_conversion, _cb, opts}) do
+    %{kind: :add_1_to_n_conversion, version: callback_version(opts)}
+  end
+
+  defp entry_declaration({:add_source_materialization, _cb, opts}) do
+    %{kind: :add_source_materialization, version: callback_version(opts)}
+  end
+
+  defp entry_declaration({:add_target_materialization, _cb, opts}) do
+    %{kind: :add_target_materialization, version: callback_version(opts)}
+  end
+
+  defp entry_declaration({:add_1_to_n_target_materialization, _cb, opts}) do
+    %{kind: :add_1_to_n_target_materialization, version: callback_version(opts)}
+  end
+
+  defp entry_declaration({:add_conversion_pattern, root, _cb, opts}) do
+    %{
+      kind: :add_conversion_pattern,
+      root: root,
+      benefit: Keyword.get(opts, :benefit, 1),
+      one_to_n: Keyword.get(opts, :one_to_n, false),
+      timeout: Keyword.get(opts, :timeout),
+      version: callback_version(opts)
+    }
+  end
+
+  defp entry_declaration({:add_pattern, descriptor, opts}) do
+    %{
+      kind: :add_pattern,
+      name: descriptor.name,
+      root: descriptor.root,
+      benefit: descriptor.benefit,
+      version: callback_version(opts)
+    }
+  end
+
+  defp callback_version(opts) do
+    Keyword.get(opts, :version, :unversioned)
+  end
+
+  defp populate_or_destroy!(entries, context, target, converter, patterns, plan_timeout) do
+    populate(entries, context, target, converter, patterns, plan_timeout)
+  rescue
+    exception ->
+      MLIR.RewritePatternSet.threaded_destroy(context, patterns)
+      reraise exception, __STACKTRACE__
+  catch
+    kind, reason ->
+      MLIR.RewritePatternSet.threaded_destroy(context, patterns)
+      :erlang.raise(kind, reason, __STACKTRACE__)
+  end
+
+  defp populate([], _context, _target, _converter, _patterns, _plan_timeout), do: :ok
+
+  defp populate([entry | rest], context, target, converter, patterns, plan_timeout) do
+    populate_entry(entry, context, target, converter, patterns, plan_timeout)
+    populate(rest, context, target, converter, patterns, plan_timeout)
+  end
+
+  defp populate_entry({:add_legal_op, name}, _context, target, _converter, _patterns, _timeout),
+    do: MLIR.ConversionTarget.add_legal_op(target, name)
+
+  defp populate_entry({:add_illegal_op, name}, _context, target, _converter, _patterns, _timeout),
+    do: MLIR.ConversionTarget.add_illegal_op(target, name)
+
+  defp populate_entry(
+         {:add_legal_dialect, name},
+         _context,
+         target,
+         _converter,
+         _patterns,
+         _timeout
+       ),
+       do: MLIR.ConversionTarget.add_legal_dialect(target, name)
+
+  defp populate_entry(
+         {:add_illegal_dialect, name},
+         _context,
+         target,
+         _converter,
+         _patterns,
+         _timeout
+       ),
+       do: MLIR.ConversionTarget.add_illegal_dialect(target, name)
+
+  defp populate_entry(
+         {:add_dynamically_legal_op, name, callback, _opts},
+         _context,
+         target,
+         _converter,
+         _patterns,
+         _timeout
+       ),
+       do: MLIR.ConversionTarget.add_dynamically_legal_op(target, name, callback)
+
+  defp populate_entry(
+         {:add_dynamically_legal_dialect, name, callback, _opts},
+         _context,
+         target,
+         _converter,
+         _patterns,
+         _timeout
+       ),
+       do: MLIR.ConversionTarget.add_dynamically_legal_dialect(target, name, callback)
+
+  defp populate_entry(
+         {:mark_recursively_legal, name, callback, _opts},
+         _context,
+         target,
+         _converter,
+         _patterns,
+         _timeout
+       ),
+       do: MLIR.ConversionTarget.mark_recursively_legal(target, name, callback)
+
+  defp populate_entry(
+         {:mark_unknown_dynamically_legal, callback, _opts},
+         _context,
+         target,
+         _converter,
+         _patterns,
+         _timeout
+       ),
+       do: MLIR.ConversionTarget.mark_unknown_dynamically_legal(target, callback)
+
+  defp populate_entry(
+         {:add_conversion, callback, _opts},
+         _context,
+         _target,
+         converter,
+         _patterns,
+         _timeout
+       ),
+       do: MLIR.TypeConverter.add_conversion(converter, callback)
+
+  defp populate_entry(
+         {:add_1_to_n_conversion, callback, _opts},
+         _context,
+         _target,
+         converter,
+         _patterns,
+         _timeout
+       ),
+       do: MLIR.TypeConverter.add_1_to_n_conversion(converter, callback)
+
+  defp populate_entry(
+         {:add_source_materialization, callback, _opts},
+         _context,
+         _target,
+         converter,
+         _patterns,
+         _timeout
+       ),
+       do: MLIR.TypeConverter.add_source_materialization(converter, callback)
+
+  defp populate_entry(
+         {:add_target_materialization, callback, _opts},
+         _context,
+         _target,
+         converter,
+         _patterns,
+         _timeout
+       ),
+       do: MLIR.TypeConverter.add_target_materialization(converter, callback)
+
+  defp populate_entry(
+         {:add_1_to_n_target_materialization, callback, _opts},
+         _context,
+         _target,
+         converter,
+         _patterns,
+         _timeout
+       ),
+       do: MLIR.TypeConverter.add_1_to_n_target_materialization(converter, callback)
+
+  defp populate_entry(
+         {:add_conversion_pattern, root_name, callback, opts},
+         context,
+         _target,
+         converter,
+         patterns,
+         plan_timeout
+       ) do
+    pattern_opts = conversion_pattern_opts(opts, context, plan_timeout)
+    MLIR.ConversionPattern.add(patterns, root_name, converter, callback, pattern_opts)
+  end
+
+  defp populate_entry(
+         {:add_pattern, descriptor, _opts},
+         context,
+         _target,
+         _converter,
+         patterns,
+         _timeout
+       ),
+       do: MLIR.RewritePatternSet.add(patterns, descriptor, ctx: context)
+
+  defp conversion_pattern_opts(opts, context, plan_timeout) do
+    pattern_opts =
+      opts
+      |> Keyword.take([:benefit, :one_to_n, :timeout])
+      |> Keyword.reject(fn {key, value} -> key == :timeout and is_nil(value) end)
+      |> Keyword.put(:ctx, context)
+
+    if plan_timeout && not Keyword.has_key?(pattern_opts, :timeout) do
+      Keyword.put(pattern_opts, :timeout, plan_timeout)
+    else
+      pattern_opts
+    end
+  end
+end

--- a/native/src/conversion.zig
+++ b/native/src/conversion.zig
@@ -768,14 +768,19 @@ const ConversionPatternState = struct {
                 e.enif_free_env(environment);
                 return c.mlirLogicalResultFailure();
             }
-            ranges[index] = kinda.callback_adapter.handleRange(
-                mlir_capi.Value,
-                environment,
-                operands[offset .. offset + len],
-            ) catch {
-                e.enif_free_env(environment);
-                return c.mlirLogicalResultFailure();
-            };
+            if (len == 0) {
+                const empty = [_]beam.term{};
+                ranges[index] = beam.make_term_list(environment, &empty);
+            } else {
+                ranges[index] = kinda.callback_adapter.handleRange(
+                    mlir_capi.Value,
+                    environment,
+                    operands[offset .. offset + len],
+                ) catch {
+                    e.enif_free_env(environment);
+                    return c.mlirLogicalResultFailure();
+                };
+            }
             offset += len;
         }
         const args = .{

--- a/test/conversion_plan_test.exs
+++ b/test/conversion_plan_test.exs
@@ -1,0 +1,595 @@
+defmodule Beaver.MLIR.CounterPlanTest do
+  use Beaver.Slang, name: "counter_plan_test"
+
+  alias Beaver.MLIR.Type
+
+  defop inc(value = Type.i32()), do: [Type.i32()]
+end
+
+defmodule Beaver.MLIR.ConversionPlanNativePatterns do
+  use Beaver.Pattern.Native
+
+  alias Beaver.MLIR
+
+  defrewrite erase_drop(operation, rewriter, owner), root: "plan_native.drop" do
+    send(owner, :native_plan_rewrite)
+    rewriter |> MLIR.PatternRewriter.as_base() |> MLIR.RewriterBase.erase_op(operation)
+    :ok
+  end
+end
+
+defmodule Beaver.MLIR.ConversionPlanTest do
+  use Beaver.Case, async: true
+
+  alias Beaver.MLIR
+  alias Beaver.MLIR.Conversion.Plan
+  alias Beaver.MLIR.ConversionPlanNativePatterns
+
+  test "lowers a Slang dialect using Plan and reuses the Plan across fresh MLIR contexts" do
+    plan =
+      Plan.new(
+        mode: :full,
+        folding_mode: :after_patterns,
+        build_materializations: true,
+        timeout: 5_000
+      )
+      |> Plan.add_legal_dialect("builtin")
+      |> Plan.add_legal_dialect("func")
+      |> Plan.add_legal_dialect("arith")
+      |> Plan.add_illegal_dialect("counter_plan_test")
+      |> Plan.add_conversion(fn type -> type end, version: "1.0")
+      |> Plan.add_conversion_pattern(
+        "counter_plan_test.inc",
+        fn operation, [input], rewriter ->
+          context = MLIR.context(operation)
+          base = MLIR.ConversionPatternRewriter.as_base(rewriter)
+          type = MLIR.Value.type(input)
+          location = MLIR.Operation.location(operation)
+
+          one =
+            %Beaver.Changeset{name: "arith.constant", context: context, location: location}
+            |> Beaver.Changeset.add_argument(value: MLIR.Attribute.integer(type, 1))
+            |> Beaver.Changeset.add_result(type)
+            |> MLIR.Operation.create()
+
+          add =
+            %Beaver.Changeset{name: "arith.addi", context: context, location: location}
+            |> Beaver.Changeset.add_argument([input, MLIR.Operation.result(one, 0)])
+            |> Beaver.Changeset.add_result(type)
+            |> MLIR.Operation.create()
+
+          MLIR.RewriterBase.set_insertion_point_before(base, operation)
+          MLIR.RewriterBase.insert(base, one)
+          MLIR.RewriterBase.insert(base, add)
+          MLIR.ConversionPatternRewriter.replace_op(rewriter, operation, add)
+          :ok
+        end,
+        version: "1.0"
+      )
+
+    # First context run
+    ctx1 = MLIR.Context.create()
+
+    try do
+      assert Beaver.Slang.load(ctx1, Beaver.MLIR.CounterPlanTest) |> MLIR.LogicalResult.success?()
+
+      module1 =
+        MLIR.Module.create!(
+          ~S"""
+          module {
+            func.func @increment(%arg0: i32) -> i32 {
+              %0 = "counter_plan_test.inc"(%arg0) : (i32) -> i32
+              return %0 : i32
+            }
+          }
+          """,
+          ctx: ctx1
+        )
+
+      assert {:ok, ^module1, _diagnostics} = Plan.run(plan, module1)
+
+      pass_manager1 = MLIR.CAPI.mlirPassManagerCreate(ctx1)
+
+      MLIR.CAPI.mlirPassManagerAddOwnedPass(
+        pass_manager1,
+        MLIR.CAPI.mlirCreateConversionArithToLLVMConversionPass()
+      )
+
+      MLIR.CAPI.mlirPassManagerAddOwnedPass(
+        pass_manager1,
+        MLIR.CAPI.mlirCreateConversionConvertFuncToLLVMPass()
+      )
+
+      assert {:ok, _} = MLIR.PassManager.run(pass_manager1, module1)
+      MLIR.PassManager.destroy(pass_manager1)
+
+      rendered1 = MLIR.to_string(module1)
+      refute rendered1 =~ "counter_plan_test.inc"
+      assert rendered1 =~ "llvm.func"
+      MLIR.Module.destroy(module1)
+    after
+      MLIR.Context.destroy(ctx1)
+    end
+
+    # Second context run using the EXACT same Plan instance
+    ctx2 = MLIR.Context.create()
+
+    try do
+      assert Beaver.Slang.load(ctx2, Beaver.MLIR.CounterPlanTest) |> MLIR.LogicalResult.success?()
+
+      module2 =
+        MLIR.Module.create!(
+          ~S"""
+          module {
+            func.func @increment(%arg0: i32) -> i32 {
+              %0 = "counter_plan_test.inc"(%arg0) : (i32) -> i32
+              return %0 : i32
+            }
+          }
+          """,
+          ctx: ctx2
+        )
+
+      assert converted2 = Plan.run!(plan, module2)
+      rendered2 = MLIR.to_string(converted2)
+      refute rendered2 =~ "counter_plan_test.inc"
+      assert rendered2 =~ "arith.addi"
+      MLIR.Module.destroy(module2)
+    after
+      MLIR.Context.destroy(ctx2)
+    end
+  end
+
+  test "composes with a Native rewrite descriptor without another pattern language", %{ctx: ctx} do
+    MLIR.Context.allow_unregistered_dialects(ctx)
+    owner = self()
+
+    descriptor =
+      ConversionPlanNativePatterns.erase_drop(
+        init_state: owner,
+        destruct: fn pid -> send(pid, :native_plan_pattern_destroyed) end
+      )
+
+    plan =
+      Plan.new(mode: :full, timeout: 1_000)
+      |> Plan.add_legal_dialect("builtin")
+      |> Plan.add_illegal_dialect("plan_native")
+      |> Plan.add_pattern(descriptor, version: "1.0")
+
+    module = MLIR.Module.create!(~s[module { "plan_native.drop"() : () -> () }], ctx: ctx)
+
+    assert {:ok, ^module, []} = Plan.run(plan, module)
+    assert_receive :native_plan_rewrite
+    assert_receive :native_plan_pattern_destroyed
+    refute MLIR.to_string(module) =~ "plan_native.drop"
+
+    assert List.last(Plan.declaration(plan).entries) == %{
+             kind: :add_pattern,
+             name: :erase_drop,
+             root: "plan_native.drop",
+             benefit: 1,
+             version: "1.0"
+           }
+
+    MLIR.Module.destroy(module)
+  end
+
+  test "full vs partial mode in Plan", %{ctx: ctx} do
+    MLIR.Context.allow_unregistered_dialects(ctx)
+
+    partial_plan =
+      Plan.new(mode: :partial, timeout: 1_000)
+      |> Plan.add_legal_dialect("builtin")
+
+    module = MLIR.Module.create!(~s[module { "foo.unknown"() : () -> () }], ctx: ctx)
+    assert {:ok, ^module, []} = Plan.run(partial_plan, module)
+    MLIR.Module.destroy(module)
+
+    full_plan =
+      Plan.new(mode: :full, timeout: 1_000)
+      |> Plan.add_legal_dialect("builtin")
+
+    full_module = MLIR.Module.create!(~s[module { "foo.unknown"() : () -> () }], ctx: ctx)
+
+    assert {:error, %MLIR.Conversion.Error{mode: :full, diagnostics: diagnostics} = error} =
+             Plan.run(full_plan, full_module)
+
+    assert diagnostics != []
+    assert Exception.message(error) =~ "foo.unknown"
+    MLIR.Module.destroy(full_module)
+  end
+
+  test "source, target, and 1:N target materializations run through Plan", %{ctx: ctx} do
+    MLIR.Context.allow_unregistered_dialects(ctx)
+    owner = self()
+    i32 = MLIR.Type.i32(ctx: ctx)
+    i64 = MLIR.Type.i64(ctx: ctx)
+
+    source_module =
+      MLIR.Module.create!(
+        ~S[module { %a = arith.constant 1 : i64 %s = "foo.source"() : () -> i32 "foo.keep"(%s) : (i32) -> () }],
+        ctx: ctx
+      )
+
+    [constant | _] =
+      source_module |> MLIR.Module.body() |> Beaver.Walker.operations() |> Enum.to_list()
+
+    replacement = MLIR.Operation.result(constant, 0)
+
+    source_plan =
+      Plan.new(mode: :full, timeout: 1_000, build_materializations: true)
+      |> Plan.add_legal_dialect("builtin")
+      |> Plan.add_legal_dialect("arith")
+      |> Plan.add_illegal_dialect("foo")
+      |> Plan.add_legal_op("foo.keep")
+      |> Plan.add_conversion(
+        fn type -> if MLIR.equal?(type, i32), do: i64, else: :declined end,
+        version: "1.0"
+      )
+      |> Plan.add_source_materialization(
+        fn rewriter, output_type, inputs, loc ->
+          send(owner, {:source_materialized, MLIR.to_string(output_type), length(inputs)})
+          [value] = build_unrealized_cast(ctx, rewriter, [output_type], inputs, loc)
+          value
+        end,
+        version: "1.0"
+      )
+      |> Plan.add_conversion_pattern(
+        "foo.source",
+        fn operation, [], rewriter ->
+          MLIR.ConversionPatternRewriter.replace_op(rewriter, operation, replacement)
+          :ok
+        end,
+        version: "1.0"
+      )
+
+    assert {:ok, ^source_module, []} = Plan.run(source_plan, source_module)
+    assert_receive {:source_materialized, "i32", 1}
+    assert MLIR.to_string(source_module) =~ "unrealized_conversion_cast"
+    MLIR.Module.destroy(source_module)
+
+    target_module =
+      MLIR.Module.create!(
+        ~S[module { %a = "foo.producer"() : () -> i32 "foo.sink"(%a) : (i32) -> () }],
+        ctx: ctx
+      )
+
+    target_plan =
+      Plan.new(mode: :partial, timeout: 1_000, build_materializations: true)
+      |> Plan.add_legal_dialect("builtin")
+      |> Plan.add_illegal_dialect("foo")
+      |> Plan.add_legal_op("foo.producer")
+      |> Plan.add_legal_op("foo.sink_legal")
+      |> Plan.add_conversion(
+        fn type ->
+          send(owner, {:target_conversion, MLIR.to_string(type)})
+          if MLIR.equal?(type, i32), do: i64, else: type
+        end,
+        version: "1.0"
+      )
+      |> Plan.add_target_materialization(
+        fn rewriter, output_type, inputs, loc, original_type ->
+          send(
+            owner,
+            {:target_materialized, MLIR.to_string(output_type), length(inputs),
+             MLIR.to_string(original_type)}
+          )
+
+          [value] = build_unrealized_cast(ctx, rewriter, [output_type], inputs, loc)
+          value
+        end,
+        version: "1.0"
+      )
+      |> Plan.add_conversion_pattern(
+        "foo.sink",
+        fn operation, [converted], rewriter ->
+          send(owner, {:target_operand, MLIR.to_string(MLIR.Value.type(converted))})
+
+          base = MLIR.ConversionPatternRewriter.as_base(rewriter)
+
+          legal_sink =
+            %Beaver.Changeset{
+              name: "foo.sink_legal",
+              context: MLIR.context(operation),
+              location: MLIR.Operation.location(operation)
+            }
+            |> Beaver.Changeset.add_argument(converted)
+            |> MLIR.Operation.create()
+
+          MLIR.RewriterBase.insert(base, legal_sink)
+          MLIR.ConversionPatternRewriter.erase_op(rewriter, operation)
+          :ok
+        end,
+        version: "1.0"
+      )
+
+    assert {:ok, ^target_module, []} = Plan.run(target_plan, target_module)
+
+    assert_receive {:target_conversion, "i32"}
+    assert_receive {:target_operand, "i64"}
+    assert_receive {:target_materialized, "i64", 1, "i32"}
+    assert MLIR.to_string(target_module) =~ "unrealized_conversion_cast"
+    MLIR.Module.destroy(target_module)
+
+    one_to_n_module =
+      MLIR.Module.create!(
+        ~S[module { %a = arith.constant 1 : i32 "foo.sink"(%a) : (i32) -> () }],
+        ctx: ctx
+      )
+
+    one_to_n_plan =
+      Plan.new(mode: :full, timeout: 1_000, build_materializations: true)
+      |> Plan.add_legal_dialect("builtin")
+      |> Plan.add_legal_dialect("arith")
+      |> Plan.add_illegal_dialect("foo")
+      |> Plan.add_1_to_n_conversion(
+        fn type -> if MLIR.equal?(type, i32), do: [i64, i64], else: :declined end,
+        version: "1.0"
+      )
+      |> Plan.add_1_to_n_target_materialization(
+        fn rewriter, output_types, inputs, loc, _original ->
+          send(
+            owner,
+            {:one_to_n_target_materialized, Enum.map(output_types, &MLIR.to_string/1),
+             length(inputs)}
+          )
+
+          build_unrealized_cast(ctx, rewriter, output_types, inputs, loc)
+        end,
+        version: "1.0"
+      )
+      |> Plan.add_conversion_pattern(
+        "foo.sink",
+        fn operation, [[lhs, rhs]], rewriter ->
+          context = MLIR.context(operation)
+          base = MLIR.ConversionPatternRewriter.as_base(rewriter)
+
+          add =
+            %Beaver.Changeset{
+              name: "arith.addi",
+              context: context,
+              location: MLIR.Operation.location(operation)
+            }
+            |> Beaver.Changeset.add_argument([lhs, rhs])
+            |> Beaver.Changeset.add_result(i64)
+            |> MLIR.Operation.create()
+
+          MLIR.RewriterBase.insert(base, add)
+          MLIR.ConversionPatternRewriter.erase_op(rewriter, operation)
+          :ok
+        end,
+        one_to_n: true,
+        version: "1.0"
+      )
+
+    assert {:ok, ^one_to_n_module, []} = Plan.run(one_to_n_plan, one_to_n_module)
+    assert_receive {:one_to_n_target_materialized, ["i64", "i64"], 1}
+
+    rendered = MLIR.to_string(one_to_n_module)
+    assert rendered =~ "arith.addi"
+    refute rendered =~ "foo.sink"
+    MLIR.Module.destroy(one_to_n_module)
+  end
+
+  test "an erasing 1:N conversion supplies an empty operand range", %{ctx: ctx} do
+    MLIR.Context.allow_unregistered_dialects(ctx)
+    owner = self()
+    i32 = MLIR.Type.i32(ctx: ctx)
+
+    plan =
+      Plan.new(mode: :full, timeout: 1_000)
+      |> Plan.add_legal_dialect("builtin")
+      |> Plan.add_legal_op("foo.producer")
+      |> Plan.add_legal_op("foo.sink_legal")
+      |> Plan.add_illegal_op("foo.sink")
+      |> Plan.add_1_to_n_conversion(
+        fn type -> if MLIR.equal?(type, i32), do: [], else: [type] end,
+        version: "1.0"
+      )
+      |> Plan.add_conversion_pattern(
+        "foo.sink",
+        fn operation, [converted], rewriter ->
+          send(owner, {:erased_operand_count, length(converted)})
+          base = MLIR.ConversionPatternRewriter.as_base(rewriter)
+
+          legal_sink =
+            %Beaver.Changeset{
+              name: "foo.sink_legal",
+              context: MLIR.context(operation),
+              location: MLIR.Operation.location(operation)
+            }
+            |> MLIR.Operation.create()
+
+          MLIR.RewriterBase.insert(base, legal_sink)
+          MLIR.ConversionPatternRewriter.erase_op(rewriter, operation)
+          :ok
+        end,
+        one_to_n: true,
+        version: "1.0"
+      )
+
+    module =
+      MLIR.Module.create!(
+        ~S[module { %a = "foo.producer"() : () -> i32 "foo.sink"(%a) : (i32) -> () }],
+        ctx: ctx
+      )
+
+    assert {:ok, ^module, []} = Plan.run(plan, module)
+    assert_receive {:erased_operand_count, 0}
+    assert MLIR.to_string(module) =~ ~s["foo.sink_legal"()]
+    refute MLIR.to_string(module) =~ ~s["foo.sink"(]
+    MLIR.Module.destroy(module)
+  end
+
+  test "cleanup on success, conversion failure, callback exception, and callback timeout",
+       %{
+         ctx: ctx
+       } do
+    MLIR.Context.allow_unregistered_dialects(ctx)
+
+    # 1. Conversion failure cleanup
+    fail_plan =
+      Plan.new(mode: :full, timeout: 1_000)
+      |> Plan.add_legal_dialect("builtin")
+      |> Plan.add_illegal_dialect("foo")
+      |> add_lifetime_probe()
+
+    fail_module = MLIR.Module.create!(~s[module { "foo.illegal"() : () -> () }], ctx: ctx)
+    assert {:error, %MLIR.Conversion.Error{mode: :full}} = Plan.run(fail_plan, fail_module)
+    MLIR.Module.destroy(fail_module)
+
+    # 2. Callback exception cleanup
+    exc_plan =
+      Plan.new(mode: :full, timeout: 1_000)
+      |> Plan.add_legal_dialect("builtin")
+      |> Plan.add_dynamically_legal_op("foo.dynamic", fn _ ->
+        raise "legality error in plan"
+      end)
+      |> add_lifetime_probe()
+
+    exc_module = MLIR.Module.create!(~s[module { "foo.dynamic"() : () -> () }], ctx: ctx)
+
+    assert {:error,
+            %MLIR.Conversion.Error{
+              callback_failure:
+                {:exception, :error, %RuntimeError{message: "legality error in plan"}, _}
+            }} = Plan.run(exc_plan, exc_module)
+
+    MLIR.Module.destroy(exc_module)
+
+    # 3. Callback timeout cleanup
+    timeout_plan =
+      Plan.new(mode: :full, timeout: 50)
+      |> Plan.add_legal_dialect("builtin")
+      |> Plan.add_dynamically_legal_op("foo.slow", fn _ ->
+        Process.sleep(200)
+        :legal
+      end)
+      |> add_lifetime_probe()
+
+    timeout_module = MLIR.Module.create!(~s[module { "foo.slow"() : () -> () }], ctx: ctx)
+    assert {:error, %MLIR.Conversion.Error{}} = Plan.run(timeout_plan, timeout_module)
+    MLIR.Module.destroy(timeout_module)
+  end
+
+  test "Plan.declaration/1 and compile/runtime option validation", %{ctx: ctx} do
+    # Option validation in Plan.new
+    assert_raise ArgumentError, ~r/unsupported Plan options/, fn ->
+      Plan.new(invalid_opt: 123)
+    end
+
+    assert_raise ArgumentError, ~r/:mode must be :full or :partial/, fn ->
+      Plan.new(mode: :invalid)
+    end
+
+    assert_raise ArgumentError, ~r/:timeout must be a non-negative integer/, fn ->
+      Plan.new(timeout: -10)
+    end
+
+    assert_raise ArgumentError, ~r/unsupported conversion folding mode/, fn ->
+      Plan.new(folding_mode: :invalid)
+    end
+
+    assert_raise ArgumentError, ~r/build_materializations must be boolean/, fn ->
+      Plan.new(build_materializations: 123)
+    end
+
+    # Option validation in builder functions
+    plan = Plan.new()
+
+    assert_raise ArgumentError, ~r/unsupported add_conversion_pattern options/, fn ->
+      Plan.add_conversion_pattern(plan, "foo.op", fn _, _, _ -> :ok end, invalid: true)
+    end
+
+    assert_raise ArgumentError, ~r/unsupported add_pattern options/, fn ->
+      Plan.add_pattern(
+        plan,
+        %Beaver.Pattern.Native.Descriptor{
+          name: :dummy,
+          root: "arith.addi",
+          match_and_rewrite: fn _, _, _, _ -> {:ok, nil} end
+        },
+        benefit: 2
+      )
+    end
+
+    # Plan.declaration/1 structure assertion
+    declared_plan =
+      Plan.new(mode: :full, folding_mode: :before_patterns, timeout: 2_000)
+      |> Plan.add_legal_dialect("builtin")
+      |> Plan.add_illegal_op("foo.bar")
+      |> Plan.add_dynamically_legal_op("foo.dynamic", fn _ -> :legal end, version: "2.1")
+      |> Plan.add_conversion(fn t -> t end)
+      |> Plan.add_conversion_pattern("foo.pattern", fn _, _, _ -> :ok end,
+        benefit: 2,
+        version: "1.0"
+      )
+
+    decl = Plan.declaration(declared_plan)
+
+    assert decl.mode == :full
+    assert decl.folding_mode == :before_patterns
+    assert decl.timeout == 2_000
+    assert length(decl.entries) == 5
+
+    assert Enum.at(decl.entries, 0) == %{kind: :add_legal_dialect, dialect: "builtin"}
+    assert Enum.at(decl.entries, 1) == %{kind: :add_illegal_op, op: "foo.bar"}
+
+    assert Enum.at(decl.entries, 2) == %{
+             kind: :add_dynamically_legal_op,
+             op: "foo.dynamic",
+             version: "2.1"
+           }
+
+    assert Enum.at(decl.entries, 3) == %{kind: :add_conversion, version: :unversioned}
+
+    assert Enum.at(decl.entries, 4) == %{
+             kind: :add_conversion_pattern,
+             root: "foo.pattern",
+             benefit: 2,
+             one_to_n: false,
+             timeout: nil,
+             version: "1.0"
+           }
+
+    nil_timeout_plan =
+      Plan.new(timeout: nil)
+      |> Plan.add_legal_dialect("builtin")
+      |> Plan.add_conversion_pattern(
+        "plan.never",
+        fn _operation, _operands, _rewriter -> :no_match end,
+        timeout: nil,
+        version: "1.0"
+      )
+
+    empty_module = MLIR.Module.create!("module {}", ctx: ctx)
+    assert {:ok, ^empty_module, []} = Plan.run(nil_timeout_plan, empty_module)
+    MLIR.Module.destroy(empty_module)
+  end
+
+  defp build_unrealized_cast(ctx, rewriter, output_types, inputs, loc) do
+    changeset =
+      %Beaver.Changeset{
+        name: "builtin.unrealized_conversion_cast",
+        context: ctx,
+        location: loc
+      }
+      |> Beaver.Changeset.add_argument(inputs)
+
+    operation =
+      Enum.reduce(output_types, changeset, &Beaver.Changeset.add_result(&2, &1))
+      |> MLIR.Operation.create()
+
+    MLIR.RewriterBase.insert(rewriter, operation)
+    operation |> MLIR.Operation.results() |> Enum.to_list()
+  end
+
+  defp add_lifetime_probe(plan) do
+    Plan.add_conversion_pattern(
+      plan,
+      "plan.never",
+      fn _operation, _operands, _rewriter -> :no_match end,
+      version: "lifetime-probe"
+    )
+  end
+end


### PR DESCRIPTION
## Summary

- add `Beaver.MLIR.Conversion.Plan` as a declarative, inspectable layer over conversion targets, type converters, materializations, and conversion patterns
- create fresh native resources for every run and clean them up in dependency-safe order
- support full and partial conversion, 1:1/1:N/erasing type conversions, callback versions, and native pattern descriptors
- update the dialect conversion guide and preserve the existing low-level APIs
- handle empty 1:N operand ranges safely in the Zig callback bridge

## Why

Building a complete dialect conversion currently requires users to coordinate several imperative APIs and their native ownership order. A scoped plan makes the complete lowering reusable across MLIR contexts without allowing native resources to escape.

The native fix avoids slicing a null C operand pointer when a valid 1:N conversion erases an operand.

## Validation

- `BEAVER_KINDA_PATH=../kinda mix format --check-formatted`
- `BEAVER_KINDA_PATH=../kinda mix compile --warnings-as-errors`
- `BEAVER_KINDA_PATH=../kinda mix test` — 260 passed, 8 excluded
- focused conversion/native pattern tests — 22 passed
- `BEAVER_KINDA_PATH=../kinda mix credo diff --strict`
- `zig fmt --check native/src/conversion.zig`
- `git diff --check`

Closes #486