### PR TITLE
Wire up Windows native build and NIF loading

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Normalize text files to LF on checkout so line-ending-sensitive tools
+# (Zig fmt, etc.) behave identically on Windows and Unix.
+* text=auto eol=lf

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -30,6 +30,10 @@ on:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
 concurrency:
   group: build-and-test-${{ github.ref }}-${{ inputs.llvm_prebuilt_asset_name || inputs.llvm_prebuilt_asset_revision || 'default' }}
   cancel-in-progress: true
@@ -56,9 +60,26 @@ jobs:
             otp: "27.3"
             elixir: "1.20.3"
             llvm: "triton"
+          - runs-on: "windows-2022"
+            otp: "27.3"
+            elixir: "1.20.3"
+            llvm: "triton"
     steps:
       - uses: actions/checkout@v4
         name: Check-out beaver
+      # Kinda 0.11.0 on Hex predates the LLP64 integer conversion fix; the
+      # Windows lane needs the paired checkout until a release containing
+      # beaver-lodge/kinda#68 is published.
+      - uses: actions/checkout@v4
+        name: Check out paired Kinda
+        if: runner.os == 'Windows'
+        with:
+          repository: beaver-lodge/kinda
+          path: kinda
+          ref: 81a51065952cb644b10cb60dacc4370ec653c9ed
+      - name: Point Mix at the paired Kinda checkout
+        if: runner.os == 'Windows'
+        run: echo "BEAVER_KINDA_PATH=${GITHUB_WORKSPACE}/kinda" >> "$GITHUB_ENV"
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
@@ -68,6 +89,7 @@ jobs:
         with:
           version: 0.16.0
       - uses: Jimver/cuda-toolkit@master
+        if: runner.os != 'Windows'
         id: cuda-toolkit
         with:
           use-github-cache: false
@@ -101,6 +123,62 @@ jobs:
           else
             mix beaver.install_prebuilt_llvm --install-dir "$RUNNER_TEMP/llvm-prebuilt"
           fi
+      - name: Set up MSVC toolchain
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+      - name: Configure Windows pagefile
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          try {
+            $source = @'
+            using System;
+            using System.ComponentModel;
+            using System.Diagnostics;
+            using System.Runtime.InteropServices;
+            using System.Text;
+            public static class Pagefile {
+              [StructLayout(LayoutKind.Sequential)] internal struct LUID { internal uint LowPart; internal int HighPart; }
+              [StructLayout(LayoutKind.Sequential)] internal struct LUID_AND_ATTRIBUTES { internal LUID Luid; internal uint Attributes; }
+              [StructLayout(LayoutKind.Sequential)] internal struct TOKEN_PRIVILEGE { internal uint PrivilegeCount; internal LUID_AND_ATTRIBUTES Privilege; }
+              [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)] internal struct UNICODE_STRING { internal ushort length; internal ushort maximumLength; internal string buffer; }
+              [DllImport("advapi32.dll", SetLastError = true)] internal static extern bool LookupPrivilegeValue(string system, string name, out LUID luid);
+              [DllImport("advapi32.dll", SetLastError = true)] internal static extern bool OpenProcessToken(IntPtr h, uint access, out IntPtr token);
+              [DllImport("advapi32.dll", SetLastError = true)] internal static extern bool AdjustTokenPrivileges(IntPtr token, bool disable, ref TOKEN_PRIVILEGE tp, uint len, IntPtr prev, IntPtr retlen);
+              [DllImport("kernel32.dll")] internal static extern bool CloseHandle(IntPtr h);
+              [DllImport("ntdll.dll", CharSet = CharSet.Unicode, SetLastError = true)] internal static extern int NtCreatePagingFile(ref UNICODE_STRING file, ref long min, ref long max, uint flags);
+              [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)] internal static extern uint QueryDosDevice(string device, StringBuilder target, int size);
+              public static void EnablePrivilege() {
+                LUID luid;
+                if (!LookupPrivilegeValue(null, "SeCreatePagefilePrivilege", out luid)) throw new Win32Exception(Marshal.GetLastWin32Error());
+                IntPtr token;
+                if (!OpenProcessToken(Process.GetCurrentProcess().Handle, 0x28, out token)) throw new Win32Exception(Marshal.GetLastWin32Error());
+                try {
+                  TOKEN_PRIVILEGE tp = new TOKEN_PRIVILEGE();
+                  tp.PrivilegeCount = 1; tp.Privilege.Luid = luid; tp.Privilege.Attributes = 2;
+                  if (!AdjustTokenPrivileges(token, false, ref tp, (uint)Marshal.SizeOf(typeof(TOKEN_PRIVILEGE)), IntPtr.Zero, IntPtr.Zero)) throw new Win32Exception(Marshal.GetLastWin32Error());
+                } finally { CloseHandle(token); }
+              }
+              public static void SetPageFileSize(long min, long max) {
+                EnablePrivilege();
+                StringBuilder path = new StringBuilder(260);
+                if (QueryDosDevice("D:", path, path.Capacity) == 0) throw new Win32Exception(Marshal.GetLastWin32Error());
+                string file = path.ToString() + "\\pagefile.sys";
+                UNICODE_STRING name = new UNICODE_STRING();
+                name.length = (ushort)(file.Length * 2);
+                name.maximumLength = (ushort)(2 * (file.Length + 1));
+                name.buffer = file;
+                int status = NtCreatePagingFile(ref name, ref min, ref max, 0);
+                if (status != 0) throw new Win32Exception(Marshal.GetLastWin32Error());
+                Console.WriteLine("PageFile: {0} / {1} bytes for {2}", min, max, file);
+              }
+            }
+          '@
+            Add-Type -TypeDefinition $source
+            [Pagefile]::SetPageFileSize(8L * 1024 * 1024 * 1024, 16L * 1024 * 1024 * 1024)
+          } catch {
+            Write-Output "pagefile setup failed (best-effort): $_"
+          }
       - name: Build native library
         env:
           MIX_ENV: test
@@ -128,17 +206,21 @@ jobs:
           mix test
       - name: Run tests
         run: |
+          extra=""
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            extra="--exclude cuda"
+          fi
           if [[ "${{ matrix.elixir }}" == "1.20.3" ]]; then
-            mix test --warnings-as-errors --exclude vulkan --exclude todo
+            mix test --warnings-as-errors --exclude vulkan --exclude todo $extra
           else
-            mix test --exclude vulkan --exclude todo
+            mix test --exclude vulkan --exclude todo $extra
           fi
       - name: Run dev build
         run: |
           mix
           mix credo
           mix elixir_make.checksum --only-local --ignore-unavailable --print
-          mix hex.build
+          env -u BEAVER_KINDA_PATH mix hex.build
       - name: Run overhead profiling
         if: matrix.otp == '27.3'
         run: |

--- a/Makefile.win
+++ b/Makefile.win
@@ -1,0 +1,29 @@
+# nmake makefile for building Beaver native libraries on Windows.
+# Mirrors Makefile using cmd.exe-compatible commands; elixir_make picks it up
+# automatically when it invokes nmake. elixir_make provides MIX_ENV,
+# MIX_APP_PATH, ERTS_INCLUDE_DIR and KINDA_SOURCE_PATH in the environment, so
+# the defaults below only apply to standalone invocations.
+
+!IFNDEF MIX_ENV
+MIX_ENV = dev
+!ENDIF
+!IFNDEF MIX_APP_PATH
+MIX_APP_PATH = _build\$(MIX_ENV)\lib\beaver
+!ENDIF
+BUILD_PRIV = $(MIX_APP_PATH)\priv
+!IFDEF KINDA_SOURCE_PATH
+KINDA_FORK_ARG = --fork="$(KINDA_SOURCE_PATH)"
+!ELSE
+KINDA_FORK_ARG =
+!ENDIF
+
+all: zig_build
+
+prepare_build_priv:
+	@if not exist "$(BUILD_PRIV)" mkdir "$(BUILD_PRIV)"
+
+zig_build: prepare_build_priv
+	zig build -p "$(BUILD_PRIV)" --search-prefix "$(ERTS_INCLUDE_DIR)\.." $(KINDA_FORK_ARG)
+
+clean:
+	@if exist .zig-cache rmdir /s /q .zig-cache

