### PR TITLE
Partition native build into cached domain libraries

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -57,6 +57,59 @@ fn createCapiModule(b: *std.Build, target: std.Build.ResolvedTarget, optimize: s
     return translate_c.createModule();
 }
 
+fn createNativeModule(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    root: []const u8,
+    capi_module: *std.Build.Module,
+    kinda_module: *std.Build.Module,
+    mlir_include_dir: []const u8,
+) *std.Build.Module {
+    const module = b.createModule(.{
+        .root_source_file = b.path(root),
+        .target = target,
+        .optimize = optimize,
+    });
+    module.addImport("kinda", kinda_module);
+    module.addImport("c_api", capi_module);
+    module.addIncludePath(.{ .cwd_relative = "native/include" });
+    // add these to get ZLS working properly
+    module.addIncludePath(.{ .cwd_relative = mlir_include_dir });
+    if (os == .linux or os == .macos) {
+        module.link_libc = true;
+    }
+    return module;
+}
+
+fn createNativePartitionLib(
+    b: *std.Build,
+    name: []const u8,
+    root: []const u8,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    capi_module: *std.Build.Module,
+    kinda_module: *std.Build.Module,
+    mlir_include_dir: []const u8,
+    linkage: std.builtin.LinkMode,
+    mlir_lib_dir: []const u8,
+) *std.Build.Step.Compile {
+    const lib = b.addLibrary(.{
+        .name = name,
+        .linkage = linkage,
+        .root_module = createNativeModule(b, target, optimize, root, capi_module, kinda_module, mlir_include_dir),
+    });
+    if (linkage == .dynamic) {
+        // Partition dylibs call the MLIR C API directly and are loaded as
+        // dependencies of the final NIF library.
+        lib.root_module.linkSystemLibrary("MLIRBeaver", .{ .use_pkg_config = .no });
+        lib.linker_allow_shlib_undefined = true;
+        lib.root_module.addLibraryPath(.{ .cwd_relative = mlir_lib_dir });
+        lib.root_module.addRPathSpecial(if (os == .linux) "$ORIGIN" else "@loader_path");
+    }
+    return lib;
+}
+
 fn createCMakeStep(b: *std.Build, llvm_cmake_dir: []const u8, mlir_cmake_dir: []const u8, optimize: std.builtin.OptimizeMode) *std.Build.Step {
     const step = b.step("cmake", "Build and install CMake targets");
 
@@ -152,33 +205,41 @@ pub fn build(b: *std.Build) void {
     const ods_extraction_step = createODSExtractionStep(b, generated_dir, mlir_include_dir, cmake_step);
     b.getInstallStep().dependOn(ods_extraction_step);
 
-    // Default target
+    const kinda = b.dependency("kinda", .{});
+    const kinda_module = kinda.module("kinda");
+
+    // Native source is partitioned into dynamic libraries so each domain is
+    // cached independently: a source edit in one domain only recompiles that
+    // partition and the final shim, instead of forcing the comptime-heavy CAPI
+    // registry and kind surfaces to rebuild.
+    const core_lib = createNativePartitionLib(b, "beaver_core", "native/src/core.zig", target, optimize, capi_module, kinda_module, mlir_include_dir, .dynamic, llvm_lib_dir);
+    const conversion_lib = createNativePartitionLib(b, "beaver_conversion", "native/src/conversion_root.zig", target, optimize, capi_module, kinda_module, mlir_include_dir, .dynamic, llvm_lib_dir);
+    const callback_bridge_lib = createNativePartitionLib(b, "beaver_callback_bridge", "native/src/callback_bridge_root.zig", target, optimize, capi_module, kinda_module, mlir_include_dir, .dynamic, llvm_lib_dir);
+    const rewrite_pattern_lib = createNativePartitionLib(b, "beaver_rewrite_pattern", "native/src/rewrite_pattern_root.zig", target, optimize, capi_module, kinda_module, mlir_include_dir, .dynamic, llvm_lib_dir);
+
+    // Default target: the NIF shim links the partitions and assembles their
+    // exported NIF tables into a single library entry at load time.
     const lib = b.addLibrary(.{
         .name = "BeaverNIF",
         .linkage = .dynamic,
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("native/src/main.zig"),
-            .target = target,
-            .optimize = optimize,
-        }),
+        .root_module = createNativeModule(b, target, optimize, "native/src/main.zig", capi_module, kinda_module, mlir_include_dir),
     });
