### PR TITLE
Add ex dialect conversion plan (M1) and bound-variable materialization

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -217,6 +217,13 @@ pub fn build(b: *std.Build) void {
     const callback_bridge_lib = createNativePartitionLib(b, "beaver_callback_bridge", "native/src/callback_bridge_root.zig", target, optimize, capi_module, kinda_module, mlir_include_dir, .dynamic, llvm_lib_dir);
     const rewrite_pattern_lib = createNativePartitionLib(b, "beaver_rewrite_pattern", "native/src/rewrite_pattern_root.zig", target, optimize, capi_module, kinda_module, mlir_include_dir, .dynamic, llvm_lib_dir);
 
+    // Partition libraries link against libMLIRBeaver from the CMake install
+    // prefix; make sure the CMake step runs before they are linked.
+    core_lib.step.dependOn(cmake_step);
+    conversion_lib.step.dependOn(cmake_step);
+    callback_bridge_lib.step.dependOn(cmake_step);
+    rewrite_pattern_lib.step.dependOn(cmake_step);
+
     // Default target: the NIF shim links the partitions and assembles their
     // exported NIF tables into a single library entry at load time.
     const lib = b.addLibrary(.{

--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -1,0 +1,229 @@
+defmodule Beaver.MLIR.Conversion.Ex do
+  @moduledoc """
+  Conversion plan for lowering the `ex` dialect to `func`/`arith`/`scf`/`cf`.
+
+  M1 lowering for the scalar subset of the `ex` dialect:
+
+    * `ex.lit` -> `arith.constant`
+    * `ex.add` -> `arith.addi`
+    * `ex.call` -> `func.call`
+    * `ex.return` -> `func.return`
+    * `ex.func` -> `func.func` (body region moved, `ex.return` types converted)
+
+  The `ex` term types (`!ex.dyn`/`!ex.bound`/`!ex.unbound`) convert to a scalar
+  word type (`i64`) until the Zig term runtime lands.
+
+  `plan/1` returns a reusable `Beaver.MLIR.Conversion.Plan`; run it with
+  `Beaver.MLIR.Conversion.Plan.run/2` and continue with the standard
+  `arith-to-llvm` and `func-to-llvm` passes.
+
+  `ex.var`/`ex.bind` must be materialized to SSA first with
+  `Beaver.MLIR.Dialect.Ex.MaterializeBoundVariables`.
+  """
+
+  alias Beaver.Changeset
+  alias Beaver.MLIR
+  alias Beaver.MLIR.Conversion.Plan
+  alias Beaver.Walker
+
+  @doc """
+  Returns a conversion plan lowering the `ex` scalar subset to `func`/`arith`.
+  """
+  @spec plan(keyword()) :: Plan.t()
+  def plan(opts \\ []) do
+    Plan.new(
+      Keyword.merge(
+        [
+          mode: :full,
+          folding_mode: :after_patterns,
+          build_materializations: true
+        ],
+        opts
+      )
+    )
+    |> Plan.add_legal_dialect("builtin")
+    |> Plan.add_legal_dialect("func")
+    |> Plan.add_legal_dialect("arith")
+    |> Plan.add_legal_dialect("cf")
+    |> Plan.add_legal_dialect("scf")
+    |> Plan.add_illegal_dialect("ex")
+    |> Plan.add_conversion(&convert_type/1, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.lit", &convert_lit/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.add", &convert_add/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.call", &convert_call/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.return", &convert_return/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.var", &convert_var/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.func", &convert_func/3, version: "1.0")
+  end
+
+  @doc """
+  Converts an `ex` term type to its scalar word representation.
+  """
+  @spec convert_type(MLIR.Type.t()) :: MLIR.Type.t()
+  def convert_type(type) do
+    case MLIR.to_string(type) do
+      "!ex.dyn" -> scalar_word()
+      "!ex.bound" -> scalar_word()
+      "!ex.unbound" -> scalar_word()
+      _ -> type
+    end
+  end
+
+  defp scalar_word, do: MLIR.Type.i64()
+
+  defp convert_lit(operation, [], rewriter) do
+    context = MLIR.context(operation)
+    base = MLIR.ConversionPatternRewriter.as_base(rewriter)
+    location = MLIR.Operation.location(operation)
+    [result] = operation |> Walker.results() |> Enum.to_list()
+    result_type = result |> MLIR.Value.type() |> convert_type()
+
+    constant =
+      %Changeset{name: "arith.constant", context: context, location: location}
+      |> Changeset.add_argument(value: required_attribute(operation, "value"))
+      |> Changeset.add_result(result_type)
+      |> MLIR.Operation.create()
+
+    MLIR.RewriterBase.set_insertion_point_before(base, operation)
+    MLIR.RewriterBase.insert(base, constant)
+
+    MLIR.ConversionPatternRewriter.replace_op(
+      rewriter,
+      operation,
+      MLIR.Operation.result(constant, 0)
+    )
+
+    :ok
+  end
+
+  defp convert_add(operation, [left, right], rewriter) do
+    context = MLIR.context(operation)
+    base = MLIR.ConversionPatternRewriter.as_base(rewriter)
+    location = MLIR.Operation.location(operation)
+    [result] = operation |> Walker.results() |> Enum.to_list()
+    result_type = result |> MLIR.Value.type() |> convert_type()
+
+    add =
+      %Changeset{name: "arith.addi", context: context, location: location}
+      |> Changeset.add_argument([left, right])
+      |> Changeset.add_result(result_type)
+      |> MLIR.Operation.create()
+
+    MLIR.RewriterBase.set_insertion_point_before(base, operation)
+    MLIR.RewriterBase.insert(base, add)
+    MLIR.ConversionPatternRewriter.replace_op(rewriter, operation, MLIR.Operation.result(add, 0))
+    :ok
+  end
+
+  defp convert_call(operation, args, rewriter) do
+    context = MLIR.context(operation)
+    base = MLIR.ConversionPatternRewriter.as_base(rewriter)
+    location = MLIR.Operation.location(operation)
+
+    callee =
+      operation
+      |> required_attribute("callee")
+      |> MLIR.CAPI.mlirStringAttrGetValue()
+      |> MLIR.to_string()
+
+    arity =
+      operation
+      |> required_attribute("arity")
+      |> MLIR.CAPI.mlirIntegerAttrGetValueInt()
+      |> Beaver.Native.to_term()
+
+    unless length(args) == arity do
+      raise ArgumentError,
+            "ex.call arity attribute #{arity} does not match #{length(args)} arguments"
+    end
+
+    [result] = operation |> Walker.results() |> Enum.to_list()
+    result_type = result |> MLIR.Value.type() |> convert_type()
+
+    call =
+      %Changeset{name: "func.call", context: context, location: location}
+      |> Changeset.add_argument(args)
+      |> Changeset.add_argument(callee: MLIR.Attribute.flat_symbol_ref(callee, ctx: context))
+      |> Changeset.add_result(result_type)
+      |> MLIR.Operation.create()
+
+    MLIR.RewriterBase.set_insertion_point_before(base, operation)
+    MLIR.RewriterBase.insert(base, call)
+    MLIR.ConversionPatternRewriter.replace_op(rewriter, operation, MLIR.Operation.result(call, 0))
+    :ok
+  end
+
+  defp convert_return(operation, operands, rewriter) do
+    context = MLIR.context(operation)
+    base = MLIR.ConversionPatternRewriter.as_base(rewriter)
+    location = MLIR.Operation.location(operation)
+
+    return_op =
+      %Changeset{name: "func.return", context: context, location: location}
+      |> Changeset.add_argument(operands)
+      |> MLIR.Operation.create()
+
+    MLIR.RewriterBase.set_insertion_point_before(base, operation)
+    MLIR.RewriterBase.insert(base, return_op)
+    MLIR.ConversionPatternRewriter.replace_op(rewriter, operation, return_op)
+    :ok
+  end
+
+  defp convert_var(operation, [], _rewriter) do
+    raise ArgumentError,
+          "ex.var without ex.bind is unsupported: #{inspect(MLIR.to_string(operation))}"
+  end
+
+  defp convert_func(operation, [], rewriter) do
+    context = MLIR.context(operation)
+    base = MLIR.ConversionPatternRewriter.as_base(rewriter)
+    location = MLIR.Operation.location(operation)
+
+    sym_name =
+      operation
+      |> required_attribute("sym_name")
+      |> MLIR.CAPI.mlirStringAttrGetValue()
+      |> MLIR.to_string()
+
+    [body_region] = operation |> Walker.regions() |> Enum.to_list()
+    [block] = body_region |> Walker.blocks() |> Enum.to_list()
+    terminator = MLIR.CAPI.mlirBlockGetTerminator(block)
+
+    if MLIR.null?(terminator),
+      do: raise(ArgumentError, "ex.func body must end with a terminator (ex.return)")
+
+    return_types =
+      terminator
+      |> Walker.operands()
+      |> Enum.to_list()
+      |> Enum.map(&(&1 |> MLIR.Value.type() |> convert_type()))
+
+    function_type = MLIR.Type.function([], return_types)
+
+    func =
+      %Changeset{name: "func.func", context: context, location: location}
+      |> Changeset.add_argument(sym_name: MLIR.Attribute.string(sym_name))
+      |> Changeset.add_argument(function_type: function_type)
+      |> Changeset.add_argument(MLIR.CAPI.mlirRegionCreate())
+      |> MLIR.Operation.create()
+
+    func_body = func |> Walker.regions() |> Enum.to_list() |> hd()
+    MLIR.CAPI.mlirRegionTakeBody(func_body, body_region)
+
+    MLIR.RewriterBase.set_insertion_point_before(base, operation)
+    MLIR.RewriterBase.insert(base, func)
+    MLIR.ConversionPatternRewriter.replace_op(rewriter, operation, func)
+    :ok
+  end
+
+  defp required_attribute(operation, name) do
+    case operation |> Walker.attributes() |> then(& &1[name]) do
+      nil ->
+        raise ArgumentError,
+              "#{MLIR.Operation.name(operation)} requires attribute #{inspect(name)}"
+
+      attribute ->
+        attribute
+    end
+  end
+end

--- a/lib/beaver/mlir/dialect/ex/materialize_bound_variables.ex
+++ b/lib/beaver/mlir/dialect/ex/materialize_bound_variables.ex
@@ -1,0 +1,73 @@
+defmodule Beaver.MLIR.Dialect.Ex.MaterializeBoundVariables do
+  @moduledoc """
+  Erases `ex.var`/`ex.bind` pairs into SSA before dialect conversion.
+
+  A binding `ex.bind(ex.var, value)` is replaced by `value` and both operations
+  are removed. A bare `ex.var` without a consuming `ex.bind` is left untouched
+  and reported as unsupported by `Beaver.MLIR.Conversion.Ex`.
+
+  `run!/1` materializes every `ex.func` in a module or operation. Run it before
+  `Beaver.MLIR.Conversion.Ex.plan/1`.
+  """
+
+  alias Beaver.MLIR
+  alias Beaver.Walker
+
+  @spec run!(MLIR.Module.t() | MLIR.Operation.t()) :: MLIR.Module.t() | MLIR.Operation.t()
+  def run!(%MLIR.Module{} = module) do
+    module |> ex_funcs() |> Enum.each(&materialize_func/1)
+    module
+  end
+
+  def run!(%MLIR.Operation{} = operation) do
+    if(MLIR.Operation.name(operation) == "ex.func",
+      do: [operation],
+      else: ex_funcs(operation)
+    )
+    |> Enum.each(&materialize_func/1)
+
+    operation
+  end
+
+  defp ex_funcs(operation) do
+    operation
+    |> operations()
+    |> Enum.filter(&(MLIR.Operation.name(&1) == "ex.func"))
+  end
+
+  defp materialize_func(ex_func) do
+    ex_func
+    |> operations()
+    |> Enum.filter(&(MLIR.Operation.name(&1) == "ex.bind"))
+    |> Enum.each(&materialize_bind(&1, ex_func))
+  end
+
+  defp operations(operation) do
+    {_, operations} =
+      Walker.postwalk(operation, [], fn
+        %MLIR.Operation{} = op, acc -> {op, [op | acc]}
+        element, acc -> {element, acc}
+      end)
+
+    Enum.reverse(operations)
+  end
+
+  defp materialize_bind(bind, ex_func) do
+    [variable, value] = bind |> Walker.operands() |> Enum.to_list()
+    variable_op = variable |> MLIR.CAPI.mlirOpResultGetOwner()
+
+    unless MLIR.Operation.name(variable_op) == "ex.var" do
+      raise ArgumentError, "ex.bind first operand must be produced by ex.var"
+    end
+
+    [bind_result] = bind |> Walker.results() |> Enum.to_list()
+
+    MLIR.IRRewriter.with_rewriter(ex_func, fn rewriter ->
+      MLIR.RewriterBase.replace_all_uses_with(rewriter, bind_result, value)
+      MLIR.RewriterBase.erase_op(rewriter, bind)
+      MLIR.RewriterBase.erase_op(rewriter, variable_op)
+    end)
+
+    :ok
+  end
+end

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -1,0 +1,115 @@
+defmodule ExConversionTest do
+  use Beaver.Case, async: true
+  alias Beaver.MLIR
+  alias Beaver.MLIR.Conversion.Ex
+  alias Beaver.MLIR.Conversion.Plan
+  alias Beaver.MLIR.Dialect.Ex.MaterializeBoundVariables
+  alias Beaver.MLIR.Dialect.Ex, as: ExDialect
+
+  @moduletag :smoke
+
+  @scalar_module ~S"""
+  module {
+    func.func @add(%a: i64, %b: i64) -> i64 {
+      %r = arith.addi %a, %b : i64
+      return %r : i64
+    }
+    "ex.func"() ({
+    ^bb0:
+      %0 = "ex.lit"() {value = 1 : i64} : () -> i64
+      %1 = "ex.lit"() {value = 2 : i64} : () -> i64
+      %2 = "ex.add"(%0, %1) : (i64, i64) -> i64
+      %3 = "ex.call"(%0, %1) {callee = "add", arity = 2 : i64, operandSegmentSizes = array<i32: 2>} : (i64, i64) -> !ex.dyn
+      "ex.return"(%2) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+    }) {sym_name = "main"} : () -> ()
+  }
+  """
+
+  @bind_module ~S"""
+  module {
+    "ex.func"() ({
+    ^bb0:
+      %0 = "ex.lit"() {value = 42 : i64} : () -> i64
+      %1 = "ex.var"() {name = "x"} : () -> !ex.unbound
+      %2 = "ex.bind"(%1, %0) : (!ex.unbound, i64) -> !ex.bound
+      "ex.return"(%2) {operandSegmentSizes = array<i32: 1>} : (!ex.bound) -> ()
+    }) {sym_name = "main"} : () -> ()
+  }
+  """
+
+  test "lowers the ex scalar subset to func/arith and llvm", %{ctx: ctx} do
+    Beaver.Slang.load(ctx, ExDialect)
+
+    module =
+      MLIR.Module.create!(@scalar_module, ctx: ctx)
+      |> MLIR.verify!()
+
+    plan = Ex.plan()
+    assert {:ok, ^module, _diagnostics} = Plan.run(plan, module)
+
+    rendered = MLIR.to_string(module, generic: true)
+    refute rendered =~ "ex."
+    assert rendered =~ "arith.addi"
+    assert rendered =~ "func.call"
+    assert rendered =~ "func.return"
+
+    pass_manager = MLIR.CAPI.mlirPassManagerCreate(ctx)
+
+    MLIR.CAPI.mlirPassManagerAddOwnedPass(
+      pass_manager,
+      MLIR.CAPI.mlirCreateConversionArithToLLVMConversionPass()
+    )
+
+    MLIR.CAPI.mlirPassManagerAddOwnedPass(
+      pass_manager,
+      MLIR.CAPI.mlirCreateConversionConvertFuncToLLVMPass()
+    )
+
+    assert {:ok, _} = MLIR.PassManager.run(pass_manager, module)
+    MLIR.PassManager.destroy(pass_manager)
+
+    rendered_llvm = MLIR.to_string(module)
+    assert rendered_llvm =~ "llvm.func"
+    assert rendered_llvm =~ "llvm.add"
+  end
+
+  test "materializes ex.var/ex.bind into SSA", %{ctx: ctx} do
+    Beaver.Slang.load(ctx, ExDialect)
+
+    module =
+      MLIR.Module.create!(@bind_module, ctx: ctx)
+      |> MLIR.verify!()
+      |> MaterializeBoundVariables.run!()
+
+    assert converted = Plan.run!(Ex.plan(), module)
+
+    rendered = MLIR.to_string(converted, generic: true)
+    refute rendered =~ "ex.var"
+    refute rendered =~ "ex.bind"
+    assert rendered =~ "arith.constant"
+    assert rendered =~ "func.return"
+  end
+
+  test "fails explicitly on a bare ex.var", %{ctx: ctx} do
+    Beaver.Slang.load(ctx, ExDialect)
+
+    module =
+      MLIR.Module.create!(
+        ~S"""
+        module {
+          "ex.func"() ({
+          ^bb0:
+            %0 = "ex.var"() {name = "x"} : () -> !ex.unbound
+            "ex.return"() {operandSegmentSizes = array<i32: 0>} : () -> ()
+          }) {sym_name = "main"} : () -> ()
+        }
+        """,
+        ctx: ctx
+      )
+      |> MLIR.verify!()
+
+    module = MaterializeBoundVariables.run!(module)
+
+    assert {:error, %MLIR.Conversion.Error{}} = Plan.run(Ex.plan(), module)
+  end
+end


### PR DESCRIPTION
M1 lowering for the scalar subset of the `ex` dialect, staying in Beaver per the tsai/beaver#6 repo-ownership split (dialect conversion patterns are Beaver infrastructure; frontend/AOT go to batata).

## Changes

- **`Beaver.MLIR.Conversion.Ex.plan/1`** ([lib/beaver/mlir/conversion/ex.ex](lib/beaver/mlir/conversion/ex.ex)): declarative `Conversion.Plan` lowering
  - `ex.lit` -> `arith.constant`
  - `ex.add` -> `arith.addi`
  - `ex.call` -> `func.call` (callee flat symbol ref from the string attribute; arity validated against the operand count)
  - `ex.return` -> `func.return`
  - `ex.func` -> `func.func` (body region moved via `mlirRegionTakeBody`, function type derived from the converted `ex.return` operand)
  - type converter maps `!ex.dyn`/`!ex.bound`/`!ex.unbound` to a scalar word type (`i64`) until the term runtime lands
  - a bare `ex.var` is reported explicitly as unsupported (conversion error)
- **`Beaver.MLIR.Dialect.Ex.MaterializeBoundVariables.run!/1`** ([lib/beaver/mlir/dialect/ex/materialize_bound_variables.ex](lib/beaver/mlir/dialect/ex/materialize_bound_variables.ex)): erases `ex.var`/`ex.bind` pairs into SSA before conversion, mirroring the prototype pass.
- **Tests** ([test/ex_conversion_test.exs](test/ex_conversion_test.exs)): scalar subset through `func`/`arith` plus the `arith-to-llvm`/`func-to-llvm` passes, bind materialization, and the bare-`ex.var` unsupported gate.

## Verification

- `mix test`: 266 passed (15 doctests, 251 tests), 8 excluded (cuda/stderr), including the new suite.
- `mix format --check-formatted` passes.