--- a/build.zig
+++ b/build.zig
@@ -77,10 +77,20 @@ fn createNativeModule(
     module.addIncludePath(.{ .cwd_relative = "native/include" });
     // add these to get ZLS working properly
     module.addIncludePath(.{ .cwd_relative = mlir_include_dir });
-    if (os == .linux or os == .macos) {
+    if (os == .linux or os == .macos or os == .windows) {
         module.link_libc = true;
     }
     return module;
+}
+
+fn installArtifact(b: *std.Build, artifact: *std.Build.Step.Compile) void {
+    if (os == .windows) {
+        // Zig installs DLLs to bin/ by default on Windows; the NIF loader and
+        // the partition DLLs expect everything next to each other in lib/.
+        b.getInstallStep().dependOn(&b.addInstallArtifact(artifact, .{ .dest_dir = .{ .override = .lib } }).step);
+    } else {
+        b.installArtifact(artifact);
+    }
 }
 
 fn createNativePartitionLib(
@@ -118,6 +128,12 @@ fn createCMakeStep(b: *std.Build, llvm_cmake_dir: []const u8, mlir_cmake_dir: []
 
     const cmake_build_dir = b.pathJoin(&.{ b.install_path, "cmake_build" });
     const cmake_cache_path = b.pathJoin(&.{ cmake_build_dir, "CMakeCache.txt" });
+    const cmake_build_type = switch (optimize) {
+        .Debug => "Debug",
+        .ReleaseSafe => "RelWithDebInfo",
+        .ReleaseFast => "Release",
+        .ReleaseSmall => "MinSizeRel",
+    };
 
     // cmake_build command
     const cmake_configure = b.addSystemCommand(&.{ "cmake", "-S", "native", "-G", "Ninja", "-B", cmake_build_dir });
@@ -126,13 +142,18 @@ fn createCMakeStep(b: *std.Build, llvm_cmake_dir: []const u8, mlir_cmake_dir: []
         b.fmt("-DMLIR_DIR={s}", .{mlir_cmake_dir}),
         b.fmt("-DCMAKE_INSTALL_PREFIX={s}", .{b.install_path}),
         b.fmt("-DCMAKE_INSTALL_MESSAGE={s}", .{"LAZY"}),
-        b.fmt("-DCMAKE_BUILD_TYPE={s}", .{switch (optimize) {
-            .Debug => "Debug",
-            .ReleaseSafe => "RelWithDebInfo",
-            .ReleaseFast => "Release",
-            .ReleaseSmall => "MinSizeRel",
-        }}),
+        // The prebuilt LLVM/MLIR archives are Release builds; compiling our
+        // C++ in Debug would mix MSVC runtimes and fail the link with an
+        // _ITERATOR_DEBUG_LEVEL mismatch.
+        b.fmt("-DCMAKE_BUILD_TYPE={s}", .{if (os == .windows) "Release" else cmake_build_type}),
     });
+    if (os == .windows) {
+        // MSVC's link.exe rejects response files whose single line exceeds
+        // 131071 characters (LNK1170), which the hundreds of MLIR static
+        // libraries in the prebuilt archive easily produce. lld-link reads
+        // response files without that limit.
+        cmake_configure.addArg("-DCMAKE_LINKER=lld-link");
+    }
     const cmake_build_install = b.addSystemCommand(&.{ "cmake", "--build", cmake_build_dir, "--target", "install" });
     step.dependOn(&cmake_build_install.step);
 
@@ -210,6 +231,19 @@ pub fn build(b: *std.Build) void {
 
     const kinda = b.dependency("kinda", .{});
     const kinda_module = kinda.module("kinda");
+    if (os == .windows) {
+        // erl_nif.h maps enif_* onto the WinDynNifCallbacks table with macros
+        // that translate-c cannot represent; take the plain extern
+        // declarations instead and forward them through windows_enif.zig.
+        kinda_module.addCMacro("STATIC_ERLANG_NIF", "1");
+        // Zig injects -D_FORTIFY_SOURCE=2 for ReleaseSafe, which activates the
+        // mingw fortify wrappers (wcscat/wcscpy and friends) in string.h.
+        // translate-c emits those bodies with local extern wrappers that go
+        // unreferenced, failing the ReleaseSafe shim build on Windows. The
+        // module -D below comes after the injected define, so it wins and
+        // keeps the header translation on the plain extern declarations.
+        kinda_module.addCMacro("_FORTIFY_SOURCE", "0");
+    }
 
     // Native source is partitioned into dynamic libraries so each domain is
     // cached independently: a source edit in one domain only recompiles that
@@ -242,13 +276,58 @@ pub fn build(b: *std.Build) void {
     lib.root_module.linkLibrary(conversion_lib);
     lib.root_module.linkLibrary(callback_bridge_lib);
     lib.root_module.linkLibrary(rewrite_pattern_lib);
-    b.installArtifact(core_lib);
-    b.installArtifact(conversion_lib);
-    b.installArtifact(callback_bridge_lib);
-    b.installArtifact(rewrite_pattern_lib);
+    installArtifact(b, core_lib);
+    installArtifact(b, conversion_lib);
+    installArtifact(b, callback_bridge_lib);
+    installArtifact(b, rewrite_pattern_lib);
     lib.step.dependOn(cmake_step);
 
     std.log.info("Setting optimization mode for {s}: {any}", .{ lib.name, lib.root_module.optimize });
+    if (os == .windows) {
+        // The emulator does not export enif_* from beam.dll on Windows; the
+        // functions are only reachable through the TWinDynNifCallbacks table
+        // passed to nif_init. windows_enif.zig forwards each enif_* import to
+        // that table, and lives in its own library so the partitions and the
+        // NIF shim all resolve the same symbols and the same table global.
+        const enif_shim = b.addLibrary(.{
+            .name = "beaver_enif_shim",
+            .linkage = .dynamic,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("native/src/windows_enif.zig"),
+                .target = target,
+                .optimize = optimize,
+            }),
+        });
+        enif_shim.root_module.addImport("kinda", kinda_module);
+        enif_shim.root_module.link_libc = true;
+        installArtifact(b, enif_shim);
+        // The install prefix doubles as a search prefix. Standalone `zig
+        // build` (no -p) does not create it up front, and the shim compile can
+        // otherwise run ahead of the CMake step that materializes it; order
+        // them like the partition libraries below.
+        enif_shim.step.dependOn(cmake_step);
+        // The CMake step installs the aggregate DLL to bin/ (LLVM install
+        // convention); mirror it into lib/ where the partitions and the NIF
+        // resolve their DLL imports from.
+        const copy_mlir_dll = b.addInstallFileWithDir(
+            .{ .cwd_relative = b.pathJoin(&.{ b.install_path, "bin", "MLIRBeaver.dll" }) },
+            .lib,
+            "MLIRBeaver.dll",
+        );
+        b.getInstallStep().dependOn(&copy_mlir_dll.step);
+        copy_mlir_dll.step.dependOn(cmake_step);
+
+        for ([_]*std.Build.Step.Compile{ core_lib, conversion_lib, callback_bridge_lib, rewrite_pattern_lib, lib }) |artifact| {
+            artifact.root_module.linkLibrary(enif_shim);
+        }
+        // resource_sync.zig, compiled into the non-core partitions, calls
+        // core_resource_type_by_name exported by the core partition. DLL
+        // imports need an explicit record, unlike the flat runtime symbol
+        // resolution that dylibs get on Unix.
+        for ([_]*std.Build.Step.Compile{ conversion_lib, callback_bridge_lib, rewrite_pattern_lib }) |partition| {
+            partition.root_module.linkLibrary(core_lib);
+        }
+    }
     if (os == .linux) {
         lib.root_module.addRPathSpecial("$ORIGIN");
     }
@@ -259,7 +338,10 @@ pub fn build(b: *std.Build) void {
     lib.linker_allow_shlib_undefined = true;
     // copy runtime libs
     b.installDirectory(.{ .source_dir = .{ .cwd_relative = llvm_lib_dir }, .install_dir = .prefix, .install_subdir = "lib", .include_extensions = &.{ ".so", ".dylib", ".dll" } });
-    b.installArtifact(lib);
+    // the Windows prebuilt puts its runtime DLLs (LLVM-C, LTO, runner utils)
+    // in bin/ rather than lib/
+    b.installDirectory(.{ .source_dir = .{ .cwd_relative = b.pathJoin(&.{ llvm_install_dir, "bin" }) }, .install_dir = .prefix, .install_subdir = "lib", .include_extensions = &.{".dll"} });
+    installArtifact(b, lib);
     const check = b.step("check", "Check if compiles");
     check.dependOn(b.getInstallStep());
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .kinda = .{
-            .url = "https://codeload.github.com/beaver-lodge/kinda/tar.gz/cd9dfbf1734f1ee09a544c18a97840d247983257",
-            .hash = "kinda-0.11.0-dev-ghcZCa9gAQD8opmlrukJS7QFroGw85IGiJkmDICPb8sr",
+            .url = "https://codeload.github.com/beaver-lodge/kinda/tar.gz/81a51065952cb644b10cb60dacc4370ec653c9ed",
+            .hash = "kinda-0.11.0-dev-ghcZCXRrAQBdY2vX_BioJ5dH2ot1dpV1d4HstzY1z7ti",
         },
     },
     .paths = .{""},

--- a/lib/beaver/mlir/capi_raw.ex
+++ b/lib/beaver/mlir/capi_raw.ex
@@ -19,19 +19,54 @@ defmodule Beaver.MLIR.CAPI.Raw do
   @on_load :load_nif
 
   def load_nif do
-    nif_file = ~c"#{:code.priv_dir(:beaver)}/lib/libBeaverNIF"
-    dylib = "#{nif_file}.dylib"
-
-    if File.exists?(dylib) do
-      dylib
-      |> Path.basename()
-      |> File.ln_s("#{nif_file}.so")
-    end
+    nif_file = nif_path()
 
     case :erlang.load_nif(nif_file, 0) do
       :ok -> :ok
       {:error, {:reload, _}} -> :ok
       {:error, reason} -> IO.puts("Failed to load nif: #{inspect(reason)}")
+    end
+  end
+
+  defp nif_path do
+    base = Path.join(:code.priv_dir(:beaver), "lib/libBeaverNIF")
+
+    case :os.type() do
+      {:win32, _} ->
+        # Zig names Windows DLLs without the Unix "lib" prefix. OTP appends
+        # the ".dll" suffix itself, so the extension must not be included in
+        # the path passed to load_nif/2 (otherwise the loader looks for
+        # BeaverNIF.dll.dll). The loader also resolves the DLL's sibling
+        # dependencies only when the path uses backslashes: with forward
+        # slashes, LOAD_WITH_ALTERED_SEARCH_PATH is not applied and the
+        # standard search order misses priv/lib, failing with error 126.
+        dll = Path.join(Path.dirname(base), "BeaverNIF")
+        # Windows resolves a DLL's own dependencies against the search path,
+        # not the directory of the DLL, so make the runtime libraries next to
+        # the NIF discoverable before loading it.
+        add_dll_search_path(Path.dirname(dll))
+        dll |> String.replace("/", "\\") |> String.to_charlist()
+
+      _ ->
+        nif_file = String.to_charlist(base)
+        dylib = "#{base}.dylib"
+
+        if File.exists?(dylib) do
+          dylib
+          |> Path.basename()
+          |> File.ln_s("#{base}.so")
+        end
+
+        nif_file
+    end
+  end
+
+  defp add_dll_search_path(dir) do
+    path = System.get_env("PATH") || ""
+    sep = if match?({:win32, _}, :os.type()), do: ";", else: ":"
+
+    unless path |> String.split(sep) |> Enum.any?(&(&1 == dir)) do
+      System.put_env("PATH", dir <> sep <> path)
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,8 @@ defmodule Beaver.MixProject do
             "KINDA_SOURCE_PATH" => Map.fetch!(Mix.Project.deps_paths(), :kinda)
           }
         end,
-        make_args: ~w{-j},
+        # NMAKE does not accept the -j flag; GNU make does.
+        make_args: if(match?({:win32, _}, :os.type()), do: [], else: ~w{-j}),
         make_clean: ["clean"]
       ]
   end

--- a/native/src/diagnostic.zig
+++ b/native/src/diagnostic.zig
@@ -7,6 +7,7 @@ const kinda = @import("kinda");
 const e = kinda.erl_nif;
 const beam = kinda.beam;
 const result = @import("kinda").result;
