### PR TITLE
Detect dangling MLIR blocks in the DSL and document the convention

### DIFF
--- a/guides/blocks.md
+++ b/guides/blocks.md
@@ -1,0 +1,83 @@
+# Blocks and the underscore convention
+
+MLIR blocks are the basic units of control flow inside a region. In Beaver's
+DSL, a `block` is a lexically scoped value: you create it with the `block`
+macro, reference it by name with `Beaver.Env.block/1`, and it lives inside the
+enclosing `region`.
+
+## Named and anonymous blocks
+
+```elixir
+mlir ctx: ctx do
+  module do
+    Func.func some_func(function_type: Type.function([], [Type.i32()])) do
+      region do
+        # anonymous block: the underscore says "this block is incidental"
+        block _() do
+          v0 = Arith.constant(value: Attribute.integer(Type.i32(), 0)) >>> Type.i32()
+          CF.br({Beaver.Env.block(bb1), [v0]}) >>> []
+        end
+
+        # named block: the name is a value other terminators can reference
+        block bb1(arg >>> Type.i32()) do
+          Func.return(arg) >>> []
+        end
+      end
+    end
+  end
+end
+```
+
+A block can be referenced **before** it is defined. `Beaver.Env.block(bb1)`
+creates the block on first use, and the later `block bb1(...) do ... end`
+definition appends it to the region. This is how terminators form control-flow
+edges between blocks that are written out of order.
+
+## Dangling blocks
+
+A block is *dangling* when it was created (usually by a forward reference) but
+never appended to a region. It is not reachable from the module, and any
+terminator that jumps to it references invalid IR.
+
+Beaver reuses Elixir's own conventions to surface this:
+
+- **Plain names are tracked.** If a plain-named block is created but never
+  appended, the region raises at the end of its body:
+
+  ```text
+  ** (ArgumentError) dangling blocks created but never appended to a region: [:bb2].
+  Define each referenced block with `block <name>() do ... end` inside the region,
+  or prefix the variable with an underscore to opt out of this check.
+  ```
+
+- **Underscore-prefixed names opt out.** `block _bb1(...) do ... end` and
+  `block _() do ... end` say "this block is not meant to be part of the final
+  IR", so they are exempt from the runtime check. A dangling underscore block
+  still fails MLIR verification if it is referenced, but the DSL itself lets
+  it through — the same way `_` suppresses unused-variable warnings in Elixir.
+
+- **The compiler warns too.** Creating a named block without ever using its
+  binding produces Elixir's ordinary unused-variable warning, pointing at the
+  block that was never joined into the region.
+
+## Three layers of detection
+
+1. **Compile time** — Elixir reports unused block variables (`variable "bb2"
+   is unused`). This is the same mechanism as unused function arguments: cheap
+   and local.
+2. **Region end** — the DSL verifies that every plain-named block was appended,
+   and raises with the offending names before you ever build the IR.
+3. **MLIR verification** — the final safety net. `MLIR.verify!/1` rejects a
+   module whose terminators reference a block in another region, with the
+   standard "reference to block defined in another region" diagnostic.
+
+## When to use which
+
+- Use a **plain name** for every block you intend to be part of the CFG, even
+  if it is written after its first reference.
+- Use `_` or an **underscore-prefixed name** for scratch blocks that are
+  created for a side effect (for example, exploring the API) and are never
+  meant to survive.
+- Keep `MLIR.verify!/1` in your pipeline: it catches the cases the DSL check
+  deliberately lets through, and it is the contract Triton and other backends
+  rely on.

--- a/lib/beaver.ex
+++ b/lib/beaver.ex
@@ -146,6 +146,25 @@ defmodule Beaver do
   def append_block_to_region(_region, _block), do: :ok
 
   @doc false
+  def assert_no_dangling_blocks([]), do: :ok
+
+  def assert_no_dangling_blocks(names) do
+    raise ArgumentError,
+          "dangling blocks created but never appended to a region: #{inspect(names)}. " <>
+            "Define each referenced block with `block <name>() do ... end` inside the region, " <>
+            "or prefix the variable with an underscore to opt out of this check."
+  end
+
+  defp dangling_block_removal(b_name, caller) do
+    if Macro.Env.has_var?(caller, {:beaver_internal_env_dangling_blocks, nil}) do
+      quote do
+        Kernel.var!(beaver_internal_env_dangling_blocks) =
+          List.delete(Kernel.var!(beaver_internal_env_dangling_blocks), unquote(b_name))
+      end
+    end
+  end
+
+  @doc false
   def parent_scope_ip_caching(caller) do
     suppress_warning = quote(do: _ = Kernel.var!(beaver_internal_env_ip))
 
@@ -202,6 +221,7 @@ defmodule Beaver do
         Beaver.Env.block(unquote({b_name, [], nil})) |> unquote(add_arguments(args))
 
       Beaver.append_block_to_region(Beaver.Env.region(), Beaver.Env.block())
+      unquote(dangling_block_removal(b_name, __CALLER__))
 
       unquote_splicing(arguments_variables(args))
       unquote(body)
