### PR TITLE
Add cache-stable CompilationPlan declarations

### DIFF
--- a/guides/incremental-compilation-runtime.md
+++ b/guides/incremental-compilation-runtime.md
@@ -9,19 +9,33 @@ The runtime caches transformed MLIR bytecode rather than a live context or JIT.
 This makes the handoff explicit: the same validated artifact can be loaded into
 a new execution engine or emitted as an object file.
 
+## Declarative compilation plans
+
+`Beaver.MLIR.CompilationPlan` closes a compilation configuration into a reusable,
+inspectable, cache-stable declaration above `Composer`, `Transform.Schedule`, and
+`CompilationRuntime`.
+
 ```elixir
+defmodule MyNativeExtension do
+  import Beaver.MLIR.CompilationPlan
+
+  defcompiler kernel_compiler do
+    Beaver.MLIR.CompilationPlan.new(
+      pipeline: "convert-func-to-llvm,convert-arith-to-llvm",
+      target: %{triple: "aarch64-apple-darwin", features: "+neon"},
+      schema_version: "my_dynamic_dialect/v3",
+      telemetry_metadata: %{compiler: :kernel}
+    )
+  end
+end
+
 alias Beaver.MLIR
 
 source = File.read!("native/kernel.mlir")
+plan = MyNativeExtension.kernel_compiler()
+cache = {:file, ".beaver/cache"}
 
-compile_opts = [
-  pipeline: "convert-func-to-llvm,convert-arith-to-llvm",
-  target: %{triple: "aarch64-apple-darwin", features: "+neon"},
-  schema_version: "my_dynamic_dialect/v3",
-  cache: {:file, ".beaver/cache"}
-]
-
-artifact = MLIR.CompilationRuntime.compile!(source, compile_opts)
+artifact = MLIR.CompilationRuntime.compile!(source, plan, cache: cache)
 
 jit = MLIR.CompilationRuntime.jit!(artifact)
 MLIR.CompilationRuntime.emit_object!(artifact, "_build/native/kernel.o")
@@ -30,15 +44,20 @@ MLIR.CompilationRuntime.emit_object!(artifact, "_build/native/kernel.o")
 next_artifact =
   "native/kernel.mlir"
   |> File.read!()
-  |> MLIR.CompilationRuntime.compile!(compile_opts)
+  |> MLIR.CompilationRuntime.compile!(plan, cache: cache)
 
 next_jit = MLIR.CompilationRuntime.jit!(next_artifact)
 MLIR.ExecutionEngine.destroy(jit)
 jit = next_jit
 ```
 
+`Beaver.MLIR.CompilationPlan.declaration/1` contains only deterministic metadata,
+and `Beaver.MLIR.CompilationPlan.identity/1` hashes that projection without creating an MLIR
+context. Cache backends, borrowed contexts, telemetry callbacks, and LLVM revision
+overrides remain runtime options and are not stored in the declaration.
+
 The artifact key contains the source digest and structural hash, Beaver's LLVM
-version, pipeline identity, target configuration, dynamic dialect/schema
+version, plan identity (`plan_id`), target configuration, dynamic dialect/schema
 version, and requested bytecode version. Changing any of these inputs is a
 cache miss. Stored bytecode is checksummed and its metadata is revalidated
 before use; read, write, or validation failure falls back to a normal compile.
@@ -47,11 +66,29 @@ For a custom Elixir pass or another runtime function, provide a stable version
 because a closure is not a deterministic cache identity:
 
 ```elixir
-MLIR.CompilationRuntime.compile!(source,
-  pipeline: [MyPass],
-  pipeline_version: {MyPass, 4}
-)
+plan =
+  Beaver.MLIR.CompilationPlan.new()
+  |> Beaver.MLIR.CompilationPlan.add_pass(MyPass, version: {MyPass, 4})
+
+MLIR.CompilationRuntime.compile!(source, plan)
 ```
+
+Callback passes use the same Composer tuple and must also carry a stable version:
+
+```elixir
+plan =
+  Beaver.MLIR.CompilationPlan.new()
+  |> Beaver.MLIR.CompilationPlan.add_pass(
+    {"lower-runtime", "builtin.module", &lower_runtime/1},
+    version: 3
+  )
+```
+
+The callback itself remains executable runtime payload; only its pass argument,
+root operation, and explicit version enter the declaration. The legacy keyword API
+continues to accept `:pipeline_version` for compatibility, but plans version each
+module or callback step so changes to surrounding pass and nested-scope data cannot
+be hidden by one manually maintained pipeline version.
 
 Use `cache: :memory` for process-local iteration, or `cache: {:file, path}` to
 reuse artifacts across BEAM restarts. Invalidate one lookup key or the whole

