### PR TITLE
Speed up CAPI manifest generation

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -37,11 +37,12 @@ fn createCapiModule(b: *std.Build, target: std.Build.ResolvedTarget, optimize: s
 
     const manifest_generator = b.addSystemCommand(&.{"elixir"});
     manifest_generator.addFileArg(b.path("native/tools/capi/gen_manifest.exs"));
+    manifest_generator.addArg("--ast");
+    manifest_generator.addFileArg(capi_ast);
     manifest_generator.addArg("--declaration");
     const declaration_manifest = manifest_generator.addOutputFileArg("capi_manifest.json");
     manifest_generator.addArg("--callback-bridge");
     const callback_bridge_manifest = manifest_generator.addOutputFileArg("capi_callback_bridge.json");
-    manifest_generator.setStdIn(.{ .lazy_path = capi_ast });
 
     b.getInstallStep().dependOn(&b.addInstallFile(declaration_manifest, "capi_manifest.json").step);
     b.getInstallStep().dependOn(&b.addInstallFile(callback_bridge_manifest, "capi_callback_bridge.json").step);

--- a/native/tools/capi/gen_manifest.exs
+++ b/native/tools/capi/gen_manifest.exs
@@ -92,10 +92,16 @@ defmodule Beaver.CAPI.ManifestGenerator do
   def run(argv) do
     {opts, _, _} =
       OptionParser.parse(argv,
-        strict: [declaration: :string, callback_bridge: :string]
+        strict: [declaration: :string, callback_bridge: :string, ast: :string]
       )
 
-    ast = IO.read(:stdio, :eof) |> decode_json!()
+    ast =
+      case Keyword.get(opts, :ast) do
+        nil -> IO.binread(:stdio, :eof)
+        path -> File.read!(path)
+      end
+      |> decode_json!()
+
     policy = policy_from_ast(ast)
 
     functions =


### PR DESCRIPTION
## Summary

The `capi_manifest.json` / `capi_callback_bridge.json` generation step took ~16s whenever the CAPI header changed. Profiling showed the work itself is fast (decode 0.08s, traversal ~0s, encode ~0.01s); the cost was `IO.read(:stdio, :eof)` on the ~15MB clang AST JSON piped through stdin.

`IO.read/2` reads through the IO server in char-oriented chunks and took ~13s on this input, while binary reads are effectively free:

- pass the AST JSON to `gen_manifest.exs` as a `--ast <file>` argument and read it with `File.read!`
- keep a stdin fallback but switch it to `IO.binread(:stdio, :eof)`

## Impact (measured, macOS)

| Stage | Before | After |
| --- | --- | --- |
| `gen_manifest.exs` (stdin) | ~15s | ~1.2s |
| `gen_manifest.exs` (`--ast` file, used by `zig build`) | ~15s | ~0.3s |
| manifest step inside `zig build` | ~16s | ~0.4-0.5s |
| full CAPI-header-change rebuild | ~24s | ~11.6s (remaining ~9s is the inherent core comptime rebuild) |

Generated manifests are byte-identical to the previous pipeline (`cmp` verified).

## Validation

- `BEAVER_KINDA_PATH=../kinda mix test` — 263 passed (15 doctests, 248 tests), 8 excluded
- `zig fmt --check`, `mix format --check-formatted`, `git diff --check` clean
- stdin fallback still works and produces identical output