+const mutex = @import("mutex.zig");
 const PrinterNIF = @import("string_ref.zig").PrinterNIF;
 
 // collect diagnostic as {severity, loc, message, nested_notes}
@@ -14,7 +15,7 @@ const DiagnosticAggregator = struct {
     const Container = std.array_list.Managed(beam.term);
     env: beam.env,
     container: Container = undefined,
-    mutex: std.c.pthread_mutex_t = std.c.PTHREAD_MUTEX_INITIALIZER,
+    mutex: mutex.Mutex = .{},
     fn collectDiagnosticNested(diagnostic: c.MlirDiagnostic, userData: ?*@This()) !beam.term {
         const env = userData.?.env;
         const severity = c.mlirDiagnosticGetSeverity(diagnostic);
@@ -44,17 +45,14 @@ const DiagnosticAggregator = struct {
     }
     fn errorHandler(diagnostic: c.MlirDiagnostic, userData: ?*anyopaque) callconv(.c) mlir_capi.LogicalResult.T {
         const self: *@This() = @ptrCast(@alignCast(userData orelse return c.mlirLogicalResultFailure()));
-        if (std.c.pthread_mutex_lock(&self.mutex) != .SUCCESS)
-            return c.mlirLogicalResultFailure();
-        defer if (std.c.pthread_mutex_unlock(&self.mutex) != .SUCCESS)
-            @panic("failed to unlock diagnostic aggregator");
+        self.mutex.lock();
+        defer self.mutex.unlock();
         return collectDiagnosticTopLevel(diagnostic, self) catch return c.mlirLogicalResultFailure();
     }
     fn deleteUserData(userData: ?*anyopaque) callconv(.c) void {
         const this: ?*@This() = @ptrCast(@alignCast(userData));
         this.?.container.deinit();
-        if (std.c.pthread_mutex_destroy(&this.?.mutex) != .SUCCESS)
-            @panic("failed to destroy diagnostic aggregator mutex");
+        this.?.mutex.destroy();
         e.enif_free_env(this.?.env);
         beam.allocator.destroy(this.?);
     }
@@ -71,10 +69,8 @@ const DiagnosticAggregator = struct {
         return user_data;
     }
     fn to_list(this: *@This(), destination_env: beam.env) !beam.term {
-        if (std.c.pthread_mutex_lock(&this.mutex) != .SUCCESS)
-            return error.FailedToLockDiagnosticAggregator;
-        defer if (std.c.pthread_mutex_unlock(&this.mutex) != .SUCCESS)
-            @panic("failed to unlock diagnostic aggregator");
+        this.mutex.lock();
+        defer this.mutex.unlock();
 
         return e.enif_make_copy(
             destination_env,

--- a/native/src/enif_support.zig
+++ b/native/src/enif_support.zig
@@ -1,3 +1,4 @@
+const std = @import("std");
 const mlir_capi = @import("mlir_capi.zig");
 pub const c = @import("prelude.zig").c;
 const rt = @import("runtime.zig");
@@ -60,11 +61,44 @@ fn register_jit_symbol(jit: mlir_capi.ExecutionEngine.T, comptime name: []const 
     c.mlirExecutionEngineRegisterSymbol(jit, name_str_ref, @ptrCast(@constCast(&f)));
 }
 
+fn register_jit_plain_symbol(jit: mlir_capi.ExecutionEngine.T, comptime name: []const u8, comptime f: anytype) void {
+    const name_str_ref = c.MlirStringRef{
+        .data = name.ptr,
+        .length = name.len,
+    };
+    c.mlirExecutionEngineRegisterSymbol(jit, name_str_ref, @ptrCast(@constCast(&f)));
+}
+
+// Route JIT allocation calls through the same C runtime std.c.free uses for
+// deallocation. On Windows the JIT would otherwise resolve `malloc` from
+// whichever loaded module exports it first, which may back a different heap
+// than Zig's linked C runtime, crashing `free` on the returned pointer.
+fn jit_malloc(size: usize) callconv(.c) ?*anyopaque {
+    return std.c.malloc(size);
+}
+fn jit_free(ptr: ?*anyopaque) callconv(.c) void {
+    std.c.free(ptr);
+}
+fn jit_realloc(ptr: ?*anyopaque, size: usize) callconv(.c) ?*anyopaque {
+    return std.c.realloc(ptr, size);
+}
+fn jit_calloc(num: usize, size: usize) callconv(.c) ?*anyopaque {
+    return std.c.calloc(num, size);
+}
+
 fn beaver_raw_jit_register_enif(env: beam.env, _: c_int, args: [*c]const beam.term) !beam.term {
     const jit = try mlir_capi.ExecutionEngine.resource.fetch(env, args[0]);
     inline for (enif_function_names) |name| {
         const f = if (@hasDecl(e, name)) @field(e, name) else @field(rt, name);
         register_jit_symbol(jit, name, f);
+    }
+    inline for (.{
+        .{ "malloc", jit_malloc },
+        .{ "free", jit_free },
+        .{ "realloc", jit_realloc },
+        .{ "calloc", jit_calloc },
+    }) |symbol| {
+        register_jit_plain_symbol(jit, symbol[0], symbol[1]);
     }
     return beam.make_ok(env);
 }
@@ -117,7 +151,10 @@ fn enif_mlir_type(env: beam.env, ctx: mlir_capi.Context.T, comptime t: type) !be
             return ptr_type(env, ctx);
         },
         else => {
-            const is_int = t == c_int or t == c_ulong or t == c_long or t == beam.env or t == usize or t == c_uint or t == i32 or t == u32 or t == i64 or t == u64;
+            const is_int =
+                t == c_int or t == c_uint or t == c_long or t == c_ulong or
+                t == c_longlong or t == c_ulonglong or t == beam.env or
+                t == usize or t == i32 or t == u32 or t == i64 or t == u64;
             const is_float = t == f32 or t == f64;
             const is_struct = t == beam.resource_type or t == e.ErlNifCond;
             if (is_int or is_struct) {

--- a/native/src/main.zig
+++ b/native/src/main.zig
@@ -2,6 +2,7 @@ const kinda = @import("kinda");
 const e = kinda.erl_nif;
 const beam = kinda.beam;
 const mlir_capi = @import("mlir_capi.zig");
+const builtin = @import("builtin");
 
 const NifFunc = e.ErlNifFunc;
 
@@ -74,7 +75,7 @@ export fn nif_unload(_: beam.env, _: ?*anyopaque) void {}
 
 var entry: e.ErlNifEntry = undefined;
 
-export fn nif_init() *const e.ErlNifEntry {
+fn nif_init_impl() *const e.ErlNifEntry {
     const nifs = assembleNifs();
     entry = e.ErlNifEntry{
         .major = 2,
@@ -92,4 +93,24 @@ export fn nif_init() *const e.ErlNifEntry {
         .min_erts = "erts-13.0",
     };
     return &entry;
+}
+
+fn nif_init_windows(callbacks: *const e.TWinDynNifCallbacks) callconv(.c) *const e.ErlNifEntry {
+    // Windows NIFs receive the emulator's enif_* function table through
+    // nif_init instead of exported symbols; copy it into the global that the
+    // windows_enif wrappers read.
+    e.WinDynNifCallbacks = callbacks.*;
+    return nif_init_impl();
+}
+
+fn nif_init_unix() callconv(.c) *const e.ErlNifEntry {
+    return nif_init_impl();
+}
+
+comptime {
+    if (builtin.os.tag == .windows) {
+        @export(&nif_init_windows, .{ .name = "nif_init" });
+    } else {
+        @export(&nif_init_unix, .{ .name = "nif_init" });
+    }
 }

--- a/native/src/mutex.zig
+++ b/native/src/mutex.zig
@@ -1,0 +1,45 @@
+//! A small portable mutex for native code that must be usable from arbitrary
+//! worker threads (for example MLIR diagnostic callbacks). Windows has no
+//! pthreads in the emulator context, so the SRWLOCK API is used there.
+const std = @import("std");
+const builtin = @import("builtin");
+const windows = std.os.windows;
+
+extern "kernel32" fn AcquireSRWLockExclusive(srwlock: *windows.SRWLOCK) void;
+extern "kernel32" fn ReleaseSRWLockExclusive(srwlock: *windows.SRWLOCK) void;
+
+pub const Mutex = if (builtin.os.tag == .windows)
+    struct {
+        srw: windows.SRWLOCK = .{},
+
+        pub fn lock(self: *Mutex) void {
+            AcquireSRWLockExclusive(&self.srw);
+        }
+
+        pub fn unlock(self: *Mutex) void {
+            ReleaseSRWLockExclusive(&self.srw);
+        }
+
+        pub fn destroy(self: *Mutex) void {
+            _ = self;
+        }
+    }
+else
+    struct {
+        raw: std.c.pthread_mutex_t = std.c.PTHREAD_MUTEX_INITIALIZER,
+
+        pub fn lock(self: *Mutex) void {
+            if (std.c.pthread_mutex_lock(&self.raw) != .SUCCESS)
+                @panic("failed to lock mutex");
+        }
+
+        pub fn unlock(self: *Mutex) void {
+            if (std.c.pthread_mutex_unlock(&self.raw) != .SUCCESS)
+                @panic("failed to unlock mutex");
+        }
+
+        pub fn destroy(self: *Mutex) void {
+            if (std.c.pthread_mutex_destroy(&self.raw) != .SUCCESS)
+                @panic("failed to destroy mutex");
+        }
+    };

--- a/native/src/runtime.zig
+++ b/native/src/runtime.zig
@@ -57,6 +57,63 @@ pub fn inspect_binary_as_memref(d: *BinaryMemRefDescriptor, env: beam.env, term:
 pub fn __decl__inspect_binary_as_memref(_: beam.env, _: beam.term) callconv(.c) BinaryMemRefDescriptor {
     @panic("call inspect_binary_as_memref for correct ABI");
 }
+// On Windows, translate-c cannot infer concrete signatures for the
+// enif_make_list/tupleN convenience macros (they become generic inline
+// functions), so provide typed stand-ins for signature introspection.
+pub fn __decl__enif_make_list1(env: beam.env, e1: beam.term) callconv(.c) beam.term {
+    return e.enif_make_list(env, 1, e1);
+}
+pub fn __decl__enif_make_list2(env: beam.env, e1: beam.term, e2: beam.term) callconv(.c) beam.term {
+    return e.enif_make_list(env, 2, e1, e2);
+}
+pub fn __decl__enif_make_list3(env: beam.env, e1: beam.term, e2: beam.term, e3: beam.term) callconv(.c) beam.term {
+    return e.enif_make_list(env, 3, e1, e2, e3);
+}
+pub fn __decl__enif_make_list4(env: beam.env, e1: beam.term, e2: beam.term, e3: beam.term, e4: beam.term) callconv(.c) beam.term {
+    return e.enif_make_list(env, 4, e1, e2, e3, e4);
+}
+pub fn __decl__enif_make_list5(env: beam.env, e1: beam.term, e2: beam.term, e3: beam.term, e4: beam.term, e5: beam.term) callconv(.c) beam.term {
+    return e.enif_make_list(env, 5, e1, e2, e3, e4, e5);
+}
+pub fn __decl__enif_make_list6(env: beam.env, e1: beam.term, e2: beam.term, e3: beam.term, e4: beam.term, e5: beam.term, e6: beam.term) callconv(.c) beam.term {
+    return e.enif_make_list(env, 6, e1, e2, e3, e4, e5, e6);
+}
+pub fn __decl__enif_make_list7(env: beam.env, e1: beam.term, e2: beam.term, e3: beam.term, e4: beam.term, e5: beam.term, e6: beam.term, e7: beam.term) callconv(.c) beam.term {
+    return e.enif_make_list(env, 7, e1, e2, e3, e4, e5, e6, e7);
+}
+pub fn __decl__enif_make_list8(env: beam.env, e1: beam.term, e2: beam.term, e3: beam.term, e4: beam.term, e5: beam.term, e6: beam.term, e7: beam.term, e8: beam.term) callconv(.c) beam.term {
+    return e.enif_make_list(env, 8, e1, e2, e3, e4, e5, e6, e7, e8);
+}
+pub fn __decl__enif_make_list9(env: beam.env, e1: beam.term, e2: beam.term, e3: beam.term, e4: beam.term, e5: beam.term, e6: beam.term, e7: beam.term, e8: beam.term, e9: beam.term) callconv(.c) beam.term {
+    return e.enif_make_list(env, 9, e1, e2, e3, e4, e5, e6, e7, e8, e9);
+}
+pub fn __decl__enif_make_tuple1(env: beam.env, e1: beam.term) callconv(.c) beam.term {
+    return e.enif_make_tuple(env, 1, e1);
+}
+pub fn __decl__enif_make_tuple2(env: beam.env, e1: beam.term, e2: beam.term) callconv(.c) beam.term {
+    return e.enif_make_tuple(env, 2, e1, e2);
+}
+pub fn __decl__enif_make_tuple3(env: beam.env, e1: beam.term, e2: beam.term, e3: beam.term) callconv(.c) beam.term {
+    return e.enif_make_tuple(env, 3, e1, e2, e3);
+}
+pub fn __decl__enif_make_tuple4(env: beam.env, e1: beam.term, e2: beam.term, e3: beam.term, e4: beam.term) callconv(.c) beam.term {
+    return e.enif_make_tuple(env, 4, e1, e2, e3, e4);
+}
+pub fn __decl__enif_make_tuple5(env: beam.env, e1: beam.term, e2: beam.term, e3: beam.term, e4: beam.term, e5: beam.term) callconv(.c) beam.term {
+    return e.enif_make_tuple(env, 5, e1, e2, e3, e4, e5);
+}
+pub fn __decl__enif_make_tuple6(env: beam.env, e1: beam.term, e2: beam.term, e3: beam.term, e4: beam.term, e5: beam.term, e6: beam.term) callconv(.c) beam.term {
+    return e.enif_make_tuple(env, 6, e1, e2, e3, e4, e5, e6);
+}
+pub fn __decl__enif_make_tuple7(env: beam.env, e1: beam.term, e2: beam.term, e3: beam.term, e4: beam.term, e5: beam.term, e6: beam.term, e7: beam.term) callconv(.c) beam.term {
+    return e.enif_make_tuple(env, 7, e1, e2, e3, e4, e5, e6, e7);
+}
+pub fn __decl__enif_make_tuple8(env: beam.env, e1: beam.term, e2: beam.term, e3: beam.term, e4: beam.term, e5: beam.term, e6: beam.term, e7: beam.term, e8: beam.term) callconv(.c) beam.term {
+    return e.enif_make_tuple(env, 8, e1, e2, e3, e4, e5, e6, e7, e8);
+}
+pub fn __decl__enif_make_tuple9(env: beam.env, e1: beam.term, e2: beam.term, e3: beam.term, e4: beam.term, e5: beam.term, e6: beam.term, e7: beam.term, e8: beam.term, e9: beam.term) callconv(.c) beam.term {
+    return e.enif_make_tuple(env, 9, e1, e2, e3, e4, e5, e6, e7, e8, e9);
+}
 pub const exported = .{
     "print_i32",
     "print_u32",

--- a/native/src/windows_enif.zig
+++ b/native/src/windows_enif.zig
@@ -1,0 +1,734 @@
+// Generated on 2026-08-06 from erl_nif.h (OTP 27.x) by translate-c with
+// STATIC_ERLANG_NIF=1. On Windows the BEAM does not export enif_* functions:
+// they are only reachable through the TWinDynNifCallbacks table passed to
+// nif_init. These exports forward each enif_* import to that table so Zig
+// code can call them through the usual erl_nif namespace.
+const e = @import("kinda").erl_nif;
+
+// The BEAM hands Windows NIFs the enif_* function table through nif_init;
+// this global is what the forwards below read. It lives in this artifact so
+// every native library that imports enif_* resolves the same table.
+export var WinDynNifCallbacks: e.TWinDynNifCallbacks = .{};
+
+export fn enif_free(ptr: ?*anyopaque) void {
+    e.WinDynNifCallbacks.enif_free.?(ptr);
+}
+
+export fn enif_mutex_destroy(mtx: ?*e.ErlNifMutex) void {
+    e.WinDynNifCallbacks.enif_mutex_destroy.?(mtx);
+}
+
+export fn enif_cond_destroy(cnd: ?*e.ErlNifCond) void {
+    e.WinDynNifCallbacks.enif_cond_destroy.?(cnd);
+}
+
+export fn enif_rwlock_destroy(rwlck: ?*e.ErlNifRWLock) void {
+    e.WinDynNifCallbacks.enif_rwlock_destroy.?(rwlck);
+}
+
+export fn enif_thread_opts_destroy(opts: [*c]e.ErlNifThreadOpts) void {
+    e.WinDynNifCallbacks.enif_thread_opts_destroy.?(opts);
+}
+
+export fn enif_ioq_destroy(q: ?*e.ErlNifIOQueue) void {
+    e.WinDynNifCallbacks.enif_ioq_destroy.?(q);
+}
+
+export fn enif_priv_data(arg0: ?*e.ErlNifEnv) ?*anyopaque {
+    return e.WinDynNifCallbacks.enif_priv_data.?(arg0);
+}
+
+export fn enif_alloc(size: usize) ?*anyopaque {
+    return e.WinDynNifCallbacks.enif_alloc.?(size);
+}
+
+export fn enif_is_atom(arg0: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_is_atom.?(arg0, term);
+}
+
+export fn enif_is_binary(arg0: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_is_binary.?(arg0, term);
+}
+
+export fn enif_is_ref(arg0: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_is_ref.?(arg0, term);
+}
+
+export fn enif_inspect_binary(arg0: ?*e.ErlNifEnv, bin_term: e.ERL_NIF_TERM, bin: [*c]e.ErlNifBinary) c_int {
+    return e.WinDynNifCallbacks.enif_inspect_binary.?(arg0, bin_term, bin);
+}
+
+export fn enif_alloc_binary(size: usize, bin: [*c]e.ErlNifBinary) c_int {
+    return e.WinDynNifCallbacks.enif_alloc_binary.?(size, bin);
+}
+
+export fn enif_realloc_binary(bin: [*c]e.ErlNifBinary, size: usize) c_int {
+    return e.WinDynNifCallbacks.enif_realloc_binary.?(bin, size);
+}
+
+export fn enif_release_binary(bin: [*c]e.ErlNifBinary) void {
+    e.WinDynNifCallbacks.enif_release_binary.?(bin);
+}
+
+export fn enif_get_int(arg0: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM, ip: [*c]c_int) c_int {
+    return e.WinDynNifCallbacks.enif_get_int.?(arg0, term, ip);
+}
+
+export fn enif_get_ulong(arg0: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM, ip: [*c]c_ulong) c_int {
+    return e.WinDynNifCallbacks.enif_get_ulong.?(arg0, term, ip);
+}
+
+export fn enif_get_double(arg0: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM, dp: [*c]f64) c_int {
+    return e.WinDynNifCallbacks.enif_get_double.?(arg0, term, dp);
+}
+
+export fn enif_get_list_cell(env: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM, head: [*c]e.ERL_NIF_TERM, tail: [*c]e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_get_list_cell.?(env, term, head, tail);
+}
+
+export fn enif_get_tuple(env: ?*e.ErlNifEnv, tpl: e.ERL_NIF_TERM, arity: [*c]c_int, array: [*c][*c]const e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_get_tuple.?(env, tpl, arity, array);
+}
+
+export fn enif_is_identical(lhs: e.ERL_NIF_TERM, rhs: e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_is_identical.?(lhs, rhs);
+}
+
+export fn enif_compare(lhs: e.ERL_NIF_TERM, rhs: e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_compare.?(lhs, rhs);
+}
+
+export fn enif_make_binary(env: ?*e.ErlNifEnv, bin: [*c]e.ErlNifBinary) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_binary.?(env, bin);
+}
+
+export fn enif_make_badarg(env: ?*e.ErlNifEnv) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_badarg.?(env);
+}
+
+export fn enif_make_int(env: ?*e.ErlNifEnv, i: c_int) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_int.?(env, i);
+}
+
+export fn enif_make_ulong(env: ?*e.ErlNifEnv, i: c_ulong) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_ulong.?(env, i);
+}
+
+export fn enif_make_double(env: ?*e.ErlNifEnv, d: f64) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_double.?(env, d);
+}
+
+export fn enif_make_atom(env: ?*e.ErlNifEnv, name: [*c]const u8) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_atom.?(env, name);
+}
+
+export fn enif_make_existing_atom(env: ?*e.ErlNifEnv, name: [*c]const u8, atom: [*c]e.ERL_NIF_TERM, arg3: e.ErlNifCharEncoding) c_int {
+    return e.WinDynNifCallbacks.enif_make_existing_atom.?(env, name, atom, arg3);
+}
+
+export fn enif_make_tuple(env: ?*e.ErlNifEnv, cnt: c_uint, t1: e.ERL_NIF_TERM, t2: e.ERL_NIF_TERM) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_tuple.?(env, cnt, t1, t2);
+}
+
+export fn enif_make_list(env: ?*e.ErlNifEnv, cnt: c_uint) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_list.?(env, cnt);
+}
+
+export fn enif_make_list_cell(env: ?*e.ErlNifEnv, car: e.ERL_NIF_TERM, cdr: e.ERL_NIF_TERM) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_list_cell.?(env, car, cdr);
+}
+
+export fn enif_make_string(env: ?*e.ErlNifEnv, string: [*c]const u8, arg2: e.ErlNifCharEncoding) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_string.?(env, string, arg2);
+}
+
+export fn enif_make_ref(env: ?*e.ErlNifEnv) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_ref.?(env);
+}
+
+export fn enif_mutex_create(name: [*c]u8) ?*e.ErlNifMutex {
+    return e.WinDynNifCallbacks.enif_mutex_create.?(name);
+}
+
+export fn enif_mutex_trylock(mtx: ?*e.ErlNifMutex) c_int {
+    return e.WinDynNifCallbacks.enif_mutex_trylock.?(mtx);
+}
+
+export fn enif_mutex_lock(mtx: ?*e.ErlNifMutex) void {
+    e.WinDynNifCallbacks.enif_mutex_lock.?(mtx);
+}
+
+export fn enif_mutex_unlock(mtx: ?*e.ErlNifMutex) void {
+    e.WinDynNifCallbacks.enif_mutex_unlock.?(mtx);
+}
+
+export fn enif_cond_create(name: [*c]u8) ?*e.ErlNifCond {
+    return e.WinDynNifCallbacks.enif_cond_create.?(name);
+}
+
+export fn enif_cond_signal(cnd: ?*e.ErlNifCond) void {
+    e.WinDynNifCallbacks.enif_cond_signal.?(cnd);
+}
+
+export fn enif_cond_broadcast(cnd: ?*e.ErlNifCond) void {
+    e.WinDynNifCallbacks.enif_cond_broadcast.?(cnd);
+}
+
+export fn enif_cond_wait(cnd: ?*e.ErlNifCond, mtx: ?*e.ErlNifMutex) void {
+    e.WinDynNifCallbacks.enif_cond_wait.?(cnd, mtx);
+}
+
+export fn enif_rwlock_create(name: [*c]u8) ?*e.ErlNifRWLock {
+    return e.WinDynNifCallbacks.enif_rwlock_create.?(name);
+}
+
+export fn enif_rwlock_tryrlock(rwlck: ?*e.ErlNifRWLock) c_int {
+    return e.WinDynNifCallbacks.enif_rwlock_tryrlock.?(rwlck);
+}
+
+export fn enif_rwlock_rlock(rwlck: ?*e.ErlNifRWLock) void {
+    e.WinDynNifCallbacks.enif_rwlock_rlock.?(rwlck);
+}
+
+export fn enif_rwlock_runlock(rwlck: ?*e.ErlNifRWLock) void {
+    e.WinDynNifCallbacks.enif_rwlock_runlock.?(rwlck);
+}
+
+export fn enif_rwlock_tryrwlock(rwlck: ?*e.ErlNifRWLock) c_int {
+    return e.WinDynNifCallbacks.enif_rwlock_tryrwlock.?(rwlck);
+}
+
+export fn enif_rwlock_rwlock(rwlck: ?*e.ErlNifRWLock) void {
+    e.WinDynNifCallbacks.enif_rwlock_rwlock.?(rwlck);
+}
+
+export fn enif_rwlock_rwunlock(rwlck: ?*e.ErlNifRWLock) void {
+    e.WinDynNifCallbacks.enif_rwlock_rwunlock.?(rwlck);
+}
+
+export fn enif_tsd_key_create(name: [*c]u8, key: [*c]e.ErlNifTSDKey) c_int {
+    return e.WinDynNifCallbacks.enif_tsd_key_create.?(name, key);
+}
+
+export fn enif_tsd_key_destroy(key: e.ErlNifTSDKey) void {
+    e.WinDynNifCallbacks.enif_tsd_key_destroy.?(key);
+}
+
+export fn enif_tsd_set(key: e.ErlNifTSDKey, data: ?*anyopaque) void {
+    e.WinDynNifCallbacks.enif_tsd_set.?(key, data);
+}
+
+export fn enif_tsd_get(key: e.ErlNifTSDKey) ?*anyopaque {
+    return e.WinDynNifCallbacks.enif_tsd_get.?(key);
+}
+
+export fn enif_thread_opts_create(name: [*c]u8) [*c]e.ErlNifThreadOpts {
+    return e.WinDynNifCallbacks.enif_thread_opts_create.?(name);
+}
+
+export fn enif_thread_create(name: [*c]u8, tid: [*c]e.ErlNifTid, func: ?*const fn (?*anyopaque) callconv(.c) ?*anyopaque, args: ?*anyopaque, opts: [*c]e.ErlNifThreadOpts) c_int {
+    return e.WinDynNifCallbacks.enif_thread_create.?(name, tid, func, args, opts);
+}
+
+export fn enif_thread_self() e.ErlNifTid {
+    return e.WinDynNifCallbacks.enif_thread_self.?();
+}
+
+export fn enif_equal_tids(tid1: e.ErlNifTid, tid2: e.ErlNifTid) c_int {
+    return e.WinDynNifCallbacks.enif_equal_tids.?(tid1, tid2);
+}
+
+export fn enif_thread_exit(resp: ?*anyopaque) void {
+    e.WinDynNifCallbacks.enif_thread_exit.?(resp);
+}
+
+export fn enif_thread_join(arg0: e.ErlNifTid, respp: [*c]?*anyopaque) c_int {
+    return e.WinDynNifCallbacks.enif_thread_join.?(arg0, respp);
+}
+
+export fn enif_realloc(ptr: ?*anyopaque, size: usize) ?*anyopaque {
+    return e.WinDynNifCallbacks.enif_realloc.?(ptr, size);
+}
+
+export fn enif_system_info(sip: [*c]e.ErlNifSysInfo, si_size: usize) void {
+    e.WinDynNifCallbacks.enif_system_info.?(sip, si_size);
+}
+
+export fn enif_fprintf(filep: ?*e.FILE, format: [*c]const u8) c_int {
+    return e.WinDynNifCallbacks.enif_fprintf.?(filep, format);
+}
+
+export fn enif_inspect_iolist_as_binary(arg0: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM, bin: [*c]e.ErlNifBinary) c_int {
+    return e.WinDynNifCallbacks.enif_inspect_iolist_as_binary.?(arg0, term, bin);
+}
+
+export fn enif_make_sub_binary(arg0: ?*e.ErlNifEnv, bin_term: e.ERL_NIF_TERM, pos: usize, size: usize) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_sub_binary.?(arg0, bin_term, pos, size);
+}
+
+export fn enif_get_string(arg0: ?*e.ErlNifEnv, list: e.ERL_NIF_TERM, buf: [*c]u8, len: c_uint, arg4: e.ErlNifCharEncoding) c_int {
+    return e.WinDynNifCallbacks.enif_get_string.?(arg0, list, buf, len, arg4);
+}
+
+export fn enif_get_atom(arg0: ?*e.ErlNifEnv, atom: e.ERL_NIF_TERM, buf: [*c]u8, len: c_uint, arg4: e.ErlNifCharEncoding) c_int {
+    return e.WinDynNifCallbacks.enif_get_atom.?(arg0, atom, buf, len, arg4);
+}
+
+export fn enif_is_fun(arg0: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_is_fun.?(arg0, term);
+}
+
+export fn enif_is_pid(arg0: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_is_pid.?(arg0, term);
+}
+
+export fn enif_is_port(arg0: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_is_port.?(arg0, term);
+}
+
+export fn enif_get_uint(arg0: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM, ip: [*c]c_uint) c_int {
+    return e.WinDynNifCallbacks.enif_get_uint.?(arg0, term, ip);
+}
+
+export fn enif_get_long(arg0: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM, ip: [*c]c_long) c_int {
+    return e.WinDynNifCallbacks.enif_get_long.?(arg0, term, ip);
+}
+
+export fn enif_make_uint(arg0: ?*e.ErlNifEnv, i: c_uint) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_uint.?(arg0, i);
+}
+
+export fn enif_make_long(arg0: ?*e.ErlNifEnv, i: c_long) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_long.?(arg0, i);
+}
+
+export fn enif_make_tuple_from_array(arg0: ?*e.ErlNifEnv, arr: [*c]const e.ERL_NIF_TERM, cnt: c_uint) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_tuple_from_array.?(arg0, arr, cnt);
+}
+
+export fn enif_make_list_from_array(arg0: ?*e.ErlNifEnv, arr: [*c]const e.ERL_NIF_TERM, cnt: c_uint) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_list_from_array.?(arg0, arr, cnt);
+}
+
+export fn enif_is_empty_list(arg0: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_is_empty_list.?(arg0, term);
+}
+
+export fn enif_open_resource_type(arg0: ?*e.ErlNifEnv, module_str: [*c]const u8, name_str: [*c]const u8, dtor: ?*const fn (?*e.ErlNifEnv, ?*anyopaque) callconv(.c) void, flags: e.ErlNifResourceFlags, tried: [*c]e.ErlNifResourceFlags) ?*e.ErlNifResourceType {
+    return e.WinDynNifCallbacks.enif_open_resource_type.?(arg0, module_str, name_str, dtor, flags, tried);
+}
+
+export fn enif_alloc_resource(@"type": ?*e.ErlNifResourceType, size: usize) ?*anyopaque {
+    return e.WinDynNifCallbacks.enif_alloc_resource.?(@"type", size);
+}
+
+export fn enif_release_resource(obj: ?*anyopaque) void {
+    e.WinDynNifCallbacks.enif_release_resource.?(obj);
+}
+
+export fn enif_make_resource(arg0: ?*e.ErlNifEnv, obj: ?*anyopaque) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_resource.?(arg0, obj);
+}
+
+export fn enif_get_resource(arg0: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM, @"type": ?*e.ErlNifResourceType, objp: [*c]?*anyopaque) c_int {
+    return e.WinDynNifCallbacks.enif_get_resource.?(arg0, term, @"type", objp);
+}
+
+export fn enif_sizeof_resource(obj: ?*anyopaque) usize {
+    return e.WinDynNifCallbacks.enif_sizeof_resource.?(obj);
+}
+
+export fn enif_make_new_binary(arg0: ?*e.ErlNifEnv, size: usize, termp: [*c]e.ERL_NIF_TERM) [*c]u8 {
+    return e.WinDynNifCallbacks.enif_make_new_binary.?(arg0, size, termp);
+}
+
+export fn enif_is_list(arg0: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_is_list.?(arg0, term);
+}
+
+export fn enif_is_tuple(arg0: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_is_tuple.?(arg0, term);
+}
+
+export fn enif_get_atom_length(arg0: ?*e.ErlNifEnv, atom: e.ERL_NIF_TERM, len: [*c]c_uint, arg3: e.ErlNifCharEncoding) c_int {
+    return e.WinDynNifCallbacks.enif_get_atom_length.?(arg0, atom, len, arg3);
+}
+
+export fn enif_get_list_length(env: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM, len: [*c]c_uint) c_int {
+    return e.WinDynNifCallbacks.enif_get_list_length.?(env, term, len);
+}
+
+export fn enif_make_atom_len(env: ?*e.ErlNifEnv, name: [*c]const u8, len: usize) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_atom_len.?(env, name, len);
+}
+
+export fn enif_make_existing_atom_len(env: ?*e.ErlNifEnv, name: [*c]const u8, len: usize, atom: [*c]e.ERL_NIF_TERM, arg4: e.ErlNifCharEncoding) c_int {
+    return e.WinDynNifCallbacks.enif_make_existing_atom_len.?(env, name, len, atom, arg4);
+}
+
+export fn enif_make_string_len(env: ?*e.ErlNifEnv, string: [*c]const u8, len: usize, arg3: e.ErlNifCharEncoding) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_string_len.?(env, string, len, arg3);
+}
+
+export fn enif_alloc_env() ?*e.ErlNifEnv {
+    return e.WinDynNifCallbacks.enif_alloc_env.?();
+}
+
+export fn enif_free_env(env: ?*e.ErlNifEnv) void {
+    e.WinDynNifCallbacks.enif_free_env.?(env);
+}
+
+export fn enif_clear_env(env: ?*e.ErlNifEnv) void {
+    e.WinDynNifCallbacks.enif_clear_env.?(env);
+}
+
+export fn enif_send(env: ?*e.ErlNifEnv, to_pid: [*c]const e.ErlNifPid, msg_env: ?*e.ErlNifEnv, msg: e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_send.?(env, to_pid, msg_env, msg);
+}
+
+export fn enif_make_copy(dst_env: ?*e.ErlNifEnv, src_term: e.ERL_NIF_TERM) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_copy.?(dst_env, src_term);
+}
+
+export fn enif_self(caller_env: ?*e.ErlNifEnv, pid: [*c]e.ErlNifPid) [*c]e.ErlNifPid {
+    return e.WinDynNifCallbacks.enif_self.?(caller_env, pid);
+}
+
+export fn enif_get_local_pid(env: ?*e.ErlNifEnv, arg1: e.ERL_NIF_TERM, pid: [*c]e.ErlNifPid) c_int {
+    return e.WinDynNifCallbacks.enif_get_local_pid.?(env, arg1, pid);
+}
+
+export fn enif_keep_resource(obj: ?*anyopaque) void {
+    e.WinDynNifCallbacks.enif_keep_resource.?(obj);
+}
+
+export fn enif_make_resource_binary(arg0: ?*e.ErlNifEnv, obj: ?*anyopaque, data: ?*const anyopaque, size: usize) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_resource_binary.?(arg0, obj, data, size);
+}
+
+export fn enif_is_exception(arg0: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_is_exception.?(arg0, term);
+}
+
+export fn enif_make_reverse_list(arg0: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM, list: [*c]e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_make_reverse_list.?(arg0, term, list);
+}
+
+export fn enif_is_number(arg0: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_is_number.?(arg0, term);
+}
+
+export fn enif_dlopen(lib: [*c]const u8, err_handler: ?*const fn (?*anyopaque, [*c]const u8) callconv(.c) void, err_arg: ?*anyopaque) ?*anyopaque {
+    return e.WinDynNifCallbacks.enif_dlopen.?(lib, err_handler, err_arg);
+}
+
+export fn enif_dlsym(handle: ?*anyopaque, symbol: [*c]const u8, err_handler: ?*const fn (?*anyopaque, [*c]const u8) callconv(.c) void, err_arg: ?*anyopaque) ?*anyopaque {
+    return e.WinDynNifCallbacks.enif_dlsym.?(handle, symbol, err_handler, err_arg);
+}
+
+export fn enif_consume_timeslice(arg0: ?*e.ErlNifEnv, percent: c_int) c_int {
+    return e.WinDynNifCallbacks.enif_consume_timeslice.?(arg0, percent);
+}
+
+export fn enif_is_map(env: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_is_map.?(env, term);
+}
+
+export fn enif_get_map_size(env: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM, size: [*c]usize) c_int {
+    return e.WinDynNifCallbacks.enif_get_map_size.?(env, term, size);
+}
+
+export fn enif_make_new_map(env: ?*e.ErlNifEnv) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_new_map.?(env);
+}
+
+export fn enif_make_map_put(env: ?*e.ErlNifEnv, map_in: e.ERL_NIF_TERM, key: e.ERL_NIF_TERM, value: e.ERL_NIF_TERM, map_out: [*c]e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_make_map_put.?(env, map_in, key, value, map_out);
+}
+
+export fn enif_get_map_value(env: ?*e.ErlNifEnv, map: e.ERL_NIF_TERM, key: e.ERL_NIF_TERM, value: [*c]e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_get_map_value.?(env, map, key, value);
+}
+
+export fn enif_make_map_update(env: ?*e.ErlNifEnv, map_in: e.ERL_NIF_TERM, key: e.ERL_NIF_TERM, value: e.ERL_NIF_TERM, map_out: [*c]e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_make_map_update.?(env, map_in, key, value, map_out);
+}
+
+export fn enif_make_map_remove(env: ?*e.ErlNifEnv, map_in: e.ERL_NIF_TERM, key: e.ERL_NIF_TERM, map_out: [*c]e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_make_map_remove.?(env, map_in, key, map_out);
+}
+
+export fn enif_map_iterator_create(env: ?*e.ErlNifEnv, map: e.ERL_NIF_TERM, iter: [*c]e.ErlNifMapIterator, entry: e.ErlNifMapIteratorEntry) c_int {
+    return e.WinDynNifCallbacks.enif_map_iterator_create.?(env, map, iter, entry);
+}
+
+export fn enif_map_iterator_destroy(env: ?*e.ErlNifEnv, iter: [*c]e.ErlNifMapIterator) void {
+    e.WinDynNifCallbacks.enif_map_iterator_destroy.?(env, iter);
+}
+
+export fn enif_map_iterator_is_head(env: ?*e.ErlNifEnv, iter: [*c]e.ErlNifMapIterator) c_int {
+    return e.WinDynNifCallbacks.enif_map_iterator_is_head.?(env, iter);
+}
+
+export fn enif_map_iterator_is_tail(env: ?*e.ErlNifEnv, iter: [*c]e.ErlNifMapIterator) c_int {
+    return e.WinDynNifCallbacks.enif_map_iterator_is_tail.?(env, iter);
+}
+
+export fn enif_map_iterator_next(env: ?*e.ErlNifEnv, iter: [*c]e.ErlNifMapIterator) c_int {
+    return e.WinDynNifCallbacks.enif_map_iterator_next.?(env, iter);
+}
+
+export fn enif_map_iterator_prev(env: ?*e.ErlNifEnv, iter: [*c]e.ErlNifMapIterator) c_int {
+    return e.WinDynNifCallbacks.enif_map_iterator_prev.?(env, iter);
+}
+
+export fn enif_map_iterator_get_pair(env: ?*e.ErlNifEnv, iter: [*c]e.ErlNifMapIterator, key: [*c]e.ERL_NIF_TERM, value: [*c]e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_map_iterator_get_pair.?(env, iter, key, value);
+}
+
+export fn enif_schedule_nif(arg0: ?*e.ErlNifEnv, arg1: [*c]const u8, arg2: c_int, arg3: ?*const fn (?*e.ErlNifEnv, c_int, [*c]const e.ERL_NIF_TERM) callconv(.c) e.ERL_NIF_TERM, arg4: c_int, arg5: [*c]const e.ERL_NIF_TERM) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_schedule_nif.?(arg0, arg1, arg2, arg3, arg4, arg5);
+}
+
+export fn enif_has_pending_exception(env: ?*e.ErlNifEnv, reason: [*c]e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_has_pending_exception.?(env, reason);
+}
+
+export fn enif_raise_exception(env: ?*e.ErlNifEnv, reason: e.ERL_NIF_TERM) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_raise_exception.?(env, reason);
+}
+
+export fn enif_getenv(key: [*c]const u8, value: [*c]u8, value_size: [*c]usize) c_int {
+    return e.WinDynNifCallbacks.enif_getenv.?(key, value, value_size);
+}
+
+export fn enif_monotonic_time(arg0: e.ErlNifTimeUnit) e.ErlNifTime {
+    return e.WinDynNifCallbacks.enif_monotonic_time.?(arg0);
+}
+
+export fn enif_time_offset(arg0: e.ErlNifTimeUnit) e.ErlNifTime {
+    return e.WinDynNifCallbacks.enif_time_offset.?(arg0);
+}
+
+export fn enif_convert_time_unit(arg0: e.ErlNifTime, arg1: e.ErlNifTimeUnit, arg2: e.ErlNifTimeUnit) e.ErlNifTime {
+    return e.WinDynNifCallbacks.enif_convert_time_unit.?(arg0, arg1, arg2);
+}
+
+export fn enif_now_time(env: ?*e.ErlNifEnv) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_now_time.?(env);
+}
+
+export fn enif_cpu_time(env: ?*e.ErlNifEnv) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_cpu_time.?(env);
+}
+
+export fn enif_make_unique_integer(env: ?*e.ErlNifEnv, properties: e.ErlNifUniqueInteger) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_unique_integer.?(env, properties);
+}
+
+export fn enif_is_current_process_alive(env: ?*e.ErlNifEnv) c_int {
+    return e.WinDynNifCallbacks.enif_is_current_process_alive.?(env);
+}
+
+export fn enif_is_process_alive(env: ?*e.ErlNifEnv, pid: [*c]e.ErlNifPid) c_int {
+    return e.WinDynNifCallbacks.enif_is_process_alive.?(env, pid);
+}
+
+export fn enif_is_port_alive(env: ?*e.ErlNifEnv, port_id: [*c]e.ErlNifPort) c_int {
+    return e.WinDynNifCallbacks.enif_is_port_alive.?(env, port_id);
+}
+
+export fn enif_get_local_port(env: ?*e.ErlNifEnv, arg1: e.ERL_NIF_TERM, port_id: [*c]e.ErlNifPort) c_int {
+    return e.WinDynNifCallbacks.enif_get_local_port.?(env, arg1, port_id);
+}
+
+export fn enif_term_to_binary(env: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM, bin: [*c]e.ErlNifBinary) c_int {
+    return e.WinDynNifCallbacks.enif_term_to_binary.?(env, term, bin);
+}
+
+export fn enif_binary_to_term(env: ?*e.ErlNifEnv, data: [*c]const u8, sz: usize, term: [*c]e.ERL_NIF_TERM, opts: c_uint) usize {
+    return e.WinDynNifCallbacks.enif_binary_to_term.?(env, data, sz, term, opts);
+}
+
+export fn enif_port_command(env: ?*e.ErlNifEnv, to_port: [*c]const e.ErlNifPort, msg_env: ?*e.ErlNifEnv, msg: e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_port_command.?(env, to_port, msg_env, msg);
+}
+
+export fn enif_thread_type() c_int {
+    return e.WinDynNifCallbacks.enif_thread_type.?();
+}
+
+export fn enif_snprintf(buffer: [*c]u8, size: usize, format: [*c]const u8) c_int {
+    return e.WinDynNifCallbacks.enif_snprintf.?(buffer, size, format);
+}
+
+export fn enif_select(env: ?*e.ErlNifEnv, ev: e.ErlNifEvent, flags: e.enum_ErlNifSelectFlags, obj: ?*anyopaque, pid: [*c]const e.ErlNifPid, ref: e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_select.?(env, ev, flags, obj, pid, ref);
+}
+
+export fn enif_open_resource_type_x(arg0: ?*e.ErlNifEnv, name_str: [*c]const u8, arg2: [*c]const e.ErlNifResourceTypeInit, flags: e.ErlNifResourceFlags, tried: [*c]e.ErlNifResourceFlags) ?*e.ErlNifResourceType {
+    return e.WinDynNifCallbacks.enif_open_resource_type_x.?(arg0, name_str, arg2, flags, tried);
+}
+
+export fn enif_monitor_process(arg0: ?*e.ErlNifEnv, obj: ?*anyopaque, arg2: [*c]const e.ErlNifPid, monitor: [*c]e.ErlNifMonitor) c_int {
+    return e.WinDynNifCallbacks.enif_monitor_process.?(arg0, obj, arg2, monitor);
+}
+
+export fn enif_demonitor_process(arg0: ?*e.ErlNifEnv, obj: ?*anyopaque, monitor: [*c]const e.ErlNifMonitor) c_int {
+    return e.WinDynNifCallbacks.enif_demonitor_process.?(arg0, obj, monitor);
+}
+
+export fn enif_compare_monitors(arg0: [*c]const e.ErlNifMonitor, arg1: [*c]const e.ErlNifMonitor) c_int {
+    return e.WinDynNifCallbacks.enif_compare_monitors.?(arg0, arg1);
+}
+
+export fn enif_hash(@"type": e.ErlNifHash, term: e.ERL_NIF_TERM, salt: e.ErlNifUInt64) e.ErlNifUInt64 {
+    return e.WinDynNifCallbacks.enif_hash.?(@"type", term, salt);
+}
+
+export fn enif_whereis_pid(env: ?*e.ErlNifEnv, name: e.ERL_NIF_TERM, pid: [*c]e.ErlNifPid) c_int {
+    return e.WinDynNifCallbacks.enif_whereis_pid.?(env, name, pid);
+}
+
+export fn enif_whereis_port(env: ?*e.ErlNifEnv, name: e.ERL_NIF_TERM, port: [*c]e.ErlNifPort) c_int {
+    return e.WinDynNifCallbacks.enif_whereis_port.?(env, name, port);
+}
+
+export fn enif_ioq_create(opts: e.ErlNifIOQueueOpts) ?*e.ErlNifIOQueue {
+    return e.WinDynNifCallbacks.enif_ioq_create.?(opts);
+}
+
+export fn enif_ioq_enq_binary(q: ?*e.ErlNifIOQueue, bin: [*c]e.ErlNifBinary, skip: usize) c_int {
+    return e.WinDynNifCallbacks.enif_ioq_enq_binary.?(q, bin, skip);
+}
+
+export fn enif_ioq_enqv(q: ?*e.ErlNifIOQueue, iov: [*c]e.ErlNifIOVec, skip: usize) c_int {
+    return e.WinDynNifCallbacks.enif_ioq_enqv.?(q, iov, skip);
+}
+
+export fn enif_ioq_size(q: ?*e.ErlNifIOQueue) usize {
+    return e.WinDynNifCallbacks.enif_ioq_size.?(q);
+}
+
+export fn enif_ioq_deq(q: ?*e.ErlNifIOQueue, count: usize, size: [*c]usize) c_int {
+    return e.WinDynNifCallbacks.enif_ioq_deq.?(q, count, size);
+}
+
+export fn enif_ioq_peek(q: ?*e.ErlNifIOQueue, iovlen: [*c]c_int) [*c]e.SysIOVec {
+    return e.WinDynNifCallbacks.enif_ioq_peek.?(q, iovlen);
+}
+
+export fn enif_inspect_iovec(env: ?*e.ErlNifEnv, max_length: usize, iovec_term: e.ERL_NIF_TERM, tail: [*c]e.ERL_NIF_TERM, iovec: [*c][*c]e.ErlNifIOVec) c_int {
+    return e.WinDynNifCallbacks.enif_inspect_iovec.?(env, max_length, iovec_term, tail, iovec);
+}
+
+export fn enif_free_iovec(iov: [*c]e.ErlNifIOVec) void {
+    e.WinDynNifCallbacks.enif_free_iovec.?(iov);
+}
+
+export fn enif_ioq_peek_head(env: ?*e.ErlNifEnv, q: ?*e.ErlNifIOQueue, size: [*c]usize, head: [*c]e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_ioq_peek_head.?(env, q, size, head);
+}
+
+export fn enif_mutex_name(arg0: ?*e.ErlNifMutex) [*c]u8 {
+    return e.WinDynNifCallbacks.enif_mutex_name.?(arg0);
+}
+
+export fn enif_cond_name(arg0: ?*e.ErlNifCond) [*c]u8 {
+    return e.WinDynNifCallbacks.enif_cond_name.?(arg0);
+}
+
+export fn enif_rwlock_name(arg0: ?*e.ErlNifRWLock) [*c]u8 {
+    return e.WinDynNifCallbacks.enif_rwlock_name.?(arg0);
+}
+
+export fn enif_thread_name(arg0: e.ErlNifTid) [*c]u8 {
+    return e.WinDynNifCallbacks.enif_thread_name.?(arg0);
+}
+
+export fn enif_vfprintf(arg0: ?*e.FILE, fmt: [*c]const u8, arg2: e.va_list) c_int {
+    return e.WinDynNifCallbacks.enif_vfprintf.?(arg0, fmt, arg2);
+}
+
+export fn enif_vsnprintf(arg0: [*c]u8, arg1: usize, fmt: [*c]const u8, arg3: e.va_list) c_int {
+    return e.WinDynNifCallbacks.enif_vsnprintf.?(arg0, arg1, fmt, arg3);
+}
+
+export fn enif_make_map_from_arrays(env: ?*e.ErlNifEnv, keys: [*c]e.ERL_NIF_TERM, values: [*c]e.ERL_NIF_TERM, cnt: usize, map_out: [*c]e.ERL_NIF_TERM) c_int {
+    return e.WinDynNifCallbacks.enif_make_map_from_arrays.?(env, keys, values, cnt, map_out);
+}
+
+export fn enif_select_x(env: ?*e.ErlNifEnv, ev: e.ErlNifEvent, flags: e.enum_ErlNifSelectFlags, obj: ?*anyopaque, pid: [*c]const e.ErlNifPid, msg: e.ERL_NIF_TERM, msg_env: ?*e.ErlNifEnv) c_int {
+    return e.WinDynNifCallbacks.enif_select_x.?(env, ev, flags, obj, pid, msg, msg_env);
+}
+
+export fn enif_make_monitor_term(env: ?*e.ErlNifEnv, arg1: [*c]const e.ErlNifMonitor) e.ERL_NIF_TERM {
+    return e.WinDynNifCallbacks.enif_make_monitor_term.?(env, arg1);
+}
+
+export fn enif_set_pid_undefined(pid: [*c]e.ErlNifPid) void {
+    e.WinDynNifCallbacks.enif_set_pid_undefined.?(pid);
+}
+
+export fn enif_is_pid_undefined(pid: [*c]const e.ErlNifPid) c_int {
+    return e.WinDynNifCallbacks.enif_is_pid_undefined.?(pid);
+}
+
+export fn enif_term_type(env: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM) e.ErlNifTermType {
+    return e.WinDynNifCallbacks.enif_term_type.?(env, term);
+}
+
+export fn enif_init_resource_type(arg0: ?*e.ErlNifEnv, name_str: [*c]const u8, arg2: [*c]const e.ErlNifResourceTypeInit, flags: e.ErlNifResourceFlags, tried: [*c]e.ErlNifResourceFlags) ?*e.ErlNifResourceType {
+    return e.WinDynNifCallbacks.enif_init_resource_type.?(arg0, name_str, arg2, flags, tried);
+}
+
+export fn enif_dynamic_resource_call(arg0: ?*e.ErlNifEnv, mod: e.ERL_NIF_TERM, name: e.ERL_NIF_TERM, rsrc: e.ERL_NIF_TERM, call_data: ?*anyopaque) c_int {
+    return e.WinDynNifCallbacks.enif_dynamic_resource_call.?(arg0, mod, name, rsrc, call_data);
+}
+
+export fn enif_get_string_length(env: ?*e.ErlNifEnv, list: e.ERL_NIF_TERM, len: [*c]c_uint, encoding: e.ErlNifCharEncoding) c_int {
+    return e.WinDynNifCallbacks.enif_get_string_length.?(env, list, len, encoding);
+}
+
+export fn enif_make_new_atom(env: ?*e.ErlNifEnv, name: [*c]const u8, atom: [*c]e.ERL_NIF_TERM, encoding: e.ErlNifCharEncoding) c_int {
+    return e.WinDynNifCallbacks.enif_make_new_atom.?(env, name, atom, encoding);
+}
+
+export fn enif_make_new_atom_len(env: ?*e.ErlNifEnv, name: [*c]const u8, len: usize, atom: [*c]e.ERL_NIF_TERM, encoding: e.ErlNifCharEncoding) c_int {
+    return e.WinDynNifCallbacks.enif_make_new_atom_len.?(env, name, len, atom, encoding);
+}
+
+// The MSVC emulator keeps 64-bit signedness distinct from c_long, so these
+// are real callbacks there. On LP64 ABIs they alias the long variants and
+// translate-c emits aliases instead, so the callbacks table has no fields.
+export fn enif_get_int64(env: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM, ip: [*c]e.ErlNifSInt64) c_int {
+    return if (@hasField(e.TWinDynNifCallbacks, "enif_get_int64"))
+        e.WinDynNifCallbacks.enif_get_int64.?(env, term, ip)
+    else
+        e.enif_get_long(env, term, @ptrCast(ip));
+}
+
+export fn enif_get_uint64(env: ?*e.ErlNifEnv, term: e.ERL_NIF_TERM, ip: [*c]e.ErlNifUInt64) c_int {
+    return if (@hasField(e.TWinDynNifCallbacks, "enif_get_uint64"))
+        e.WinDynNifCallbacks.enif_get_uint64.?(env, term, ip)
+    else
+        e.enif_get_ulong(env, term, @ptrCast(ip));
+}
+
+export fn enif_make_int64(env: ?*e.ErlNifEnv, value: e.ErlNifSInt64) e.ERL_NIF_TERM {
+    return if (@hasField(e.TWinDynNifCallbacks, "enif_make_int64"))
+        e.WinDynNifCallbacks.enif_make_int64.?(env, value)
+    else
+        e.enif_make_long(env, @intCast(value));
+}
+
+export fn enif_make_uint64(env: ?*e.ErlNifEnv, value: e.ErlNifUInt64) e.ERL_NIF_TERM {
+    return if (@hasField(e.TWinDynNifCallbacks, "enif_make_uint64"))
+        e.WinDynNifCallbacks.enif_make_uint64.?(env, value)
+    else
+        e.enif_make_ulong(env, @intCast(value));
+}
+
+export fn enif_set_option(env: ?*e.ErlNifEnv, opt: e.ErlNifOption) c_int {
+    return e.WinDynNifCallbacks.enif_set_option.?(env, opt);
+}