--- a/lib/beaver/mlir/compilation_plan.ex
+++ b/lib/beaver/mlir/compilation_plan.ex
@@ -1,0 +1,452 @@
+defmodule Beaver.MLIR.CompilationPlan do
+  @moduledoc """
+  A reusable, inspectable, cache-stable MLIR compiler declaration.
+
+  A plan closes Composer-compatible pass data, a Transform schedule, target and
+  schema configuration, bytecode version, context options, and telemetry metadata
+  into one value. It owns no MLIR context or native resource.
+
+  Pipeline strings and nested pipeline strings are deterministic data. Module and
+  callback passes contain executable behavior, so each such step must be wrapped
+  with an explicit stable version through `add_pass/3` or `versioned/2`. Function
+  bodies, processes, references, and native handles are never hashed.
+
+  `declaration/1` projects the executable plan to deterministic data, while
+  `identity/1` hashes that projection. Both are computed from the current struct;
+  no cached identity can drift from a modified plan.
+  """
+
+  alias Beaver.MLIR.CompilationRuntime.CacheKey
+  alias Beaver.MLIR.Transform.Schedule, as: TransformSchedule
+
+  @versioned_step :beaver_compilation_plan_versioned_step
+
+  defstruct pipeline: [],
+            transform_schedule: nil,
+            transform_options: [],
+            target: %{},
+            schema_version: :static,
+            desired_emit_version: nil,
+            context_options: [],
+            telemetry_metadata: %{}
+
+  @type pass_step() ::
+          binary()
+          | module()
+          | {binary(), [pass_step()]}
+          | {binary(), binary(), function()}
+          | {:beaver_compilation_plan_versioned_step, term(), term()}
+
+  @type t() :: %__MODULE__{
+          pipeline: [pass_step()],
+          transform_schedule: TransformSchedule.Resolved.t() | binary() | nil,
+          transform_options: keyword(),
+          target: term(),
+          schema_version: term(),
+          desired_emit_version: integer() | nil,
+          context_options: keyword(),
+          telemetry_metadata: map()
+        }
+
+  @valid_options [
+    :pipeline,
+    :transform_schedule,
+    :transform_options,
+    :target,
+    :schema_version,
+    :desired_emit_version,
+    :bytecode_version,
+    :context_options,
+    :telemetry_metadata
+  ]
+
+  @doc "Creates and validates a compilation plan without constructing native resources."
+  @spec new(keyword()) :: t()
+  def new(opts \\ []) do
+    validate_keyword!(opts, @valid_options, "CompilationPlan options")
+
+    desired_emit_version = desired_emit_version!(opts)
+    transform_options = keyword_value!(opts, :transform_options, [])
+    context_options = keyword_value!(opts, :context_options, [])
+    telemetry_metadata = metadata_value!(opts)
+
+    %__MODULE__{
+      pipeline: opts |> Keyword.get(:pipeline, []) |> List.wrap() |> normalize_pipeline(),
+      transform_schedule: Keyword.get(opts, :transform_schedule),
+      transform_options: transform_options,
+      target: Keyword.get(opts, :target, %{}),
+      schema_version: Keyword.get(opts, :schema_version, :static),
+      desired_emit_version: desired_emit_version,
+      context_options: context_options,
+      telemetry_metadata: telemetry_metadata
+    }
+    |> validate!()
+  end
+
+  @doc "Wraps one Composer pass payload with an explicit stable version."
+  @spec versioned(term(), term()) :: pass_step()
+  def versioned(pass, version) when not is_nil(version) do
+    {@versioned_step, pass, version}
+  end
+
+  def versioned(_pass, nil) do
+    raise ArgumentError, "a versioned pass requires a non-nil :version"
+  end
+
+  @doc "Appends one Composer-compatible pass, optionally with `:version`."
+  @spec add_pass(t(), term(), keyword()) :: t()
+  def add_pass(%__MODULE__{} = plan, pass, opts \\ []) do
+    validate_keyword!(opts, [:version], "add_pass options")
+
+    step =
+      case Keyword.fetch(opts, :version) do
+        {:ok, version} -> versioned(pass, version)
+        :error -> normalize_pass_step(pass)
+      end
+
+    %{plan | pipeline: plan.pipeline ++ [step]}
+    |> validate!()
+  end
+
+  @doc "Appends a nested Composer pass scope."
+  @spec nested(t(), binary(), [pass_step()]) :: t()
+  def nested(%__MODULE__{} = plan, operation_name, passes)
+      when is_binary(operation_name) and is_list(passes) do
+    %{plan | pipeline: plan.pipeline ++ [{operation_name, normalize_pipeline(passes)}]}
+    |> validate!()
+  end
+
+  @doc "Sets the Transform schedule and its execution options."
+  @spec set_transform_schedule(t(), TransformSchedule.Resolved.t() | binary() | nil, keyword()) ::
+          t()
+  def set_transform_schedule(%__MODULE__{} = plan, schedule, opts \\ []) do
+    unless Keyword.keyword?(opts) do
+      raise ArgumentError, ":transform_options must be a keyword list"
+    end
+
+    %{plan | transform_schedule: schedule, transform_options: opts}
+    |> validate!()
+  end
+
+  @doc "Sets the target configuration included in the plan identity."
+  @spec set_target(t(), term()) :: t()
+  def set_target(%__MODULE__{} = plan, target), do: validate!(%{plan | target: target})
+
+  @doc "Sets the dynamic dialect/schema identity."
+  @spec set_schema_version(t(), term()) :: t()
+  def set_schema_version(%__MODULE__{} = plan, version) do
+    validate!(%{plan | schema_version: version})
+  end
+
+  @doc "Sets the desired MLIR bytecode emission version."
+  @spec set_bytecode_version(t(), integer() | :current | nil) :: t()
+  def set_bytecode_version(%__MODULE__{} = plan, version) do
+    validate!(%{plan | desired_emit_version: validate_bytecode_version!(version)})
+  end
+
+  @doc "Sets options used when the compilation runtime creates an MLIR context."
+  @spec set_context_options(t(), keyword()) :: t()
+  def set_context_options(%__MODULE__{} = plan, opts) do
+    unless Keyword.keyword?(opts),
+      do: raise(ArgumentError, ":context_options must be a keyword list")
+
+    validate!(%{plan | context_options: opts})
+  end
+
+  @doc "Sets deterministic metadata attached to compilation and artifact telemetry."
+  @spec set_telemetry_metadata(t(), map() | keyword()) :: t()
+  def set_telemetry_metadata(%__MODULE__{} = plan, metadata) do
+    validate!(%{plan | telemetry_metadata: metadata_map!(metadata)})
+  end
+
+  @doc "Returns the deterministic, callback-free declaration represented by a plan."
+  @spec declaration(t()) :: map()
+  def declaration(%__MODULE__{} = plan) do
+    validate_shape!(plan)
+
+    declaration = %{
+      pipeline: Enum.map(plan.pipeline, &pass_declaration!/1),
+      transform_schedule: transform_schedule_declaration!(plan.transform_schedule),
+      transform_options: transform_options_declaration!(plan),
+      target: plan.target,
+      schema_version: plan.schema_version,
+      bytecode_version: plan.desired_emit_version || :current,
+      context_options: canonical_keyword!(plan.context_options, :context_options),
+      telemetry_metadata: plan.telemetry_metadata
+    }
+
+    ensure_deterministic!(declaration, "compilation plan declaration")
+  end
+
+  @doc "Returns the stable SHA-256 identity of `declaration/1`."
+  @spec identity(t()) :: binary()
+  def identity(%__MODULE__{} = plan) do
+    CacheKey.lookup(%{compilation_plan: {1, declaration(plan)}})
+  end
+
+  @doc false
+  @spec executable_pipeline(t()) :: list()
+  def executable_pipeline(%__MODULE__{pipeline: pipeline}) do
+    Enum.map(pipeline, &executable_pass/1)
+  end
+
+  @doc "Validates a plan and returns it unchanged."
+  @spec validate!(t()) :: t()
+  def validate!(%__MODULE__{} = plan) do
+    _identity = identity(plan)
+    plan
+  end
+
+  def validate!(other) do
+    raise ArgumentError,
+          "defcompiler must return a Beaver.MLIR.CompilationPlan, got: #{inspect(other, limit: 5)}"
+  end
+
+  @doc "Defines a zero-arity function that returns a validated compilation plan."
+  defmacro defcompiler(call, opts_or_block) do
+    plan_module = __MODULE__
+
+    body =
+      case opts_or_block do
+        [do: block] ->
+          block
+
+        opts when is_list(opts) ->
+          quote do
+            unquote(plan_module).new(unquote(opts))
+          end
+      end
+
+    quote do
+      def unquote(call) do
+        unquote(body)
+        |> unquote(plan_module).validate!()
+      end
+    end
+  end
+
+  defp desired_emit_version!(opts) do
+    desired = Keyword.fetch(opts, :desired_emit_version)
+    alias_value = Keyword.fetch(opts, :bytecode_version)
+
+    case {desired, alias_value} do
+      {{:ok, left}, {:ok, right}} ->
+        left = validate_bytecode_version!(left)
+        right = validate_bytecode_version!(right)
+
+        if left == right do
+          left
+        else
+          raise ArgumentError, ":desired_emit_version and :bytecode_version disagree"
+        end
+
+      {{:ok, value}, _} ->
+        validate_bytecode_version!(value)
+
+      {_, {:ok, value}} ->
+        validate_bytecode_version!(value)
+
+      _ ->
+        nil
+    end
+  end
+
+  defp validate_bytecode_version!(:current), do: nil
+  defp validate_bytecode_version!(value) when is_integer(value) or is_nil(value), do: value
+
+  defp validate_bytecode_version!(value) do
+    raise ArgumentError, ":desired_emit_version must be an integer or nil, got: #{inspect(value)}"
+  end
+
+  defp keyword_value!(opts, key, default) do
+    value = Keyword.get(opts, key, default)
+
+    unless Keyword.keyword?(value) do
+      raise ArgumentError, "#{inspect(key)} must be a keyword list"
+    end
+
+    value
+  end
+
+  defp metadata_value!(opts) do
+    opts |> Keyword.get(:telemetry_metadata, %{}) |> metadata_map!()
+  end
+
+  defp metadata_map!(metadata) when is_map(metadata), do: metadata
+
+  defp metadata_map!(metadata) when is_list(metadata) do
+    if Keyword.keyword?(metadata) do
+      Map.new(metadata)
+    else
+      raise ArgumentError, ":telemetry_metadata must be a map or keyword list"
+    end
+  end
+
+  defp metadata_map!(_metadata) do
+    raise ArgumentError, ":telemetry_metadata must be a map or keyword list"
+  end
+
+  defp validate_keyword!(opts, allowed, label) do
+    unless Keyword.keyword?(opts) do
+      raise ArgumentError, "#{label} must be a keyword list, got: #{inspect(opts)}"
+    end
+
+    keys = Keyword.keys(opts)
+
+    if length(keys) != length(Enum.uniq(keys)) do
+      raise ArgumentError, "#{label} must not contain duplicate keys"
+    end
+
+    case keys -- allowed do
+      [] -> :ok
+      unsupported -> raise ArgumentError, "unsupported #{label}: #{inspect(unsupported)}"
+    end
+  end
+
+  defp normalize_pipeline(pipeline), do: Enum.map(pipeline, &normalize_pass_step/1)
+
+  defp normalize_pass_step({operation_name, passes})
+       when is_binary(operation_name) and is_list(passes) do
+    {operation_name, normalize_pipeline(passes)}
+  end
+
+  defp normalize_pass_step({pass, [version: version]}), do: versioned(pass, version)
+  defp normalize_pass_step({@versioned_step, pass, version}), do: versioned(pass, version)
+  defp normalize_pass_step(pass), do: pass
+
+  defp pass_declaration!({@versioned_step, pass, version}) do
+    version = stable_version!(version)
+    {:versioned, versioned_pass_declaration!(pass), version}
+  end
+
+  defp pass_declaration!({operation_name, passes})
+       when is_binary(operation_name) and is_list(passes) do
+    {:nested, operation_name, Enum.map(passes, &pass_declaration!/1)}
+  end
+
+  defp pass_declaration!(pipeline) when is_binary(pipeline), do: {:pipeline, pipeline}
+
+  defp pass_declaration!(module) when is_atom(module) do
+    raise ArgumentError,
+          "module pass #{inspect(module)} requires an explicit :version"
+  end
+
+  defp pass_declaration!({_argument, _operation_name, callback}) when is_function(callback) do
+    raise ArgumentError, "callback-backed pass requires an explicit :version"
+  end
+
+  defp pass_declaration!(callback) when is_function(callback) do
+    raise ArgumentError,
+          "callback-backed pass requires an explicit :version and a Composer pass tuple"
+  end
+
+  defp pass_declaration!(pass) do
+    raise ArgumentError,
+          "unsupported or non-deterministic Composer pass: #{inspect(pass, limit: 5)}"
+  end
+
+  defp versioned_pass_declaration!(module) when is_atom(module) do
+    {:module, Atom.to_string(module)}
+  end
+
+  defp versioned_pass_declaration!({argument, operation_name, callback})
+       when is_function(callback) do
+    {:callback, ensure_deterministic!(argument, "pass argument"),
+     ensure_deterministic!(operation_name, "pass operation")}
+  end
+
+  defp versioned_pass_declaration!({operation_name, passes})
+       when is_binary(operation_name) and is_list(passes) do
+    {:nested, operation_name, Enum.map(passes, &pass_declaration!/1)}
+  end
+
+  defp versioned_pass_declaration!(pipeline) when is_binary(pipeline),
+    do: {:pipeline, pipeline}
+
+  defp versioned_pass_declaration!(callback) when is_function(callback) do
+    raise ArgumentError,
+          "a callback Composer pass must be {argument, operation_name, callback}"
+  end
+
+  defp versioned_pass_declaration!(pass) do
+    raise ArgumentError,
+          "unsupported Composer pass payload: #{inspect(pass, limit: 5)}"
+  end
+
+  defp executable_pass({@versioned_step, pass, _version}), do: executable_pass(pass)
+
+  defp executable_pass({operation_name, passes})
+       when is_binary(operation_name) and is_list(passes) do
+    {operation_name, Enum.map(passes, &executable_pass/1)}
+  end
+
+  defp executable_pass(pass), do: pass
+
+  defp transform_schedule_declaration!(nil), do: :none
+
+  defp transform_schedule_declaration!(%TransformSchedule.Resolved{} = schedule) do
+    TransformSchedule.cache_identity(schedule)
+  end
+
+  defp transform_schedule_declaration!(schedule) when is_binary(schedule) do
+    TransformSchedule.cache_identity(schedule)
+  end
+
+  defp transform_schedule_declaration!(schedule) do
+    raise ArgumentError,
+          ":transform_schedule must be resolved data or MLIR text/bytecode, got: #{inspect(schedule, limit: 5)}"
+  end
+
+  defp transform_options_declaration!(%__MODULE__{transform_schedule: nil}), do: :none
+
+  defp transform_options_declaration!(%__MODULE__{transform_options: opts}) do
+    opts |> canonical_keyword!(:transform_options) |> Map.new()
+  end
+
+  defp canonical_keyword!(opts, label) do
+    unless Keyword.keyword?(opts),
+      do: raise(ArgumentError, "#{inspect(label)} must be a keyword list")
+
+    keys = Keyword.keys(opts)
+
+    if length(keys) != length(Enum.uniq(keys)) do
+      raise ArgumentError, "#{inspect(label)} must not contain duplicate keys"
+    end
+
+    Enum.sort(opts)
+  end
+
+  defp validate_shape!(%__MODULE__{} = plan) do
+    unless is_list(plan.pipeline), do: raise(ArgumentError, ":pipeline must be a list")
+
+    unless Keyword.keyword?(plan.transform_options),
+      do: raise(ArgumentError, ":transform_options must be a keyword list")
+
+    unless Keyword.keyword?(plan.context_options),
+      do: raise(ArgumentError, ":context_options must be a keyword list")
+
+    unless is_map(plan.telemetry_metadata),
+      do: raise(ArgumentError, ":telemetry_metadata must be a map")
+
+    unless is_integer(plan.desired_emit_version) or is_nil(plan.desired_emit_version) do
+      raise ArgumentError, ":desired_emit_version must be an integer or nil"
+    end
+
+    :ok
+  end
+
+  defp ensure_deterministic!(value, label) do
+    _digest = CacheKey.lookup(%{compilation_plan_value: value})
+    value
+  rescue
+    error in ArgumentError ->
+      reraise ArgumentError,
+              [message: "#{label} must contain only deterministic data: #{error.message}"],
+              __STACKTRACE__
+  end
+
+  defp stable_version!(nil),
+    do: raise(ArgumentError, "a versioned pass requires a non-nil :version")
+
+  defp stable_version!(version), do: ensure_deterministic!(version, "pass version")
+end

