### PR TITLE
Fix Triton prebuilt pipeline: nvidia backend + bash 3.2 portability

### DIFF
--- a/scripts/build-triton-prebuilt.sh
+++ b/scripts/build-triton-prebuilt.sh
@@ -25,6 +25,7 @@ cmake -S "${triton_dir}" -B "${build_dir}" -G Ninja \
   -DTRITON_BUILD_UT=OFF \
   -DTRITON_BUILD_PROTON=OFF \
   -DTRITON_BUILD_WITH_CCACHE="${ccache}" \
+  -DTRITON_CODEGEN_BACKENDS=nvidia \
   -DTRITON_CACHE_PATH="${TRITON_CACHE_PATH:-${HOME}/.triton}" \
   -DLLVM_SYSPATH="${llvm_syspath}" \
   -DMLIR_DIR="${mlir_dir}" \
@@ -48,6 +49,12 @@ core_targets=(
   TritonLLVMIR
   TritonAnalysis
   TritonTools
+  NVGPUIR
+  NVWSIR
+  NVWSTransforms
+  NVGPUToLLVM
+  TritonNVIDIAGPUToLLVM
+  NVHopperTransforms
 )
 
 echo "Building ${#core_targets[@]} Triton core targets"
@@ -80,6 +87,9 @@ esac
 echo "Copying Triton headers"
 cp -R "${triton_dir}/include"/. "${output_dir}/include"/
 cp -R "${build_dir}/include"/. "${output_dir}/include"/
+mkdir -p "${output_dir}/include/third_party"
+cp -R "${triton_dir}/third_party"/. "${output_dir}/include/third_party"/
+cp -R "${build_dir}/third_party"/. "${output_dir}/include/third_party"/
 
 echo "Triton prebuilt at ${output_dir}"
 find "${output_dir}" -maxdepth 2 -type d | head -20

--- a/scripts/build-triton-prebuilt.sh
+++ b/scripts/build-triton-prebuilt.sh
@@ -63,8 +63,12 @@ ninja -C "${build_dir}" "${core_targets[@]}"
 mkdir -p "${output_dir}/lib" "${output_dir}/include"
 
 echo "Bundling Triton object libraries"
-mapfile -t objects < <(
-  find "${build_dir}/lib" "${build_dir}/third_party" -path '*CMakeFiles/*.dir/*.o' 2>/dev/null
+objects=()
+while IFS= read -r -d '' obj; do
+  objects+=("${obj}")
+done < <(
+  find "${build_dir}/lib" "${build_dir}/third_party" \
+    -path '*CMakeFiles/*.dir/*.o' -print0 2>/dev/null
 )
 if ((${#objects[@]} == 0)); then
   echo "no Triton object files found under ${build_dir}" >&2

--- a/scripts/build-triton-prebuilt.sh
+++ b/scripts/build-triton-prebuilt.sh
@@ -45,7 +45,6 @@ core_targets=(
   GluonTransforms
   TritonToTritonGPU
   TritonGPUToLLVM
-  TritonInstrumentToLLVM
   TritonLLVMIR
   TritonAnalysis
   TritonTools


### PR DESCRIPTION
Follow-up to #494. The Triton core prebuilt pipeline needed two fixes, discovered while building the #491 integration:

1. `TRITON_CODEGEN_BACKENDS=nvidia` — Triton's core GPU transforms include NVWS/NVGPU generated headers from `third_party/nvidia`, so the compiler-only build must enable the backend (which also provides the `convert-triton-gpu-to-llvm` pass libraries). The prebuilt now bundles `third_party` headers + generated incs.
2. Portable object collection — GitHub macOS runners default to bash 3.2 which lacks `mapfile`; replaced with a while-read loop.

Also drops `TritonInstrumentToLLVM` from the core targets (it depends on nvidia tablegen outputs and isn't needed by the integration).

Verified: both ubuntu-x64 and macOS-arm64 prebuilt builds pass and publish assets to release `triton-prebuilt-882eb72e…`.