--- a/scripts/install_llvm/lib/mix/tasks/beaver.install_prebuilt_llvm.ex
+++ b/scripts/install_llvm/lib/mix/tasks/beaver.install_prebuilt_llvm.ex
@@ -328,11 +328,7 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
       verify_sha256!(archive, sha256)
       extract!(archive, extract_dir)
 
-      llvm_config =
-        case Path.wildcard(Path.join(extract_dir, "**/bin/llvm-config")) do
-          [path | _] -> path
-          [] -> Mix.raise("could not locate bin/llvm-config in #{asset_name}")
-        end
+      llvm_config = find_llvm_config!(extract_dir, asset_name)
 
       asset_root = llvm_config |> Path.dirname() |> Path.dirname()
 
@@ -340,7 +336,7 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
       File.mkdir_p!(install_dir)
       copy_tree!(asset_root, install_dir)
 
-      llvm_config_path = Path.join(install_dir, "bin/llvm-config")
+      llvm_config_path = Path.join(install_dir, "bin/#{Path.basename(llvm_config)}")
       File.chmod(llvm_config_path, 0o755)
 
       IO.puts("Installed #{asset_name} into #{install_dir}")
@@ -440,14 +436,56 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
   defp extract!(archive, extract_dir) do
     File.mkdir_p!(extract_dir)
 