@@ -243,8 +263,10 @@ defmodule Beaver do
 
       Beaver.MLIR.Region.under(region, fn ->
         Kernel.var!(beaver_env_region) = region
+        Kernel.var!(beaver_internal_env_dangling_blocks) = []
         %Beaver.MLIR.Region{} = Kernel.var!(beaver_env_region)
         unquote(body)
+        Beaver.assert_no_dangling_blocks(Kernel.var!(beaver_internal_env_dangling_blocks))
       end)
 
       Kernel.var!(beaver_internal_env_regions) =

--- a/lib/beaver/env.ex
+++ b/lib/beaver/env.ex
@@ -78,8 +78,28 @@ defmodule Beaver.Env do
     if Macro.Env.has_var?(__CALLER__, {var_name, nil}) do
       block_var
     else
+      track_dangling =
+        Macro.Env.has_var?(__CALLER__, {:beaver_internal_env_dangling_blocks, nil}) and
+          not String.starts_with?(Atom.to_string(var_name), "_")
+
+      track =
+        if track_dangling do
+          quote do
+            Kernel.var!(beaver_internal_env_dangling_blocks) =
+              Kernel.var!(beaver_internal_env_dangling_blocks) ++ [unquote(var_name)]
+
+            # Mark the rebinding as read; consecutive forward references would
+            # otherwise trigger Elixir's "unused variable with the same name
+            # in the context" warning.
+            _ = Kernel.var!(beaver_internal_env_dangling_blocks)
+          end
+        end
+
       quote do
-        Kernel.var!(unquote(block_var)) = Beaver.MLIR.Block.create()
+        Kernel.var!(beaver_internal_env_block) = Beaver.MLIR.Block.create()
+        Kernel.var!(unquote(block_var)) = Kernel.var!(beaver_internal_env_block)
+        unquote(track)
+        Kernel.var!(beaver_internal_env_block)
       end
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -62,6 +62,7 @@ defmodule Beaver.MixProject do
         "guides/native-rewrite-patterns.md",
         "guides/action-tracing.md",
         "guides/enif-pointer-interop.md",
+        "guides/blocks.md",
         "CONTRIBUTING.md",
         "README.md"
       ],

--- a/test/block_test.exs
+++ b/test/block_test.exs
@@ -63,6 +63,46 @@ defmodule BlockTest do
             ]} = res
   end
 
+  test "dangling block with a plain name raises at region end", %{ctx: ctx} do
+    assert_raise ArgumentError, ~r/dangling blocks created but never appended to a region/, fn ->
+      mlir ctx: ctx do
+        module do
+          Func.func some_func(function_type: Type.function([], [Type.i32()])) do
+            region do
+              block do
+                v0 = Arith.constant(value: Attribute.integer(Type.i32(), 0)) >>> Type.i32()
+                CF.br({Beaver.Env.block(dangling), [v0]}) >>> []
+                _ = dangling
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  test "assert_no_dangling_blocks validates the tracked names", %{ctx: ctx} do
+    assert :ok = Beaver.assert_no_dangling_blocks([])
+
+    assert_raise ArgumentError, ~r/dangling blocks created but never appended to a region/, fn ->
+      Beaver.assert_no_dangling_blocks([:dangling])
+    end
+
+    mlir ctx: ctx do
+      module do
+        Func.func some_func(function_type: Type.function([], [Type.i32()])) do
+          region do
+            block do
+              v0 = Arith.constant(value: Attribute.integer(Type.i32(), 0)) >>> Type.i32()
+              Func.return(v0) >>> []
+            end
+          end
+        end
+      end
+      |> MLIR.verify!()
+    end
+  end
+
   test "verify? returns a boolean summary of verification status", %{ctx: ctx} do
     valid_module =
       mlir ctx: ctx do


### PR DESCRIPTION
Closes #262.

## Context

The issue proposed reusing Elixir's underscored/unused-variable convention for MLIR blocks: a block created but never appended to a region should be detectable. Investigation showed the mechanism already partially worked (Elixir emits `variable "bb" is unused` for abandoned forward references, and `MLIR.verify!/1` rejects dangling terminators), but nothing made it a *designed* behavior and it was undocumented.

## What

- **Runtime check**: `Beaver.Env.block/1` forward references are tracked per region; a plain-named block that is never appended raises at the end of the `region` body with the offending names:

  ```
  ** (ArgumentError) dangling blocks created but never appended to a region: [:bb2]. ...
  ```

- **Underscore opt-out**: underscore-prefixed names (`_bb1`, `_`) are exempt from the check, matching Elixir's `_` convention and the existing "dangling block" test that deliberately lets `_bb1` reach `MLIR.verify()`.
- **Docs**: `guides/blocks.md` explains named/anonymous blocks, forward references, the three detection layers (compile-time unused-variable warning → region-end runtime check → MLIR verifier), and when to use underscore names.
- Tests: plain-name dangling raises at region end; `Beaver.assert_no_dangling_blocks/1` unit coverage; existing block/region tests unchanged.

## Validation

- `mix test --warnings-as-errors --exclude vulkan --exclude todo` → 287 passed
- `mix format --check-formatted`, `mix credo` clean