--- a/lib/beaver/mlir/compilation_runtime.ex
+++ b/lib/beaver/mlir/compilation_runtime.ex
@@ -20,8 +20,10 @@ defmodule Beaver.MLIR.CompilationRuntime do
     * dynamic dialect/schema version;
     * requested bytecode emit version.
 
-  Custom pass functions are not stable cache identities. Supply an explicit
-  `:pipeline_version` whenever `:pipeline` contains runtime functions.
+  Custom pass functions are not stable cache identities. In the keyword API,
+  supply `:pipeline_version` whenever `:pipeline` contains runtime functions.
+  `Beaver.MLIR.CompilationPlan` instead requires an explicit version on every
+  module- or callback-backed pass step.
 
   ## Telemetry
 
@@ -33,6 +35,7 @@ defmodule Beaver.MLIR.CompilationRuntime do
   alias Beaver.Composer
   alias Beaver.MLIR
   alias MLIR.CompilationCache
+  alias MLIR.CompilationPlan
   alias MLIR.Transform
   alias MLIR.Transform.Schedule, as: TransformSchedule
   alias __MODULE__.{Artifact, CacheKey}
@@ -53,50 +56,134 @@ defmodule Beaver.MLIR.CompilationRuntime do
           | {:llvm_revision, String.t()}
           | {:telemetry, (list(atom()), map(), map() -> any())}
 