+    lib.root_module.linkLibrary(core_lib);
+    lib.root_module.linkLibrary(conversion_lib);
+    lib.root_module.linkLibrary(callback_bridge_lib);
+    lib.root_module.linkLibrary(rewrite_pattern_lib);
+    b.installArtifact(core_lib);
+    b.installArtifact(conversion_lib);
+    b.installArtifact(callback_bridge_lib);
+    b.installArtifact(rewrite_pattern_lib);
     lib.step.dependOn(cmake_step);
 
     std.log.info("Setting optimization mode for {s}: {any}", .{ lib.name, lib.root_module.optimize });
-
-    const kinda = b.dependency("kinda", .{});
-    lib.root_module.addImport("kinda", kinda.module("kinda"));
-    lib.root_module.addImport("c_api", capi_module);
-    lib.root_module.addIncludePath(.{ .cwd_relative = "native/include" });
-    // add these to get ZLS working properly
-    lib.root_module.addIncludePath(.{ .cwd_relative = mlir_include_dir });
     if (os == .linux) {
         lib.root_module.addRPathSpecial("$ORIGIN");
-        lib.root_module.link_libc = true;
     }
     if (os == .macos) {
         lib.root_module.addRPathSpecial("@loader_path");
-        lib.root_module.link_libc = true;
     }
     lib.root_module.linkSystemLibrary("MLIRBeaver", .{ .use_pkg_config = .no });
     lib.linker_allow_shlib_undefined = true;

--- a/native/src/callback_bridge_root.zig
+++ b/native/src/callback_bridge_root.zig
@@ -1,0 +1,18 @@
+const std = @import("std");
+const kinda = @import("kinda");
+const e = kinda.erl_nif;
+const beam = kinda.beam;
+
+const callback_bridge = @import("callback_bridge.zig");
+const resource_sync = @import("resource_sync.zig");
+
+pub const nifs = callback_bridge.nifs;
+
+export const callback_bridge_nifs: [nifs.len]e.ErlNifFunc = nifs;
+export const callback_bridge_nifs_len: usize = nifs.len;
+
+export fn callback_bridge_open(env: beam.env) void {
+    kinda.callback_runtime.ReplyToken.open(env);
+    resource_sync.syncResourceTypes();
+    callback_bridge.open(env);
+}

--- a/native/src/conversion_root.zig
+++ b/native/src/conversion_root.zig
@@ -1,0 +1,20 @@
+const std = @import("std");
+const kinda = @import("kinda");
+const e = kinda.erl_nif;
+const beam = kinda.beam;
+
+const conversion = @import("conversion.zig");
+const resource_sync = @import("resource_sync.zig");
+
+pub const nifs = conversion.nifs;
+
+export const conversion_nifs: [nifs.len]e.ErlNifFunc = nifs;
+export const conversion_nifs_len: usize = nifs.len;
+
+export fn conversion_open(env: beam.env) void {
+    // Opens this DSO's private callback-runtime library pin; the shared
+    // ReplyToken handle is overwritten by the sync below.
+    kinda.callback_runtime.ReplyToken.open(env);
+    resource_sync.syncResourceTypes();
+    conversion.open(env);
+}