-    {output, status} =
-      System.cmd("tar", ["-xzf", archive, "-C", extract_dir], stderr_to_stdout: true)
+    if match?({:win32, _}, :os.type()) do
+      # Windows runners do not guarantee a usable system tar for these
+      # archives, so go through erl_tar for the Windows prebuilt. The Unix
+      # archives cannot use erl_tar: they store negative base-256 mtime fields
+      # (reproducible builds) that erl_tar rejects with :integer_overflow, and
+      # they rely on symlinks that the system tar handles faithfully.
+      case :erl_tar.extract(String.to_charlist(archive), [
+             :compressed,
+             {:cwd, String.to_charlist(extract_dir)}
+           ]) do
+        :ok -> :ok
+        {:error, reason} -> Mix.raise("failed to extract #{archive}: #{inspect(reason)}")
+      end
+    else
+      {output, status} =
+        System.cmd("tar", ["-xzf", archive, "-C", extract_dir], stderr_to_stdout: true)
 
-    unless status == 0 do
-      Mix.raise("failed to extract #{archive}:\n#{output}")
+      unless status == 0 do
+        Mix.raise("failed to extract #{archive}:\n#{output}")
+      end
+
+      :ok
     end
+  end
 
-    :ok
+  # Path.wildcard/1 has Windows-specific separator semantics that are easy to
+  # get wrong for a pattern built from a native path, so locate llvm-config by
+  # walking the extracted tree instead.
+  defp find_llvm_config!(extract_dir, asset_name) do
+    case walk_for_llvm_config(extract_dir) do
+      nil -> Mix.raise("could not locate bin/llvm-config in #{asset_name}")
+      path -> path
+    end
+  end
+
+  defp walk_for_llvm_config(dir) do
+    Enum.find_value(File.ls!(dir), fn entry ->
+      path = Path.join(dir, entry)
+
+      cond do
+        File.dir?(path) ->
+          walk_for_llvm_config(path)
+
+        Path.basename(dir) == "bin" and String.starts_with?(entry, "llvm-config") ->
+          path
+
+        true ->
+          nil
+      end
+    end)
   end
 
   defp write_github_env!(install_dir, asset_name, asset_url, github_env) do

