### PR TITLE
Fix Linux partition library load regression

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -118,19 +118,6 @@ jobs:
           MIX_ENV: test
         run: |
           mix compile.elixir_make
-      - name: Debug partition dynamic tables
-        if: always()
-        run: |
-          ls -la _build/test/lib/beaver/priv/lib
-          for f in _build/test/lib/beaver/priv/lib/*.so*; do
-            echo "===== $f"
-            readelf -d "$f" 2>&1 | grep -E 'SONAME|NEEDED' || true
-          done
-      - name: Debug NIF dlopen trace
-        if: always()
-        run: |
-          cd _build/test/lib/beaver/priv
-          LD_DEBUG=libs python3 -c "import ctypes; ctypes.CDLL('./lib/libBeaverNIF.so')" 2>&1 | tail -50 || true
       - name: Reject compiler warnings
         if: matrix.elixir == '1.20.3'
         env:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -118,6 +118,19 @@ jobs:
           MIX_ENV: test
         run: |
           mix compile.elixir_make
+      - name: Debug partition dynamic tables
+        if: always()
+        run: |
+          ls -la _build/test/lib/beaver/priv/lib
+          for f in _build/test/lib/beaver/priv/lib/*.so*; do
+            echo "===== $f"
+            readelf -d "$f" 2>&1 | grep -E 'SONAME|NEEDED' || true
+          done
+      - name: Debug NIF dlopen trace
+        if: always()
+        run: |
+          cd _build/test/lib/beaver/priv
+          LD_DEBUG=libs python3 -c "import ctypes; ctypes.CDLL('./lib/libBeaverNIF.so')" 2>&1 | tail -50 || true
       - name: Reject compiler warnings
         if: matrix.elixir == '1.20.3'
         env:

--- a/build.zig
+++ b/build.zig
@@ -101,10 +101,11 @@ fn createNativePartitionLib(
         .root_module = createNativeModule(b, target, optimize, root, capi_module, kinda_module, mlir_include_dir),
     });
     if (linkage == .dynamic) {
-        // Partition dylibs call the MLIR C API directly. Their undefined
-        // symbols are resolved at runtime from the final NIF library's
-        // dependency on MLIRBeaver, so the partition caches stay valid when
-        // only the C++ aggregate changes.
+        // Partition dylibs call the MLIR C API directly, so link them against
+        // libMLIRBeaver. Resolving those symbols only through the NIF shim's
+        // dependency does not work on Linux: glibc does not put sibling
+        // dependencies in a partition's symbol scope.
+        lib.root_module.linkSystemLibrary("MLIRBeaver", .{ .use_pkg_config = .no });
         lib.linker_allow_shlib_undefined = true;
         lib.root_module.addLibraryPath(.{ .cwd_relative = mlir_lib_dir });
         lib.root_module.addRPathSpecial(if (os == .linux) "$ORIGIN" else "@loader_path");

--- a/build.zig
+++ b/build.zig
@@ -219,12 +219,16 @@ pub fn build(b: *std.Build) void {
     const callback_bridge_lib = createNativePartitionLib(b, "beaver_callback_bridge", "native/src/callback_bridge_root.zig", target, optimize, capi_module, kinda_module, mlir_include_dir, .dynamic, llvm_lib_dir);
     const rewrite_pattern_lib = createNativePartitionLib(b, "beaver_rewrite_pattern", "native/src/rewrite_pattern_root.zig", target, optimize, capi_module, kinda_module, mlir_include_dir, .dynamic, llvm_lib_dir);
 
-    // Partition libraries link against libMLIRBeaver from the CMake install
-    // prefix; make sure the CMake step runs before they are linked.
-    core_lib.step.dependOn(cmake_step);
-    conversion_lib.step.dependOn(cmake_step);
-    callback_bridge_lib.step.dependOn(cmake_step);
-    rewrite_pattern_lib.step.dependOn(cmake_step);
+    // Partition libraries link against libMLIRBeaver installed by the CMake
+    // step into the install prefix. On Linux, an explicit library path is
+    // required for the DT_NEEDED entry to be recorded (a bare search prefix is
+    // dropped by the linker); the CMake step must also run before they link.
+    const mlir_lib_dir = b.pathJoin(&.{ b.install_path, "lib" });
+
+    for ([_]*std.Build.Step.Compile{ core_lib, conversion_lib, callback_bridge_lib, rewrite_pattern_lib }) |partition| {
+        partition.root_module.addLibraryPath(.{ .cwd_relative = mlir_lib_dir });
+        partition.step.dependOn(cmake_step);
+    }
 
     // Default target: the NIF shim links the partitions and assembles their
     // exported NIF tables into a single library entry at load time.


### PR DESCRIPTION
## Problem

On Linux, NIF loading fails with `libbeaver_rewrite_pattern.so: undefined symbol: beaverContextAddWork`, breaking all Elixir CI jobs and the docs site build. Introduced by #503, which removed the partition libraries' direct `linkSystemLibrary("MLIRBeaver")` call and relied on the NIF shim's dependency to resolve MLIR C API symbols at runtime.

That only works on macOS: glibc does not put sibling dependencies (the shim's libMLIRBeaver) in a partition library's symbol scope, so the partition's undefined symbols stay unresolved at load time.

## Fix

- Restore `linkSystemLibrary("MLIRBeaver")` in `createNativePartitionLib` so each partition records its own `DT_NEEDED` on `libMLIRBeaver.so.24.0`.
- Point the partitions' library path at the CMake install prefix's `lib` dir (where libMLIRBeaver lands) and keep the cmake-step dependency so the lib exists when partitions link.

## Verification

- Elixir CI matrix (otp25/27.3/28.4 × ex1.18/1.20.3, incl. triton): all green; before the fix every job failed at NIF load.
- Partition libraries now carry the MLIRBeaver dependency on both macOS and Linux (readelf confirmed on CI).

Note: the release workflow's `Run tests with prebuilt` step is a separate, pre-existing failure (red on main since #497, before this fix); it now fails later (prebuilt tarball extraction missing libMLIRBeaver) and is not addressed by this PR.