### PR TITLE
Add Transform schedule authoring DSL

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -8,7 +8,12 @@ locals_without_parens = [
   defalias: 2,
   defconstraint: 2,
   defrewrite: 2,
-  defrewrite: 3
+  defrewrite: 3,
+  defschedule: 1,
+  sequence: 0,
+  sequence: 1,
+  sequence: 2,
+  alternatives: 1
 ]
 
 # Used by "mix format"

--- a/guides/transform-autotuning.md
+++ b/guides/transform-autotuning.md
@@ -32,36 +32,68 @@ Tune operations leave choices in Transform IR instead of hiding them in host
 language control flow. This example selects a tile size, tiles a matched
 `linalg.matmul`, and chooses whether to vectorize its enclosing isolated op.
 
-```mlir
-module attributes {transform.with_named_sequence} {
-  transform.named_sequence @__transform_main(
-      %root: !transform.any_op {transform.readonly}) {
-    %tile = transform.tune.knob<"tile_size">
-      options = [8, 16, 32] -> !transform.param<i64>
+```elixir
+defmodule MatmulSchedule do
+  use Beaver.MLIR.Transform.Schedule.DSL
 
-    %matmul = transform.structured.match ops{["linalg.matmul"]} in %root
-      : (!transform.any_op) -> !transform.any_op
+  alias Beaver.MLIR
+  alias Beaver.MLIR.Dialect.Transform
 
-    %tiled, %loop = transform.structured.tile_using_for %matmul
-      tile_sizes [%tile]
-      : (!transform.any_op, !transform.param<i64>)
-        -> (!transform.any_op, !transform.any_op)
+  defschedule tiling_and_vectorization do
+    sequence "__transform_main", [root >>> any_op()] do
+      tile = knob("tile_size", [8, 16, 32], type: param(MLIR.Type.i64()))
 
-    transform.tune.alternatives<"vectorize"> {
-      %func = transform.get_parent_op %tiled {isolated_from_above}
-        : (!transform.any_op) -> !transform.any_op
-      %vectorized =
-        transform.structured.vectorize_children_and_apply_patterns %func
-        : (!transform.any_op) -> !transform.any_op
-      transform.yield
-    }, {
-      transform.yield
-    }
+      operation_names =
+        MLIR.Attribute.array(
+          [MLIR.Attribute.string("linalg.matmul")],
+          ctx: Beaver.Env.context()
+        )
 