--- a/test/compilation_runtime_test.exs
+++ b/test/compilation_runtime_test.exs
@@ -144,7 +144,9 @@ defmodule CompilationRuntimeTest do
 
     on_exit(fn -> File.rm(object_path) end)
 
-    assert CompilationRuntime.emit_object!(artifact, object_path) == object_path
+    # emit_object! returns the canonicalized (expanded) path; on Windows the
+    # expansion also normalizes drive letter case and separators.
+    assert CompilationRuntime.emit_object!(artifact, object_path) == Path.expand(object_path)
     assert File.stat!(object_path).size > 0
   end
 end


### PR DESCRIPTION
## Summary

Makes a Windows source build of Beaver work end to end, using the existing Triton Windows prebuilt LLVM/MLIR archive, and adds a `windows-2022` CI lane that runs the full suite.

## What changed

- **`build.zig`**: link libc on Windows too, install DLLs into `lib/` (Zig defaults to `bin/`), build the CMake side in `Release` to match the prebuilt MSVC runtimes (avoids `_ITERATOR_DEBUG_LEVEL` mismatches), use `lld-link` for CMake links (LNK1170 response-file overflow), and keep the standalone `zig build` prefix ordering sane on Windows.
- **`native/src/windows_enif.zig`** (new): OTP does not export `enif_*` from `beam.dll` on Windows; the emulator only hands the NIF a `TWinDynNifCallbacks` table at `nif_init`. This shim DLL forwards every `enif_*` import to that table so the partitions and the NIF shim all resolve the same symbols.
- **`lib/beaver/mlir/capi_raw.ex`**: load `BeaverNIF.dll` without the Unix `lib` prefix or the `.dll` extension (OTP appends it), use backslash absolute paths so the loader applies the DLL's own search path, and prepend `priv/lib` to `PATH` so sibling runtime DLLs next to the NIF are found.
- **`scripts/install_llvm`**: extract the Windows prebuilt with `erl_tar` (Windows runners do not guarantee a usable system tar) and locate `llvm-config` by walking the tree instead of `Path.wildcard/1`.
- **`Makefile.win`** (new): NMAKE makefile for `elixir_make` on Windows (no `-j` flag, `cmd.exe`-compatible).
- **`build.zig.zon`**: bump the standalone Zig build's Kinda package to `81a5106`, matching the paired checkout; the Hex `0.11.0` release predates the LLP64 integer conversion fixes.
- **Windows CI lane**: `windows-2022` / OTP 27.3 / Elixir 1.20.3 / Triton LLVM, with MSVC toolchain setup, a best-effort pagefile enlarge step, `--exclude cuda`, and the paired Kinda checkout until a Hex release containing the fixes lands.
- **JIT allocator fix**: register `malloc`/`free`/`realloc`/`calloc` on the JIT so allocation and `std.c.free` come from the same C runtime heap on Windows.
- **ReleaseSafe header fix**: disable mingw fortify (`-D_FORTIFY_SOURCE=0`) for the Kinda C import; Zig injects `-D_FORTIFY_SOURCE=2` in ReleaseSafe, which activates `string.h` fortify wrappers that translate-c emits as unused local externs and fails the shim build.

## CI status

All lanes green: Ubuntu (OTP 25.0/27.3/28.4, Elixir 1.18/1.20.3, eudsl + triton LLVM), **Windows** (OTP 27.3 / Elixir 1.20.3 / triton), plus the precompiled NIF build workflow.