--- a/native/src/core.zig
+++ b/native/src/core.zig
@@ -1,0 +1,92 @@
+const std = @import("std");
+const kinda = @import("kinda");
+const e = kinda.erl_nif;
+const beam = kinda.beam;
+
+const mlir_capi = @import("mlir_capi.zig");
+const enif_support = @import("enif_support.zig");
+const prelude = @import("prelude.zig");
+const diagnostic = @import("diagnostic.zig");
+const pass = @import("pass.zig");
+const registry = @import("registry.zig");
+const pointer = @import("pointer.zig");
+const string_ref = @import("string_ref.zig");
+const memref = @import("memref.zig");
+const unranked_memref_descriptor = @import("unranked_memref_descriptor.zig");
+const value = @import("value.zig");
+const action_tracing = @import("action_tracing.zig");
+const capi_registry = @import("capi_registry.zig");
+
+const callback_nifs = .{kinda.callback_runtime.ReplyToken.nif("beaver_raw_callback_reply")};
+
+pub const nifs = capi_registry.nifs ++
+    mlir_capi.EntriesOfKinds ++
+    pass.nifs ++
+    registry.nifs ++
+    string_ref.nifs ++
+    diagnostic.nifs ++
+    pointer.nifs ++
+    memref.nifs ++
+    enif_support.nifs ++
+    callback_nifs ++
+    unranked_memref_descriptor.nifs ++
+    value.nifs ++
+    action_tracing.nifs;
+
+export const core_nifs: [nifs.len]e.ErlNifFunc = nifs;
+export const core_nifs_len: usize = nifs.len;
+
+pub fn open_all(env: beam.env) void {
+    kinda.open_internal_resource_types(env);
+    kinda.Internal.OpaqueStruct.open_all(env);
+    mlir_capi.open_all(env);
+    kinda.callback_runtime.ReplyToken.open(env);
+    unranked_memref_descriptor.open_all(env);
+    action_tracing.open(env);
+}
+
+pub fn register_all_passes() void {
+    pass.register_all_passes();
+}
+
+/// Returns the resource type handle opened by this partition for a resource
+/// name. The leaf partitions call this during `nif_load` instead of reopening
+/// the same resource types: opening the same name twice within one load
+/// creates distinct resource types, so handles must be shared explicitly.
+export fn core_resource_type_by_name(name: [*:0]const u8) ?*anyopaque {
+    inline for (mlir_capi.allKinds) |k| {
+        if (std.mem.eql(u8, std.mem.span(name), k.resource.name)) {
+            return @ptrCast(k.resource.t);
+        }
+        if (std.mem.eql(u8, std.mem.span(name), k.Ptr.resource.name)) {
+            return @ptrCast(k.Ptr.resource.t);
+        }
+        if (std.mem.eql(u8, std.mem.span(name), k.Array.resource.name)) {
+            return @ptrCast(k.Array.resource.t);
+        }
+    }
+    if (std.mem.eql(u8, std.mem.span(name), kinda.Internal.OpaquePtr.resource.name)) {
+        return @ptrCast(kinda.Internal.OpaquePtr.resource.t);
+    }
+    if (std.mem.eql(u8, std.mem.span(name), kinda.Internal.OpaqueArray.resource.name)) {
+        return @ptrCast(kinda.Internal.OpaqueArray.resource.t);
+    }
+    if (std.mem.eql(u8, std.mem.span(name), kinda.Internal.USize.resource.name)) {
+        return @ptrCast(kinda.Internal.USize.resource.t);
+    }
+    if (std.mem.eql(u8, std.mem.span(name), kinda.Internal.OpaqueStruct.resource.name)) {
+        return @ptrCast(kinda.Internal.OpaqueStruct.resource.t);
+    }
+    if (std.mem.eql(u8, std.mem.span(name), kinda.callback_runtime.ReplyToken.resource_name)) {
+        return @ptrCast(kinda.callback_runtime.ReplyToken.resource_type);
+    }
+    return null;
+}
+
+export fn core_open_all(env: beam.env) void {
+    open_all(env);
+}
+
+export fn core_register_all_passes() void {
+    register_all_passes();
+}

--- a/native/src/main.zig
+++ b/native/src/main.zig
@@ -1,42 +1,63 @@
-const std = @import("std");
-const mem = @import("std").mem;
-const testing = std.testing;
 const kinda = @import("kinda");
 const e = kinda.erl_nif;
 const beam = kinda.beam;
 const mlir_capi = @import("mlir_capi.zig");
-const enif_support = @import("enif_support.zig");
-const prelude = @import("prelude.zig");
-const diagnostic = @import("diagnostic.zig");
-const pass = @import("pass.zig");
-const registry = @import("registry.zig");
-const pointer = @import("pointer.zig");
-const string_ref = @import("string_ref.zig");
-const memref = @import("memref.zig");
-const unranked_memref_descriptor = @import("unranked_memref_descriptor.zig");
-const value = @import("value.zig");
-const callback_bridge = @import("callback_bridge.zig");
-const conversion = @import("conversion.zig");
-const action_tracing = @import("action_tracing.zig");
 
-const rewrite_pattern = @import("rewrite_pattern.zig");
-const capi_registry = @import("capi_registry.zig");
-const callback_nifs = .{kinda.callback_runtime.ReplyToken.nif("beaver_raw_callback_reply")};
-const handwritten_nifs = capi_registry.nifs ++ mlir_capi.EntriesOfKinds ++ pass.nifs ++ registry.nifs ++ string_ref.nifs ++ diagnostic.nifs ++ pointer.nifs ++ memref.nifs ++ enif_support.nifs ++ callback_nifs ++ unranked_memref_descriptor.nifs ++ rewrite_pattern.nifs ++ value.nifs ++ callback_bridge.nifs ++ conversion.nifs ++ action_tracing.nifs;
+const NifFunc = e.ErlNifFunc;
 