-    transform.yield
-  }
-}
+      matmul = Transform.structured_match(target: root, ops: operation_names) >>> any_op()
+
+      static_sizes =
+        MLIR.Attribute.dense_array([-1], Beaver.Native.I64, ctx: Beaver.Env.context())
+
+      scalable_sizes =
+        MLIR.Attribute.dense_array([false], Beaver.Native.Bool, ctx: Beaver.Env.context())
+
+      [tiled, _loop] =
+        Transform.structured_tile_using_for(
+          target: matmul,
+          dynamic_sizes: [tile],
+          static_sizes: static_sizes,
+          scalable_sizes: scalable_sizes
+        ) >>> [any_op(), any_op()]
+
+      alternatives "vectorize" do
+        branch do
+          isolated = MLIR.Attribute.unit(ctx: Beaver.Env.context())
+
+          function =
+            Transform.get_parent_op(target: tiled, isolated_from_above: isolated) >>> any_op()
+
+          _vectorized =
+            Transform.structured_vectorize_children_and_apply_patterns(target: function) >>>
+              any_op()
+        end
+
+        branch do
+          :ok
+        end
+      end
+    end
+  end
+end
+
+schedule_context = Beaver.MLIR.Context.create()
+transform_ir = MatmulSchedule.tiling_and_vectorization(ctx: schedule_context)
 ```
+
+`defschedule` emits and verifies an ordinary `Beaver.MLIR.Module`; it does not
+retain a parallel Elixir choice graph. Each declaration also carries its
+Elixir file and line as an MLIR location. The caller owns `transform_ir` and
+`schedule_context` and must destroy the module before the context after the
+search is complete.
 
 Discovery and enumeration are deterministic. An alternatives choice is visited
 before choices in its regions, and choices from unselected regions do not

--- a/lib/beaver/mlir/transform/schedule.ex
+++ b/lib/beaver/mlir/transform/schedule.ex
@@ -2,10 +2,11 @@ defmodule Beaver.MLIR.Transform.Schedule do
   @moduledoc """
   Deterministic discovery and resolution of Transform Tune schedules.
 
-  A resolved schedule is immutable BEAM data: MLIR bytecode, printable text,
-  the active choices, and a stable digest. Resolution writes choices back to
-  `transform.tune.knob` and `transform.tune.alternatives`, so replay does not
-  invoke the resolver or repeat a search.
+  Schedules can be authored using Elixir DSL (`Beaver.MLIR.Transform.Schedule.DSL`)
+  or supplied as raw MLIR modules. A resolved schedule is immutable BEAM data:
+  MLIR bytecode, printable text, the active choices, and a stable digest.
+  Resolution writes choices back to `transform.tune.knob` and `transform.tune.alternatives`,
+  so replay does not invoke the resolver or repeat a search.
   """
 
   alias Beaver.MLIR

--- a/lib/beaver/mlir/transform/schedule/dsl.ex
+++ b/lib/beaver/mlir/transform/schedule/dsl.ex
@@ -1,0 +1,644 @@
+defmodule Beaver.MLIR.Transform.Schedule.DSL do
+  @moduledoc """
+  An Elixir authoring frontend for upstream Transform dialect schedules.
+
+  The DSL creates a verified `Beaver.MLIR.Module` in a caller-owned context.
+  Its helpers create ordinary Transform dialect operations immediately; there
+  is no second schedule graph to synchronize with the IR.
+
+  A schedule module can mix the focused helpers in this module with Beaver's
+  normal SSA syntax:
+
+      defmodule MySchedule do
+        use Beaver.MLIR.Transform.Schedule.DSL
+
+        defschedule search do
+          sequence "__transform_main", [root >>> any_op()] do
+            _tile = knob("tile", [8, 16], type: param(MLIR.Type.i64()))
+            # Any existing Beaver SSA operation may be emitted here.
+            yield()
+          end
+        end
+      end
+
+      schedule = MySchedule.search(ctx: context)
+
+  The caller owns both `context` and the returned module.
+  """
+
+  alias __MODULE__, as: DSL
+  alias Beaver.MLIR
+  alias Beaver.MLIR.Transform
+
+  @doc "Imports `defschedule` and the schedule authoring helpers."
+  defmacro __using__(_opts) do
+    quote do
+      use Beaver
+      require Beaver.Env
+      import DSL
+    end
+  end
+
+  @doc """
+  Defines a zero-arity schedule builder with an optional keyword argument.
+
+  The generated function requires `:ctx` to be a caller-owned
+  `Beaver.MLIR.Context`. It returns a verified `Beaver.MLIR.Module`; the caller
+  must destroy the module before destroying the context.
+  """
+  defmacro defschedule(call, do: body) do
+    name = schedule_function_name!(call)
+    caller = Macro.escape(__CALLER__)
+
+    quote do
+      def unquote(name)(opts \\ []) do
+        DSL.__build_schedule__(
+          opts,
+          unquote(caller),
+          fn context, block ->
+            # Establish only the outer module insertion environment here. The
+            # sequence helper runs Beaver's SSA prewalk for its own body; doing
+            # so at both levels would transform nested block arguments twice.
+            Kernel.var!(beaver_internal_env_ctx) = context
+            Kernel.var!(beaver_internal_env_ip) = block
+            unquote(body)
+            _ = Kernel.var!(beaver_internal_env_ctx)
+            _ = Kernel.var!(beaver_internal_env_ip)
+          end
+        )
+      end
+    end
+  end
+
+  defp schedule_function_name!({name, _, args}) when is_atom(name) and args in [[], nil], do: name
+  defp schedule_function_name!(name) when is_atom(name), do: name
+
+  defp schedule_function_name!(other) do
+    raise ArgumentError,
+          "defschedule expects a zero-arity function name, got: #{Macro.to_string(other)}"
+  end
+
+  @doc false
+  def __build_schedule__(opts, caller, build_body) when is_function(build_body, 2) do
+    context = schedule_context!(opts)
+    location = source_location(caller, context)
+    module = MLIR.Module.empty(location)
+
+    try do
+      module
+      |> MLIR.Operation.from_module()
+      |> put_unit_attribute("transform.with_named_sequence", context)
+
+      build_body.(context, MLIR.Module.body(module))
+      ensure_named_sequence!(module)
+      verify_schedule!(module)
+    rescue
+      exception ->
+        MLIR.Module.destroy(module)
+        reraise exception, __STACKTRACE__
+    catch
+      kind, reason ->
+        MLIR.Module.destroy(module)
+        :erlang.raise(kind, reason, __STACKTRACE__)
+    end
+  end
+
+  defp schedule_context!(opts) do
+    unless Keyword.keyword?(opts) do
+      raise ArgumentError, "schedule options must be a keyword list, got: #{inspect(opts)}"
+    end
+
+    case Keyword.keys(opts) -- [:ctx] do
+      [] -> :ok
+      unsupported -> raise ArgumentError, "unsupported schedule options: #{inspect(unsupported)}"
+    end
+
+    case Keyword.get(opts, :ctx) do
+      %MLIR.Context{} = context ->
+        context
+
+      value ->
+        raise ArgumentError,
+              "defschedule requires a caller-owned %Beaver.MLIR.Context{} via ctx: context, " <>
+                "got: #{inspect(value)}"
+    end
+  end
+
+  defp put_unit_attribute(operation, name, context) do
+    MLIR.CAPI.mlirOperationSetAttributeByName(
+      operation,
+      MLIR.StringRef.create(name),
+      MLIR.Attribute.unit(ctx: context)
+    )
+
+    operation
+  end
+
+  defp ensure_named_sequence!(module) do
+    found? =
+      module
+      |> MLIR.Module.body()
+      |> Beaver.Walker.operations()
+      |> Enum.any?(&(MLIR.Operation.name(&1) == "transform.named_sequence"))
+
+    unless found?, do: raise(ArgumentError, "defschedule must declare at least one sequence")
+  end
+
+  defp verify_schedule!(module) do
+    case MLIR.verify(module) do
+      {:ok, verified} ->
+        verified
+
+      :null ->
+        raise ArgumentError, "transform schedule verification failed: module is null"
+
+      {:error, diagnostics} ->
+        raise ArgumentError,
+              MLIR.Diagnostic.format(diagnostics, "transform schedule verification failed")
+    end
+  end
+
+  @doc "Declares the default `__transform_main` sequence with one `any_op` root handle."
+  defmacro sequence(do: body) do
+    build_sequence_ast("__transform_main", default_root_argument(), body, __CALLER__)
+  end
+
+  @doc "Declares a named sequence with one default `any_op` root handle."
+  defmacro sequence(name, do: body) do
+    build_sequence_ast(literal_name!(name, "sequence"), default_root_argument(), body, __CALLER__)
+  end
+
+  @doc """
+  Declares a named sequence with typed handle arguments.
+
+  Arguments use Beaver's `>>>` spelling, for example
+  `[root >>> any_op(), function >>> operation("func.func")]`. Sequence results
+  are intentionally expressed by ordinary Transform SSA operations and
+  `yield/1`; this helper currently declares result-free entry points.
+  """
+  defmacro sequence(name, arguments, do: body) do
+    build_sequence_ast(literal_name!(name, "sequence"), arguments, body, __CALLER__)
+  end
+
+  defp default_root_argument do
+    root = Macro.var(:root, nil)
+
+    quote do
+      [unquote(root) >>> DSL.any_op()]
+    end
+  end
+
+  defp build_sequence_ast(name, arguments_ast, body, caller) do
+    {type_builders, bindings} = sequence_arguments!(arguments_ast)
+    caller = Macro.escape(caller)
+
+    quote do
+      DSL.__build_sequence__(
+        Beaver.Env.context(),
+        Beaver.Env.ip(),
+        unquote(name),
+        unquote(type_builders),
+        unquote(caller),
+        fn context, sequence_block ->
+          Beaver.mlir ctx: context, ip: sequence_block do
+            unquote_splicing(bindings)
+            unquote(body)
+          end
+        end
+      )
+    end
+  end
+
+  defp sequence_arguments!(arguments) when is_list(arguments) and arguments != [] do
+    arguments
+    |> Enum.with_index()
+    |> Enum.map(fn {argument, index} -> sequence_argument!(argument, index) end)
+    |> Enum.unzip()
+  end
+
+  defp sequence_arguments!([]), do: {[], []}
+
+  defp sequence_arguments!(other) do
+    raise ArgumentError,
+          "sequence arguments must be a literal list, got: #{Macro.to_string(other)}"
+  end
+
+  # The surrounding `Beaver.mlir` prewalk lowers `name >>> type` to this tuple
+  # before the nested `sequence` macro expands. Accept the original spelling as
+  # well so the macro remains usable when expanded outside that prewalk.
+  defp sequence_argument!({:>>>, _, [variable, type]}, index),
+    do: sequence_argument!({variable, type}, index)
+
+  defp sequence_argument!({variable = {name, _, context}, type}, index)
+       when is_atom(name) and (is_atom(context) or is_nil(context)) do
+    type_builder =
+      quote do
+        fn context -> Beaver.Deferred.create(unquote(type), context) end
+      end
+
+    binding =
+      if name |> Atom.to_string() |> String.starts_with?("_") do
+        quote do
+          unquote(variable) = Beaver.MLIR.Block.get_arg!(sequence_block, unquote(index))
+        end
+      else
+        quote do
+          unquote(variable) = Beaver.MLIR.Block.get_arg!(sequence_block, unquote(index))
+          _ = unquote(variable)
+        end
+      end
+
+    {type_builder, binding}
+  end
+
+  defp sequence_argument!(invalid, _index) do
+    raise ArgumentError,
+          "sequence arguments must use `name >>> transform_type`, got: " <>
+            Macro.to_string(invalid)
+  end
+
+  @doc false
+  def __build_sequence__(context, insertion_point, name, type_builders, caller, body)
+      when is_function(body, 2) do
+    location = source_location(caller, context)
+    argument_types = Enum.map(type_builders, &resolve_type!(&1, context, "sequence argument"))
+    region = MLIR.CAPI.mlirRegionCreate()
+
+    try do
+      block = MLIR.Block.create(Enum.map(argument_types, &{&1, location}))
+      MLIR.CAPI.mlirRegionAppendOwnedBlock(region, block)
+      body.(context, block)
+      ensure_yield(block, context, location)
+
+      readonly =
+        MLIR.Attribute.dictionary(
+          [{"transform.readonly", MLIR.Attribute.unit(ctx: context)}],
+          ctx: context
+        )
+
+      %Beaver.SSA{
+        op: "transform.named_sequence",
+        arguments: [
+          region,
+          sym_name: MLIR.Attribute.string(name, ctx: context),
+          function_type:
+            MLIR.Attribute.type(MLIR.Type.function(argument_types, [], ctx: context)),
+          arg_attrs:
+            MLIR.Attribute.array(List.duplicate(readonly, length(argument_types)), ctx: context),
+          res_attrs: MLIR.Attribute.array([], ctx: context)
+        ],
+        results: [],
+        ctx: context,
+        ip: insertion_point,
+        loc: location
+      }
+      |> MLIR.Operation.create()
+    rescue
+      exception ->
+        MLIR.CAPI.mlirRegionDestroy(region)
+        reraise exception, __STACKTRACE__
+    catch
+      kind, reason ->
+        MLIR.CAPI.mlirRegionDestroy(region)
+        :erlang.raise(kind, reason, __STACKTRACE__)
+    end
+  end
+
+  @doc """
+  Creates `transform.tune.knob` and returns its parameter handle.
+
+  Integer, float, boolean, string, `:unit`, `MLIR.Attribute`, and deferred
+  attribute values are accepted. Integer-only knobs default to
+  `!transform.param<i64>`; other domains default to `!transform.any_param`.
+  Pass `:type` to select an explicit Transform parameter type.
+  """
+  defmacro knob(name, options, opts \\ []) do
+    caller = Macro.escape(__CALLER__)
+
+    quote do
+      DSL.__build_knob__(
+        Beaver.Env.context(),
+        Beaver.Env.ip(),
+        unquote(name),
+        unquote(options),
+        unquote(opts),
+        unquote(caller)
+      )
+    end
+  end
+
+  @doc false
+  def __build_knob__(context, insertion_point, name, options, opts, caller) do
+    name = runtime_name!(name, "knob")
+    validate_knob_options!(options)
+    validate_helper_options!(opts, [:type], "knob")
+    location = source_location(caller, context)
+    attributes = Enum.map(options, &knob_attribute!(&1, context))
+
+    result_type =
+      case Keyword.fetch(opts, :type) do
+        {:ok, type} -> resolve_type!(type, context, "knob result")
+        :error -> default_knob_type(options, context)
+      end
+
+    operation =
+      %Beaver.SSA{
+        op: "transform.tune.knob",
+        arguments: [
+          name: MLIR.Attribute.string(name, ctx: context),
+          options: MLIR.Attribute.array(attributes, ctx: context)
+        ],
+        results: [result_type],
+        ctx: context,
+        ip: insertion_point,
+        loc: location
+      }
+      |> MLIR.Operation.create()
+
+    MLIR.Operation.result(operation, 0)
+  end
+
+  defp validate_knob_options!(options) when is_list(options) and options != [], do: :ok
+
+  defp validate_knob_options!([]), do: raise(ArgumentError, "knob options cannot be empty")
+
+  defp validate_knob_options!(other) do
+    raise ArgumentError, "knob options must be a non-empty list, got: #{inspect(other)}"
+  end
+
+  defp default_knob_type(options, context) do
+    if Enum.all?(options, &is_integer/1) do
+      param(MLIR.Type.i64(ctx: context))
+    else
+      any_param(ctx: context)
+    end
+  end
+
+  defp knob_attribute!(%MLIR.Attribute{} = attribute, context) do
+    ensure_same_context!(attribute, context, "knob option")
+    attribute
+  end
+
+  defp knob_attribute!(value, context) when is_integer(value),
+    do: MLIR.Attribute.integer(MLIR.Type.i64(ctx: context), value)
+
+  defp knob_attribute!(value, context) when is_float(value),
+    do: MLIR.Attribute.float(MLIR.Type.f64(ctx: context), value)
+
+  defp knob_attribute!(value, context) when is_boolean(value),
+    do: MLIR.Attribute.bool(value, ctx: context)
+
+  defp knob_attribute!(value, context) when is_binary(value),
+    do: MLIR.Attribute.string(value, ctx: context)
+
+  defp knob_attribute!(:unit, context), do: MLIR.Attribute.unit(ctx: context)
+
+  defp knob_attribute!(deferred, context) when is_function(deferred, 1) do
+    case deferred.(context) do
+      %MLIR.Attribute{} = attribute -> knob_attribute!(attribute, context)
+      value -> unsupported_knob_option!(value)
+    end
+  end
+
+  defp knob_attribute!(value, _context), do: unsupported_knob_option!(value)
+
+  defp unsupported_knob_option!(value) do
+    raise ArgumentError, "unsupported scalar or attribute in knob options: #{inspect(value)}"
+  end
+
+  @doc """
+  Creates `transform.tune.alternatives` from explicit `branch` blocks.
+
+      alternatives "vectorize" do
+        branch do
+          # Transform SSA operations
+        end
+
+        branch do
+          # A second alternative
+        end
+      end
+
+  Each branch receives an implicit `transform.yield` when it does not already
+  end in one.
+  """
+  defmacro alternatives(name, branches_or_block) do
+    caller = Macro.escape(__CALLER__)
+    branches = branch_builders(branches_or_block)
+
+    quote do
+      DSL.__build_alternatives__(
+        Beaver.Env.context(),
+        Beaver.Env.ip(),
+        unquote(name),
+        unquote(branches),
+        unquote(caller)
+      )
+    end
+  end
+
+  defp branch_builders(do: block), do: branch_builders_from_block!(block)
+  defp branch_builders(other), do: other
+
+  defp branch_builders_from_block!({:branch, _, [[do: body]]}),
+    do: [branch_builder(body)]
+
+  defp branch_builders_from_block!({:__block__, _, expressions}) do
+    Enum.map(expressions, fn
+      {:branch, _, [[do: body]]} ->
+        branch_builder(body)
+
+      invalid ->
+        raise ArgumentError,
+              "alternatives accepts only `branch do ... end` entries, got: " <>
+                Macro.to_string(invalid)
+    end)
+  end
+
+  defp branch_builders_from_block!(invalid) do
+    raise ArgumentError,
+          "alternatives expects `branch do ... end`, got: #{Macro.to_string(invalid)}"
+  end
+
+  defp branch_builder(body) do
+    quote do
+      fn context, block ->
+        Beaver.mlir ctx: context, ip: block do
+          unquote(body)
+        end
+      end
+    end
+  end
+
+  @doc false
+  @spec __build_alternatives__(term(), term(), term(), term(), term()) :: term()
+  def __build_alternatives__(context, insertion_point, name, branches, caller) do
+    name = runtime_name!(name, "alternatives")
+    validate_branches!(branches)
+
+    location = source_location(caller, context)
+    regions = build_branch_regions(branches, context, location, [])
+
+    try do
+      %Beaver.SSA{
+        op: "transform.tune.alternatives",
+        arguments: [name: MLIR.Attribute.string(name, ctx: context)],
+        results: [],
+        filler: fn -> regions end,
+        ctx: context,
+        ip: insertion_point,
+        loc: location
+      }
+      |> MLIR.Operation.create()
+    rescue
+      exception ->
+        Enum.each(regions, &MLIR.CAPI.mlirRegionDestroy/1)
+        reraise exception, __STACKTRACE__
+    catch
+      kind, reason ->
+        Enum.each(regions, &MLIR.CAPI.mlirRegionDestroy/1)
+        :erlang.raise(kind, reason, __STACKTRACE__)
+    end
+  end
+
+  defp validate_branches!(branches) do
+    unless is_list(branches) and branches != [] and Enum.all?(branches, &is_function(&1, 2)) do
+      raise ArgumentError,
+            "invalid branch layout for alternatives: expected one or more branch blocks"
+    end
+  end
+
+  defp build_branch_regions([], _context, _location, built), do: Enum.reverse(built)
+
+  defp build_branch_regions([branch | rest], context, location, built) do
+    region = MLIR.CAPI.mlirRegionCreate()
+
+    region =
+      try do
+        block = MLIR.Block.create()
+        MLIR.CAPI.mlirRegionAppendOwnedBlock(region, block)
+        branch.(context, block)
+        ensure_yield(block, context, location)
+        region
+      rescue
+        exception ->
+          MLIR.CAPI.mlirRegionDestroy(region)
+          Enum.each(built, &MLIR.CAPI.mlirRegionDestroy/1)
+          reraise exception, __STACKTRACE__
+      catch
+        kind, reason ->
+          MLIR.CAPI.mlirRegionDestroy(region)
+          Enum.each(built, &MLIR.CAPI.mlirRegionDestroy/1)
+          :erlang.raise(kind, reason, __STACKTRACE__)
+      end
+
+    # Keep the recursive call outside the cleanup scope above. A deeper
+    # failure already destroys every region in `built`, including this one.
+    build_branch_regions(rest, context, location, [region | built])
+  end
+
+  @doc "Creates `transform.yield` with zero or more yielded handles."
+  defmacro yield(operands \\ []) do
+    caller = Macro.escape(__CALLER__)
+
+    quote do
+      DSL.__build_yield__(
+        Beaver.Env.context(),
+        Beaver.Env.ip(),
+        unquote(operands),
+        unquote(caller)
+      )
+    end
+  end
+
+  @doc false
+  def __build_yield__(context, insertion_point, operands, caller) do
+    %Beaver.SSA{
+      op: "transform.yield",
+      arguments: List.wrap(operands),
+      results: [],
+      ctx: context,
+      ip: insertion_point,
+      loc: source_location(caller, context)
+    }
+    |> MLIR.Operation.create()
+  end
+
+  defp ensure_yield(block, context, location) do
+    terminator = block |> Beaver.Walker.operations() |> Enum.to_list() |> List.last()
+
+    if is_nil(terminator) or MLIR.Operation.name(terminator) != "transform.yield" do
+      %Beaver.SSA{
+        op: "transform.yield",
+        arguments: [],
+        results: [],
+        ctx: context,
+        ip: block,
+        loc: location
+      }
+      |> MLIR.Operation.create()
+    end
+  end
+
+  @doc "Returns a deferred `!transform.any_op` type."
+  def any_op(opts \\ []), do: Transform.any_op_type(opts)
+
+  @doc "Returns a deferred `!transform.any_value` type."
+  def any_value(opts \\ []), do: Transform.any_value_type(opts)
+
+  @doc "Returns a deferred `!transform.any_param` type."
+  def any_param(opts \\ []), do: Transform.any_param_type(opts)
+
+  @doc "Returns a deferred operation-specific Transform handle type."
+  def operation(name, opts \\ []), do: Transform.operation_type(name, opts)
+
+  @doc "Returns a Transform parameter type wrapping an MLIR type."
+  def param(type), do: Transform.param_type(type)
+
+  defp resolve_type!(type, context, label) do
+    case Beaver.Deferred.create(type, context) do
+      %MLIR.Type{} = resolved ->
+        ensure_same_context!(resolved, context, label)
+        resolved
+
+      value ->
+        raise ArgumentError, "#{label} must resolve to an MLIR type, got: #{inspect(value)}"
+    end
+  end
+
+  defp ensure_same_context!(entity, context, label) do
+    unless MLIR.equal?(MLIR.context(entity), context) do
+      raise ArgumentError, "#{label} belongs to a different MLIR context"
+    end
+  end
+
+  defp validate_helper_options!(opts, supported, helper) do
+    unless Keyword.keyword?(opts) do
+      raise ArgumentError, "#{helper} options must be a keyword list, got: #{inspect(opts)}"
+    end
+
+    case Keyword.keys(opts) -- supported do
+      [] -> :ok
+      unsupported -> raise ArgumentError, "unsupported #{helper} options: #{inspect(unsupported)}"
+    end
+  end
+
+  defp literal_name!(name, _label) when is_binary(name) and name != "", do: name
+  defp literal_name!(name, label) when is_atom(name), do: runtime_name!(name, label)
+
+  defp literal_name!(name, label) do
+    raise ArgumentError,
+          "#{label} name must be a literal non-empty string or atom, got: #{Macro.to_string(name)}"
+  end
+
+  defp runtime_name!(name, _label) when is_binary(name) and name != "", do: name
+  defp runtime_name!(name, _label) when is_atom(name), do: Atom.to_string(name)
+
+  defp runtime_name!(name, label) do
+    raise ArgumentError, "#{label} name must be a non-empty string or atom, got: #{inspect(name)}"
+  end
+
+  defp source_location(caller, context) do
+    MLIR.Location.file(name: caller.file, line: caller.line, ctx: context)
+  end
+end

--- a/test/transform_schedule_dsl_test.exs
+++ b/test/transform_schedule_dsl_test.exs
@@ -1,0 +1,355 @@
+defmodule Beaver.MLIR.Transform.Schedule.DSLTest do
+  use ExUnit.Case, async: true
+
+  alias Beaver.MLIR
+  alias Beaver.MLIR.Dialect.{SMT, Transform}
+  alias Beaver.MLIR.Transform.{Schedule, Tuner}
+  alias Beaver.MLIR.Transform.Schedule.DSL
+
+  defmodule GuideSchedule do
+    use DSL
+
+    defschedule tiling_and_vectorization do
+      sequence "__transform_main", [root >>> any_op()] do
+        tile = knob("tile_size", [8, 16, 32], type: param(MLIR.Type.i64()))
+
+        operation_names =
+          MLIR.Attribute.array(
+            [MLIR.Attribute.string("linalg.matmul")],
+            ctx: Beaver.Env.context()
+          )
+
+        matmul =
+          Transform.structured_match(target: root, ops: operation_names) >>> any_op()
+
+        dynamic_tile =
+          MLIR.Attribute.dense_array([-1], Beaver.Native.I64, ctx: Beaver.Env.context())
+
+        scalable_tile =
+          MLIR.Attribute.dense_array([false], Beaver.Native.Bool, ctx: Beaver.Env.context())
+
+        [tiled, _loop] =
+          Transform.structured_tile_using_for(
+            target: matmul,
+            dynamic_sizes: [tile],
+            static_sizes: dynamic_tile,
+            scalable_sizes: scalable_tile
+          ) >>> [any_op(), any_op()]
+
+        alternatives "vectorize" do
+          branch do
+            isolated = MLIR.Attribute.unit(ctx: Beaver.Env.context())
+
+            function =
+              Transform.get_parent_op(target: tiled, isolated_from_above: isolated) >>> any_op()
+
+            _vectorized =
+              Transform.structured_vectorize_children_and_apply_patterns(target: function) >>>
+                any_op()
+          end
+
+          branch do
+            :ok
+          end
+        end
+      end
+    end
+  end
+
+  defmodule ConditionalSchedule do
+    use DSL
+
+    defschedule route_schedule do
+      sequence "__transform_main", [_root >>> any_op()] do
+        alternatives "route" do
+          branch do
+            _fast = knob("fast_tile", [8, 16])
+          end
+
+          branch do
+            _slow = knob("slow_tile", [32, 64])
+          end
+        end
+      end
+    end
+  end
+
+  defmodule ScalarSchedule do
+    use DSL
+
+    defschedule scalar_schedule do
+      sequence "__transform_main", [_root >>> any_op()] do
+        _integer = knob("integer", [8, 16])
+        _float = knob("float", [0.5, 1.5])
+        _boolean = knob("boolean", [true, false])
+        _string = knob("string", ["fast", "slow"])
+        _unit = knob("unit", [:unit])
+
+        _attribute =
+          knob("attribute", [
+            fn context -> MLIR.Attribute.integer(MLIR.Type.i32(ctx: context), 42) end
+          ])
+      end
+    end
+  end
+
+  defmodule CustomNamedSchedule do
+    use DSL
+
+    defschedule custom_schedule do
+      sequence "custom_transform", [_root >>> operation("builtin.module")] do
+        _tile = knob("tile", [4, 8])
+      end
+    end
+  end
+
+  defmodule ConstraintSchedule do
+    use DSL
+
+    defschedule constrained_schedule do
+      sequence "__transform_main", [_root >>> any_op()] do
+        tile =
+          Transform.param_constant(
+            value: MLIR.Attribute.integer(MLIR.Type.i64(ctx: Beaver.Env.context()), 42)
+          ) >>> param(MLIR.Type.i64())
+
+        Transform.smt_constrain_params params: [tile] do
+          region do
+            block _(_symbol >>> ~t{!smt.int}) do
+              SMT.yield() >>> []
+            end
+          end
+        end >>> []
+      end
+    end
+  end
+
+  defmodule InvalidDeclarations do
+    use DSL
+
+    defschedule empty_knob do
+      sequence do
+        _value = knob("empty", [])
+      end
+    end
+
+    defschedule unsupported_scalar do
+      sequence do
+        _value = knob("pid", [self()])
+      end
+    end
+
+    defschedule no_sequence do
+      :ok
+    end
+
+    defschedule verifier_failure do
+      sequence do
+        _invalid = Transform.get_parent_op(target: root) >>> param(MLIR.Type.i64())
+      end
+    end
+  end
+
+  @payload """
+  module {
+    func.func @matmul_op(%A: tensor<16x16xf32>, %B: tensor<16x16xf32>, %C: tensor<16x16xf32>) -> tensor<16x16xf32> {
+      %0 = linalg.matmul ins(%A, %B : tensor<16x16xf32>, tensor<16x16xf32>) outs(%C : tensor<16x16xf32>) -> tensor<16x16xf32>
+      return %0 : tensor<16x16xf32>
+    }
+  }
+  """
+
+  setup do
+    context = MLIR.Context.create()
+    on_exit(fn -> MLIR.Context.destroy(context) end)
+    %{ctx: context}
+  end
+
+  test "authors the guide search space as verified upstream Transform IR", %{ctx: ctx} do
+    schedule = own(GuideSchedule.tiling_and_vectorization(ctx: ctx))
+
+    assert {:ok, analysis} = Schedule.analyze(schedule)
+    assert Enum.map(analysis.choices, & &1.name) == ["tile_size", "vectorize"]
+
+    assert {:ok, candidates} = Schedule.enumerate(schedule)
+
+    assert candidates == [
+             %{"tile_size" => 8, "vectorize" => 0},
+             %{"tile_size" => 8, "vectorize" => 1},
+             %{"tile_size" => 16, "vectorize" => 0},
+             %{"tile_size" => 16, "vectorize" => 1},
+             %{"tile_size" => 32, "vectorize" => 0},
+             %{"tile_size" => 32, "vectorize" => 1}
+           ]
+
+    resolved = Schedule.resolve!(schedule, %{"tile_size" => 16, "vectorize" => 1})
+    assert resolved.choices == %{"tile_size" => 16, "vectorize" => 1}
+  end
+
+  test "generated IR is deterministic and round-trips through text and bytecode", %{ctx: ctx} do
+    first = own(ConditionalSchedule.route_schedule(ctx: ctx))
+    second = own(ConditionalSchedule.route_schedule(ctx: ctx))
+
+    assert {:ok, _} = MLIR.verify(first)
+    assert MLIR.to_string(first) == MLIR.to_string(second)
+    assert MLIR.Bytecode.write!(first) == MLIR.Bytecode.write!(second)
+
+    text = MLIR.to_string(first)
+    bytecode = MLIR.Bytecode.write!(first)
+    assert text =~ "transform.with_named_sequence"
+    assert text =~ ~s(transform.tune.alternatives<"route">)
+    assert String.starts_with?(bytecode, "ML\xEFR")
+
+    text_round_trip = own(MLIR.Module.create!(text, ctx: ctx))
+    bytecode_round_trip = own(MLIR.Module.create!(bytecode, ctx: ctx))
+
+    for round_trip <- [text_round_trip, bytecode_round_trip] do
+      assert {:ok, candidates} = Schedule.enumerate(round_trip)
+      assert length(candidates) == 4
+    end
+  end
+
+  test "choices nested in alternatives stay conditional", %{ctx: ctx} do
+    schedule = own(ConditionalSchedule.route_schedule(ctx: ctx))
+
+    assert {:ok,
+            [
+              %{"route" => 0, "fast_tile" => 8},
+              %{"route" => 0, "fast_tile" => 16},
+              %{"route" => 1, "slow_tile" => 32},
+              %{"route" => 1, "slow_tile" => 64}
+            ]} = Schedule.enumerate(schedule)
+
+    resolved = Schedule.resolve!(schedule, %{"route" => 1, "slow_tile" => 64})
+    replay = Schedule.resolve!(schedule, %{"route" => 1, "slow_tile" => 64})
+
+    assert resolved.choices == %{"route" => 1, "slow_tile" => 64}
+    assert Schedule.cache_identity(resolved) == Schedule.cache_identity(replay)
+
+    payload = own(MLIR.Module.create!(@payload, ctx: ctx))
+    assert {:ok, %MLIR.Transform.Result{}} = MLIR.Transform.execute(payload, resolved)
+
+    assert %Tuner.Result{
+             candidates: [
+               %Tuner.Candidate{status: :ok, choices: %{"route" => 1, "slow_tile" => 64}}
+             ]
+           } =
+             Tuner.search!(schedule, fn _resolved, candidate -> {:ok, candidate.choices} end,
+               candidates: [%{"route" => 1, "slow_tile" => 64}],
+               max_concurrency: 1
+             )
+  end
+
+  test "knobs preserve common Elixir scalar and MLIR attribute values", %{ctx: ctx} do
+    schedule = own(ScalarSchedule.scalar_schedule(ctx: ctx))
+    assert {:ok, analysis} = Schedule.analyze(schedule)
+
+    assert Enum.map(analysis.choices, & &1.name) == [
+             "integer",
+             "float",
+             "boolean",
+             "string",
+             "unit",
+             "attribute"
+           ]
+
+    assert {:ok, [candidate | _]} = Schedule.enumerate(schedule)
+    assert candidate["integer"] == 8
+    assert candidate["float"] == 0.5
+    assert candidate["boolean"] == true
+    assert candidate["string"] == "fast"
+    assert candidate["unit"] == :unit
+    assert candidate["attribute"] == 42
+  end
+
+  test "generic SSA constraint regions remain inspectable", %{ctx: ctx} do
+    schedule = own(ConstraintSchedule.constrained_schedule(ctx: ctx))
+    assert {:ok, [constraint]} = Schedule.constraints(schedule)
+    assert constraint.ir =~ "transform.smt.constrain_params"
+    assert constraint.ir =~ "smt.yield"
+
+    solver = fn constraints, selections ->
+      assert length(constraints) == 1
+      assert selections == %{}
+      {:ok, %{solver: :test, satisfiable: true}}
+    end
+
+    assert {:ok, resolved} = Schedule.resolve(schedule, %{}, solver: solver)
+    assert resolved.solver_metadata == %{solver: :test, satisfiable: true}
+  end
+
+  test "custom named sequences and typed handles are selectable", %{ctx: ctx} do
+    schedule = own(CustomNamedSchedule.custom_schedule(ctx: ctx))
+    assert {:ok, analysis} = Schedule.analyze(schedule, sequence: "custom_transform")
+    assert Enum.map(analysis.choices, & &1.name) == ["tile"]
+    assert MLIR.to_string(schedule) =~ ~s(!transform.op<"builtin.module">)
+  end
+
+  test "generated operations retain declaration source locations", %{ctx: ctx} do
+    schedule = own(ConditionalSchedule.route_schedule(ctx: ctx))
+
+    assert schedule
+           |> MLIR.Module.body()
+           |> Beaver.Walker.operations()
+           |> Enum.any?(fn operation ->
+             operation |> MLIR.location() |> MLIR.to_string() =~ "transform_schedule_dsl_test.exs"
+           end)
+
+    assert_raise ArgumentError, ~r/verification failed.*transform_schedule_dsl_test\.exs/s, fn ->
+      InvalidDeclarations.verifier_failure(ctx: ctx)
+    end
+  end
+
+  test "invalid declarations fail without taking context ownership", %{ctx: ctx} do
+    assert_raise ArgumentError, ~r/requires a caller-owned/, fn ->
+      InvalidDeclarations.empty_knob()
+    end
+
+    assert_raise ArgumentError, ~r/unsupported schedule options/, fn ->
+      InvalidDeclarations.empty_knob(ctx: ctx, unknown: true)
+    end
+
+    assert_raise ArgumentError, ~r/knob options cannot be empty/, fn ->
+      InvalidDeclarations.empty_knob(ctx: ctx)
+    end
+
+    assert_raise ArgumentError, ~r/unsupported scalar or attribute/, fn ->
+      InvalidDeclarations.unsupported_scalar(ctx: ctx)
+    end
+
+    assert_raise ArgumentError, ~r/must declare at least one sequence/, fn ->
+      InvalidDeclarations.no_sequence(ctx: ctx)
+    end
+
+    # Every failed builder destroyed only its temporary module; the caller's
+    # context remains usable.
+    assert %MLIR.Module{} = own(ConditionalSchedule.route_schedule(ctx: ctx))
+  end
+
+  test "resolved DSL schedules work unchanged with CompilationRuntime", %{ctx: ctx} do
+    cache = start_supervised!({MLIR.CompilationCache.Memory, []})
+    schedule = own(ConditionalSchedule.route_schedule(ctx: ctx))
+    resolved = Schedule.resolve!(schedule, %{"route" => 1, "slow_tile" => 64})
+
+    first =
+      MLIR.CompilationRuntime.compile!(@payload,
+        cache: {:memory, cache},
+        transform_schedule: resolved
+      )
+
+    second =
+      MLIR.CompilationRuntime.compile!(@payload,
+        cache: {:memory, cache},
+        transform_schedule: resolved
+      )
+
+    assert first.cache == :miss
+    assert second.cache == :hit
+    assert first.metadata.transform_schedule == Schedule.cache_identity(resolved)
+  end
+
+  defp own(module) do
+    on_exit(fn -> MLIR.Module.destroy(module) end)
+    module
+  end
+end


### PR DESCRIPTION
## Summary

- add a `defschedule` authoring DSL that emits verified upstream Transform dialect IR directly
- support typed named-sequence handles, scalar tune knobs, conditional alternatives, implicit yields, generic Beaver SSA regions, and declaration source locations
- keep generated schedules compatible with `Schedule`, `Tuner`, `CompilationRuntime`, and `Transform.execute` without introducing a host-only schedule graph
- rewrite the tiling/vectorization guide example in the DSL and export formatter rules for its block macros

## Why

Larger autotuning spaces currently require repetitive handwritten MLIR or low-level SSA construction. This adds a concise Elixir authoring frontend while retaining ordinary MLIR text and bytecode as the durable, inspectable schedule representation.

Closes #488.

## Validation

- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `mix credo diff --strict`
- `mix test --warnings-as-errors --exclude vulkan --exclude todo` — 282 passed, 11 excluded
- `mix docs` — generated successfully; only existing CAPI/hidden-module documentation warnings
- `git diff --check`