+  @type plan_runtime_option ::
+          {:cache, CompilationCache.cache()}
+          | {:context, MLIR.Context.t()}
+          | {:llvm_revision, String.t()}
+          | {:telemetry, (list(atom()), map(), map() -> any())}
+
   @spec llvm_revision() :: String.t()
   def llvm_revision do
     MLIR.CAPI.beaverGetLLVMVersion() |> MLIR.to_string()
   end
 
-  @spec compile(binary() | MLIR.Module.t(), [compile_option()]) ::
+  @spec compile(binary() | MLIR.Module.t(), [compile_option()] | CompilationPlan.t()) ::
           {:ok, Artifact.t()} | {:error, Exception.t()}
-  def compile(source, opts \\ []) do
+  def compile(source, opts_or_plan \\ [])
+
+  def compile(source, %CompilationPlan{} = plan), do: compile(source, plan, [])
+
+  def compile(source, opts) when is_list(opts) do
     {:ok, compile!(source, opts)}
   rescue
     exception -> {:error, exception}
   end
 
-  @spec compile!(binary() | MLIR.Module.t(), [compile_option()]) :: Artifact.t()
-  def compile!(source, opts \\ []) do
+  @spec compile(binary() | MLIR.Module.t(), CompilationPlan.t(), [plan_runtime_option()]) ::
+          {:ok, Artifact.t()} | {:error, Exception.t()}
+  def compile(source, %CompilationPlan{} = plan, runtime_opts) do
+    {:ok, compile!(source, plan, runtime_opts)}
+  rescue
+    exception -> {:error, exception}
+  end
+
+  @spec compile!(binary() | MLIR.Module.t(), [compile_option()] | CompilationPlan.t()) ::
+          Artifact.t()
+  def compile!(source, opts_or_plan \\ [])
+
+  def compile!(source, %CompilationPlan{} = plan), do: compile!(source, plan, [])
+
+  def compile!(source, opts) when is_list(opts) do
+    do_compile!(source, opts, nil)
+  end
+
+  @spec compile!(binary() | MLIR.Module.t(), CompilationPlan.t(), [plan_runtime_option()]) ::
+          Artifact.t()
+  def compile!(source, %CompilationPlan{} = plan, runtime_opts) do
+    {opts, plan_info} = plan_options!(plan, runtime_opts)
+    do_compile!(source, opts, plan_info)
+  end
+
+  defp plan_options!(%CompilationPlan{} = plan, runtime_opts) do
+    validate_plan_runtime_options!(runtime_opts)
+    declaration = CompilationPlan.declaration(plan)
+    plan_id = CompilationPlan.identity(plan)
+
+    plan_opts =
+      [
+        pipeline: CompilationPlan.executable_pipeline(plan),
+        pipeline_version: declaration.pipeline,
+        transform_schedule: plan.transform_schedule,
+        transform_options: plan.transform_options,
+        target: plan.target,
+        schema_version: plan.schema_version,
+        desired_emit_version: plan.desired_emit_version,
+        context_options: plan.context_options
+      ]
+      |> Keyword.reject(fn {key, value} -> key == :desired_emit_version and is_nil(value) end)
+
+    plan_info = %{
+      id: plan_id,
+      declaration: declaration,
+      telemetry_metadata: plan.telemetry_metadata
+    }
+
+    {Keyword.merge(plan_opts, runtime_opts), plan_info}
+  end
+
+  defp validate_plan_runtime_options!(opts) do
+    unless Keyword.keyword?(opts) do
+      raise ArgumentError, "CompilationPlan runtime options must be a keyword list"
+    end
+
+    allowed = [:cache, :context, :telemetry, :llvm_revision]
+    keys = Keyword.keys(opts)
+
+    if length(keys) != length(Enum.uniq(keys)) do
+      raise ArgumentError, "CompilationPlan runtime options must not contain duplicate keys"
+    end
+
+    case keys -- allowed do
+      [] ->
+        :ok
+
+      unsupported ->
+        raise ArgumentError, "unsupported plan runtime options: #{inspect(unsupported)}"
+    end
+  end
+
+  defp do_compile!(source, opts, plan_info) do
     cache = Keyword.get(opts, :cache, :memory)
     {source_bytes, source_context} = source_bytes_and_context(source)