-const num_nifs = handwritten_nifs.len;
-export var nifs: [num_nifs]e.ErlNifFunc = handwritten_nifs;
+// NIF tables exported by the partitioned native libraries. Each partition is
+// compiled as its own library so editing one domain does not force the
+// comptime-heavy CAPI registry to be regenerated. The tables are concatenated
+// at load time below because comptime values cannot cross artifact boundaries.
+extern const core_nifs: [0]NifFunc;
+extern const core_nifs_len: usize;
+extern const conversion_nifs: [0]NifFunc;
+extern const conversion_nifs_len: usize;
+extern const callback_bridge_nifs: [0]NifFunc;
+extern const callback_bridge_nifs_len: usize;
+extern const rewrite_pattern_nifs: [0]NifFunc;
+extern const rewrite_pattern_nifs_len: usize;
+
+// Registration hooks exported by the partitioned native libraries.
+extern fn core_register_all_passes() void;
+extern fn core_open_all(env: beam.env) void;
+extern fn conversion_open(env: beam.env) void;
+extern fn callback_bridge_open(env: beam.env) void;
+extern fn rewrite_pattern_open(env: beam.env) void;
+
+const max_nifs = 4096;
+var assembled_nifs: [max_nifs]NifFunc = undefined;
+var assembled_len: usize = 0;
+
+fn appendNifs(table: [*]const NifFunc, len: usize, index: *usize) void {
+    for (table[0..len]) |nif_entry| {
+        assembled_nifs[index.*] = nif_entry;
+        index.* += 1;
+    }
+}
+
+fn assembleNifs() []NifFunc {
+    const total =
+        core_nifs_len +
+        conversion_nifs_len +
+        callback_bridge_nifs_len +
+        rewrite_pattern_nifs_len;
+    if (total > max_nifs) @panic("assembled NIF table exceeds static capacity");
+    var index: usize = 0;
+    appendNifs(@ptrCast(&core_nifs), core_nifs_len, &index);
+    appendNifs(@ptrCast(&conversion_nifs), conversion_nifs_len, &index);
+    appendNifs(@ptrCast(&callback_bridge_nifs), callback_bridge_nifs_len, &index);
+    appendNifs(@ptrCast(&rewrite_pattern_nifs), rewrite_pattern_nifs_len, &index);
+    assembled_len = index;
+    return assembled_nifs[0..assembled_len];
+}
 
 export fn nif_load(env: beam.env, _: [*c]?*anyopaque, _: beam.term) c_int {
-    pass.register_all_passes();
-    kinda.open_internal_resource_types(env);
-    kinda.Internal.OpaqueStruct.open_all(env);
-    mlir_capi.open_all(env);
-    unranked_memref_descriptor.open_all(env);
-    kinda.callback_runtime.ReplyToken.open(env);
-    callback_bridge.open(env);
-    conversion.open(env);
-    action_tracing.open(env);
+    core_register_all_passes();
+    core_open_all(env);
+    conversion_open(env);
+    callback_bridge_open(env);
+    rewrite_pattern_open(env);
     return 0;
 }
 