-    inputs = compatibility_inputs(source_bytes, opts)
+    inputs = source_bytes |> compatibility_inputs(opts) |> put_plan_input(plan_info)
     lookup_key = CacheKey.lookup(inputs)
 
     {cached, cache_lookup_duration} = timed(fn -> CompilationCache.get(cache, lookup_key) end)
 
-    MLIR.Telemetry.emit(
+    emit(
       [:cache, :lookup],
       %{duration: cache_lookup_duration},
       %{lookup_key: lookup_key},
-      opts
+      opts,
+      plan_info
     )
 
     case validate_cache_entry(cached, lookup_key, inputs) do
       {:ok, entry} ->
         timings = %{cache_lookup: cache_lookup_duration, parse: 0, transform: 0, serialize: 0}
-        emit_cache_result(:hit, lookup_key, timings, opts)
+        emit_cache_result(:hit, lookup_key, timings, opts, plan_info)
         artifact_from_entry(entry, :hit, timings)
 
       {:miss, reason} ->
         if reason != :not_found do
           CompilationCache.delete(cache, lookup_key)
 
-          MLIR.Telemetry.emit(
+          emit(
             [:cache, :failure],
             %{count: 1},
             %{lookup_key: lookup_key, reason: reason},
-            opts
+            opts,
+            plan_info
           )
         end
 
@@ -107,7 +194,8 @@ defmodule Beaver.MLIR.CompilationRuntime do
           lookup_key,
           cache,
           cache_lookup_duration,
-          opts
+          opts,
+          plan_info
         )
     end
   end
@@ -180,7 +268,8 @@ defmodule Beaver.MLIR.CompilationRuntime do
          lookup_key,
          cache,
          cache_lookup_duration,
-         opts
+         opts,
+         plan_info
        ) do
     {context, owned_context?} = compilation_context(source_context, opts)
 
@@ -211,6 +300,7 @@ defmodule Beaver.MLIR.CompilationRuntime do
             lookup_key: lookup_key,
             artifact_key: artifact_key
           })
+          |> put_plan_artifact_metadata(plan_info)
 
         entry = %{
           format: @entry_format,
@@ -226,11 +316,12 @@ defmodule Beaver.MLIR.CompilationRuntime do
             :ok
 
           {:error, reason} ->
-            MLIR.Telemetry.emit(
+            emit(
               [:cache, :failure],
               %{count: 1},
               %{lookup_key: lookup_key, reason: {:write, reason}},
-              opts
+              opts,
+              plan_info
             )
         end
 
@@ -241,10 +332,10 @@ defmodule Beaver.MLIR.CompilationRuntime do
           serialize: serialize_duration
         }
 
-        emit_stage(:parse, parse_duration, artifact_key, opts)
-        emit_stage(:transform, transform_duration, artifact_key, opts)
-        emit_stage(:serialize, serialize_duration, artifact_key, opts)
-        emit_cache_result(:miss, lookup_key, timings, opts)
+        emit_stage(:parse, parse_duration, artifact_key, opts, plan_info)
+        emit_stage(:transform, transform_duration, artifact_key, opts, plan_info)
+        emit_stage(:serialize, serialize_duration, artifact_key, opts, plan_info)
+        emit_cache_result(:miss, lookup_key, timings, opts, plan_info)
 
         artifact_from_entry(entry, :miss, timings)
       after
@@ -280,6 +371,9 @@ defmodule Beaver.MLIR.CompilationRuntime do
       bytecode_version: Keyword.get(opts, :desired_emit_version, :current)
     }
   end
+
+  defp put_plan_input(inputs, nil), do: inputs
+  defp put_plan_input(inputs, %{id: plan_id}), do: Map.put(inputs, :plan_id, plan_id)
 
   defp pipeline_identity(opts) do
     case Keyword.fetch(opts, :pipeline_version) do
@@ -418,20 +512,53 @@ defmodule Beaver.MLIR.CompilationRuntime do
     Keyword.take(opts, [:shared_lib_paths, :opt_level, :object_dump, :enable_pic, :dirty])
   end
 
-  defp emit_stage(stage, duration, artifact_key, opts) do
-    MLIR.Telemetry.emit([stage], %{duration: duration}, %{artifact_key: artifact_key}, opts)
+  defp put_plan_artifact_metadata(metadata, nil), do: metadata
+
+  defp put_plan_artifact_metadata(metadata, plan_info) do
+    Map.merge(metadata, %{
+      compilation_plan: plan_info.declaration,
+      plan_id: plan_info.id,
+      telemetry_metadata: plan_info.telemetry_metadata
+    })
   end
 