@@ -51,22 +72,24 @@ export fn nif_upgrade(
 
 export fn nif_unload(_: beam.env, _: ?*anyopaque) void {}
 
-const entry = e.ErlNifEntry{
-    .major = 2,
-    .minor = 16,
-    .name = mlir_capi.root_module,
-    .num_of_funcs = num_nifs,
-    .funcs = &(nifs[0]),
-    .load = nif_load,
-    .reload = null,
-    .upgrade = nif_upgrade,
-    .unload = nif_unload,
-    .vm_variant = "beam.vanilla",
-    .options = 1,
-    .sizeof_ErlNifResourceTypeInit = @sizeOf(e.ErlNifResourceTypeInit),
-    .min_erts = "erts-13.0",
-};
+var entry: e.ErlNifEntry = undefined;
 
 export fn nif_init() *const e.ErlNifEntry {
+    const nifs = assembleNifs();
+    entry = e.ErlNifEntry{
+        .major = 2,
+        .minor = 16,
+        .name = mlir_capi.root_module,
+        .num_of_funcs = @intCast(nifs.len),
+        .funcs = nifs.ptr,
+        .load = nif_load,
+        .reload = null,
+        .upgrade = nif_upgrade,
+        .unload = nif_unload,
+        .vm_variant = "beam.vanilla",
+        .options = 1,
+        .sizeof_ErlNifResourceTypeInit = @sizeOf(e.ErlNifResourceTypeInit),
+        .min_erts = "erts-13.0",
+    };
     return &entry;
 }

--- a/native/src/resource_sync.zig
+++ b/native/src/resource_sync.zig
@@ -1,0 +1,33 @@
+const std = @import("std");
+const kinda = @import("kinda");
+const e = kinda.erl_nif;
+
+const mlir_capi = @import("mlir_capi.zig");
+
+extern fn core_resource_type_by_name(name: [*:0]const u8) ?*anyopaque;
+
+fn lookup(name: [*:0]const u8) ?*e.ErlNifResourceType {
+    const handle = core_resource_type_by_name(name) orelse return null;
+    return @ptrCast(handle);
+}
+
+fn syncKind(comptime k: type) void {
+    k.resource.t = lookup(k.resource.name);
+    k.Ptr.resource.t = lookup(k.Ptr.resource.name);
+    k.Array.resource.t = lookup(k.Array.resource.name);
+}
+
+/// Copies the resource type handles opened by the core partition into this
+/// partition's kind instances. Resource type handles cannot be reopened during
+/// the same NIF load, so every partition that fetches or creates kind terms
+/// must share the core-opened handles this way.
+pub fn syncResourceTypes() void {
+    inline for (mlir_capi.allKinds) |k| {
+        syncKind(k);
+    }
+    syncKind(kinda.Internal.OpaquePtr);
+    syncKind(kinda.Internal.OpaqueArray);
+    syncKind(kinda.Internal.USize);
+    syncKind(kinda.Internal.OpaqueStruct);
+    kinda.callback_runtime.ReplyToken.resource_type = lookup(kinda.callback_runtime.ReplyToken.resource_name);
+}

--- a/native/src/rewrite_pattern_root.zig
+++ b/native/src/rewrite_pattern_root.zig
@@ -1,0 +1,17 @@
+const std = @import("std");
+const kinda = @import("kinda");
+const e = kinda.erl_nif;
+const beam = kinda.beam;
+
+const rewrite_pattern = @import("rewrite_pattern.zig");
+const resource_sync = @import("resource_sync.zig");
+
+pub const nifs = rewrite_pattern.nifs;
+
+export const rewrite_pattern_nifs: [nifs.len]e.ErlNifFunc = nifs;
+export const rewrite_pattern_nifs_len: usize = nifs.len;
+
+export fn rewrite_pattern_open(env: beam.env) void {
+    kinda.callback_runtime.ReplyToken.open(env);
+    resource_sync.syncResourceTypes();
+}


### PR DESCRIPTION
## Summary

Splits the single monolithic `BeaverNIF` Zig compilation into four domain libraries plus a thin NIF shim:

- `beaver_core` — kinds, CAPI registry, and the small registries (`pass`, `registry`, `pointer`, `string_ref`, `diagnostic`, `memref`, `enif_*`, `value`, `action_tracing`)
- `beaver_conversion` — `conversion.zig`
- `beaver_callback_bridge` — `callback_bridge.zig`
- `beaver_rewrite_pattern` — `rewrite_pattern.zig`
- `BeaverNIF` — exports the single NIF entry, assembling the per-partition NIF tables at load time

Each partition is a separate dynamic library with its own Zig cache entry, so editing one domain no longer forces the comptime-heavy CAPI registry (~600 reflected NIFs) and kind surfaces to recompile and relink.

## Why this helps

Before, any edit to any `native/src/*.zig` recompiled the whole 3,279-entry NIF table from scratch (about 7s of Zig compile + link per edit, 9s wall). With the partition, a conversion/callback/rewrite edit only rebuilds that partition and the shim.

Measured on this machine (macOS, Debug):

| Edit | Before | After |
| --- | --- | --- |
| `conversion.zig` | ~9.1s | ~3.5s |
| `rewrite_pattern.zig` | ~9.1s | ~3.5s |
| no-op rebuild | ~2.0s | ~2.0s |

## How resource types stay consistent across libraries

`enif_open_resource_type` opens are keyed by module+name and pending opens within a single load are not visible to each other, so reopening the same kind in every dylib would create distinct resource types. Instead:

- `beaver_core` opens all kinds once and exports `core_resource_type_by_name/1`
- the leaf partitions call `resource_sync.syncResourceTypes()` during `nif_load` to copy the core-opened handles into their own kind instances
- each dylib opens its own private callback-runtime `LibraryPin` (per-DSO, as designed)

## Files

- `build.zig` — partition step creation, linking, rpath, install
- `native/src/main.zig` — shim: assembles the exported NIF tables and registration hooks
- `native/src/core.zig` — core partition root (NIF table + open/registration + handle lookup)
- `native/src/resource_sync.zig` — cross-partition resource-type handle sync
- `native/src/{conversion,callback_bridge,rewrite_pattern}_root.zig` — leaf partition roots

## Validation

- `BEAVER_KINDA_PATH=../kinda mix test` — 253 passed (15 doctests, 238 tests), 8 excluded
- `zig fmt --check` and `git diff --check` clean
- Debug and ReleaseSafe (`MIX_ENV=prod`) builds both succeed