-  defp emit_cache_result(result, lookup_key, timings, opts) do
-    MLIR.Telemetry.emit(
+  defp emit_stage(stage, duration, artifact_key, opts, plan_info) do
+    emit([stage], %{duration: duration}, %{artifact_key: artifact_key}, opts, plan_info)
+  end
+
+  defp emit_cache_result(result, lookup_key, timings, opts, plan_info) do
+    metadata = %{lookup_key: lookup_key, timings: timings}
+
+    emit(
       [:cache, result],
       %{count: 1},
-      %{lookup_key: lookup_key, timings: timings},
-      opts
+      metadata,
+      opts,
+      plan_info
     )
   end
 
-  defp event_metadata(artifact), do: %{artifact_key: artifact.key, cache: artifact.cache}
+  defp emit(event, measurements, metadata, opts, plan_info) do
+    MLIR.Telemetry.emit(event, measurements, telemetry_metadata(metadata, plan_info), opts)
+  end
+
+  defp telemetry_metadata(metadata, nil), do: metadata
+
+  defp telemetry_metadata(metadata, plan_info) do
+    plan_info.telemetry_metadata
+    |> Map.merge(metadata)
+    |> Map.put(:plan_id, plan_info.id)
+  end
+
+  defp event_metadata(artifact) do
+    artifact.metadata
+    |> Map.get(:telemetry_metadata, %{})
+    |> Map.merge(%{artifact_key: artifact.key, cache: artifact.cache})
+    |> maybe_put_plan_id(artifact.metadata)
+  end
+
+  defp maybe_put_plan_id(metadata, %{plan_id: plan_id}), do: Map.put(metadata, :plan_id, plan_id)
+  defp maybe_put_plan_id(metadata, _artifact_metadata), do: metadata
 
   defp digest(binary), do: :crypto.hash(:sha256, binary) |> Base.encode16(case: :lower)
 

--- a/test/compilation_plan_test.exs
+++ b/test/compilation_plan_test.exs
@@ -1,0 +1,264 @@
+defmodule CompilationPlanTest do
+  use ExUnit.Case, async: true
+
+  import Beaver.MLIR.CompilationPlan
+  alias Beaver.MLIR
+  alias MLIR.CompilationCache
+  alias MLIR.CompilationPlan
+  alias MLIR.CompilationRuntime
+
+  @source """
+  module {
+    func.func @add(%lhs: i32, %rhs: i32) -> i32 attributes {llvm.emit_c_interface} {
+      %result = arith.addi %lhs, %rhs : i32
+      return %result : i32
+    }
+  }
+  """
+
+  @canonicalize_schedule """
+  module attributes {transform.with_named_sequence} {
+    transform.named_sequence @__transform_main(%root: !transform.any_op) {
+      transform.apply_patterns to %root {
+        transform.apply_patterns.canonicalization
+      } : !transform.any_op
+      transform.yield
+    }
+  }
+  """
+
+  defmodule DummyModulePass do
+    def initialize(_op, _ctx), do: {:ok, nil}
+    def run(op, _state), do: {:ok, op}
+    def clone(state), do: state
+    def destruct(_state), do: :ok
+  end
+
+  setup do
+    cache = start_supervised!({CompilationCache.Memory, []})
+    %{cache: {:memory, cache}}
+  end
+
+  test "deterministic declaration/identity across fresh spawned processes" do
+    opts = [
+      pipeline: ["canonicalize"],
+      target: %{triple: "host"},
+      schema_version: "v1",
+      bytecode_version: :current,
+      telemetry_metadata: %{app: "test"}
+    ]
+
+    plan1 = CompilationPlan.new(opts)
+
+    task =
+      Task.async(fn ->
+        CompilationPlan.new(opts)
+      end)
+
+    plan2 = Task.await(task)
+
+    assert CompilationPlan.identity(plan1) == CompilationPlan.identity(plan2)
+    assert CompilationPlan.declaration(plan1) == CompilationPlan.declaration(plan2)
+    assert byte_size(CompilationPlan.identity(plan1)) == 64
+  end
+
+  test "real cache hits when compiling through a plan", %{cache: cache} do
+    opts = [pipeline: ["canonicalize"], target: %{triple: "host"}]
+    plan = CompilationPlan.new(opts)
+    equivalent = Task.async(fn -> CompilationPlan.new(opts) end) |> Task.await()
+
+    res1 = CompilationRuntime.compile!(@source, plan, cache: cache)
+    res2 = CompilationRuntime.compile!(@source, equivalent, cache: cache)
+
+    assert res1.cache == :miss
+    assert res2.cache == :hit
+    assert res1.key == res2.key
+    assert res1.bytecode == res2.bytecode
+    assert res2.timings.parse == 0
+    assert res2.timings.transform == 0
+  end
+
+  test "each invalidation dimension produces a unique identity and cache miss", %{cache: cache} do
+    base =
+      CompilationPlan.new(
+        pipeline: ["canonicalize"],
+        target: %{triple: "host"},
+        schema_version: 1,
+        bytecode_version: :current
+      )
+
+    res_base = CompilationRuntime.compile!(@source, base, cache: cache)
+    assert res_base.cache == :miss
+    assert CompilationRuntime.compile!(@source, base, cache: cache).cache == :hit
+
+    var_pipeline =
+      CompilationPlan.new(pipeline: ["cse"], target: %{triple: "host"}, schema_version: 1)
+
+    var_nested = CompilationPlan.nested(base, "func.func", ["canonicalize"])
+    var_schedule = CompilationPlan.set_transform_schedule(base, @canonicalize_schedule)
+
+    var_schedule_options =
+      CompilationPlan.set_transform_schedule(base, @canonicalize_schedule,
+        expensive_checks: false
+      )
+
+    var_target = CompilationPlan.set_target(base, %{triple: "other"})
+    var_schema = CompilationPlan.set_schema_version(base, 2)
+    var_bytecode = CompilationPlan.set_bytecode_version(base, 0)
+    var_context = CompilationPlan.set_context_options(base, allow_unregistered: true)
+    var_telemetry = CompilationPlan.set_telemetry_metadata(base, compiler: :changed)
+    var_versioned_pass_v1 = CompilationPlan.add_pass(base, DummyModulePass, version: 1)
+    var_versioned_pass_v2 = CompilationPlan.add_pass(base, DummyModulePass, version: 2)
+
+    plans = [
+      var_pipeline,
+      var_nested,
+      var_schedule,
+      var_schedule_options,
+      var_target,
+      var_schema,
+      var_bytecode,
+      var_context,
+      var_telemetry,
+      var_versioned_pass_v1,
+      var_versioned_pass_v2
+    ]
+
+    ids = Enum.map([base | plans], &CompilationPlan.identity/1)
+    assert length(Enum.uniq(ids)) == length(ids)
+
+    for plan <- plans do
+      res = CompilationRuntime.compile!(@source, plan, cache: cache)
+      assert res.cache == :miss
+    end
+  end
+
+  test "callback and module steps without version are rejected" do
+    assert_raise ArgumentError, ~r/explicit :version/, fn ->
+      CompilationPlan.new(pipeline: [DummyModulePass])
+    end
+
+    assert_raise ArgumentError, ~r/explicit :version/, fn ->
+      CompilationPlan.new(pipeline: [fn op -> op end])
+    end
+
+    assert_raise ArgumentError, ~r/deterministic data/, fn ->
+      CompilationPlan.new(target: self())
+    end
+  end
+
+  test "callback declarations omit closures but retain static pass structure" do
+    callback_a = fn operation -> operation end
+    callback_b = fn operation -> send(self(), operation) end
+
+    plan_a =
+      CompilationPlan.new()
+      |> CompilationPlan.add_pass({"callback-a", "builtin.module", callback_a}, version: 1)
+
+    equivalent =
+      CompilationPlan.new()
+      |> CompilationPlan.add_pass({"callback-a", "builtin.module", callback_b}, version: 1)
+
+    changed_root =
+      CompilationPlan.new()
+      |> CompilationPlan.add_pass({"callback-a", "func.func", callback_a}, version: 1)
+
+    assert CompilationPlan.identity(plan_a) == CompilationPlan.identity(equivalent)
+    refute CompilationPlan.identity(plan_a) == CompilationPlan.identity(changed_root)
+    refute inspect(CompilationPlan.declaration(plan_a)) =~ "#Function"
+  end
+
+  test "execution of a versioned callback-backed Composer pass", %{cache: cache} do
+    owner = self()
+
+    run_fn = fn op ->
+      send(owner, :versioned_callback_pass_ran)
+      op
+    end
+
+    cb_pass = {"test_pass", "builtin.module", run_fn}
+
+    plan = CompilationPlan.new(pipeline: [{cb_pass, version: "v1"}])
+
+    res = CompilationRuntime.compile!(@source, plan, cache: cache)
+    assert res.cache == :miss
+    assert is_binary(res.bytecode)
+    assert_receive :versioned_callback_pass_ran
+  end
+
+  test "plan identity is included in artifact metadata and telemetry events", %{cache: cache} do
+    parent = self()
+
+    telemetry = fn event, measurements, metadata ->
+      send(parent, {event, measurements, metadata})
+    end
+
+    plan =
+      CompilationPlan.new(
+        pipeline: ["convert-func-to-llvm", "convert-arith-to-llvm"],
+        telemetry_metadata: %{user_tag: "unit_test"}
+      )
+
+    artifact = CompilationRuntime.compile!(@source, plan, cache: cache, telemetry: telemetry)
+
+    plan_id = CompilationPlan.identity(plan)
+    assert artifact.metadata.plan_id == plan_id
+    assert artifact.metadata.compilation_plan == CompilationPlan.declaration(plan)
+    assert artifact.metadata.bytecode_version == :current
+
+    assert_received {[:beaver, :mlir, :compilation, :cache, :miss], _, meta_miss}
+    assert meta_miss.plan_id == plan_id
+    assert meta_miss.user_tag == "unit_test"
+
+    assert_received {[:beaver, :mlir, :compilation, :parse], _, meta_parse}
+    assert meta_parse.plan_id == plan_id
+
+    jit = CompilationRuntime.jit!(artifact, telemetry: telemetry)
+
+    try do
+      assert_received {[:beaver, :mlir, :compilation, :codegen], _, meta_codegen}
+      assert meta_codegen.plan_id == plan_id
+      assert meta_codegen.user_tag == "unit_test"
+    after
+      MLIR.ExecutionEngine.destroy(jit)
+    end
+  end
+
+  test "unchanged keyword API continues to work", %{cache: cache} do
+    opts = [cache: cache, pipeline: "canonicalize"]
+
+    res1 = CompilationRuntime.compile!(@source, opts)
+    res2 = CompilationRuntime.compile!(@source, opts)
+
+    assert res1.cache == :miss
+    assert res2.cache == :hit
+    refute Map.has_key?(res1.metadata, :plan_id)
+  end
+
+  test "identity is recomputed from the current plan and runtime overrides cannot drift it" do
+    plan = CompilationPlan.new(pipeline: "canonicalize", target: %{triple: "host"})
+    mutated = %{plan | target: %{triple: "other"}}
+
+    refute CompilationPlan.identity(plan) == CompilationPlan.identity(mutated)
+
+    assert_raise ArgumentError, ~r/unsupported plan runtime options/, fn ->
+      CompilationRuntime.compile!(@source, plan, target: %{triple: "other"})
+    end
+  end
+
+  defcompiler(my_compiler,
+    pipeline: ["canonicalize"],
+    target: %{triple: "host"}
+  )
+
+  defcompiler block_compiler do
+    CompilationPlan.new(pipeline: "cse")
+  end
+
+  test "defcompiler macro declares a plan returning function" do
+    plan = my_compiler()
+    assert %CompilationPlan{} = plan
+    assert CompilationPlan.declaration(plan).pipeline == [{:pipeline, "canonicalize"}]
+    assert CompilationPlan.declaration(block_compiler()).pipeline == [{:pipeline, "cse"}]
+  end
+end


### PR DESCRIPTION
## Summary

- add `Beaver.MLIR.CompilationPlan` as an inspectable, cache-stable declaration above Composer, Transform schedules, and CompilationRuntime
- require explicit per-step versions for module- and callback-backed passes while keeping closures and process-local terms out of cache identity
- allow `CompilationRuntime.compile/2` and `compile!/2` to consume plans without changing the existing keyword API or cache-key semantics
- include plan identity and declared telemetry metadata in artifacts and compilation/JIT/object telemetry
- add `defcompiler`, documentation, and focused cache/invalidation/runtime tests

## Why

Reusable compiler configurations currently rely on a manually maintained `pipeline_version`, which can drift from executable pass and nested-scope data. CompilationPlan separates executable payload from a deterministic declaration and closes every compatibility input into one reusable identity.

## Validation

- `BEAVER_KINDA_PATH=../kinda mix format --check-formatted`
- `BEAVER_KINDA_PATH=../kinda mix compile --warnings-as-errors`
- `BEAVER_KINDA_PATH=../kinda mix test` — 273 passed, 11 excluded
- `BEAVER_KINDA_PATH=../kinda mix credo diff --strict`
- `BEAVER_KINDA_PATH=../kinda mix docs`
- `git diff --check`

Closes #487