### PR TITLE
fix: materialize ex term type conversion with the type's context

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -62,14 +62,17 @@ defmodule Beaver.MLIR.Conversion.Ex do
   @spec convert_type(MLIR.Type.t()) :: MLIR.Type.t()
   def convert_type(type) do
     case MLIR.to_string(type) do
-      "!ex.dyn" -> scalar_word()
-      "!ex.bound" -> scalar_word()
-      "!ex.unbound" -> scalar_word()
+      "!ex.dyn" -> scalar_word(type)
+      "!ex.bound" -> scalar_word(type)
+      "!ex.unbound" -> scalar_word(type)
       _ -> type
     end
   end
 
-  defp scalar_word, do: MLIR.Type.i64()
+  defp scalar_word(type) do
+    ctx = MLIR.context(type)
+    MLIR.Type.integer(64, ctx: ctx)
+  end
 
   defp convert_lit(operation, [], rewriter) do
     context = MLIR.context(operation)

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -112,4 +112,31 @@ defmodule ExConversionTest do
 
     assert {:error, %MLIR.Conversion.Error{}} = Plan.run(Ex.plan(), module)
   end
+
+  test "converts ex term types feeding ex.return", %{ctx: ctx} do
+    Beaver.Slang.load(ctx, ExDialect)
+
+    module =
+      MLIR.Module.create!(
+        ~S"""
+        module {
+          "ex.func"() ({
+          ^bb0:
+            %0 = "ex.lit"() {value = 1 : i64} : () -> i64
+            %1 = "ex.call"(%0, %0) {callee = "add", arity = 2 : i64, operandSegmentSizes = array<i32: 2>} : (i64, i64) -> !ex.dyn
+            "ex.return"(%1) {operandSegmentSizes = array<i32: 1>} : (!ex.dyn) -> ()
+          }) {sym_name = "main"} : () -> ()
+        }
+        """,
+        ctx: ctx
+      )
+      |> MLIR.verify!()
+
+    converted = Plan.run!(Ex.plan(), module)
+
+    rendered = MLIR.to_string(converted, generic: true)
+    refute rendered =~ "ex."
+    assert rendered =~ "func.call"
+    assert rendered =~ "func.return"
+  end
 end


### PR DESCRIPTION
Fixes `Beaver.MLIR.Conversion.Ex.convert_type/1` returning a `Beaver.Deferred` (`MLIR.Type.i64()` builds a lazy type) for `!ex.dyn`/`!ex.bound`/`!ex.unbound`. The conversion framework requires a concrete `MLIR.Type` from type-converter callbacks, so converting a term type that feeds `ex.return` failed with `invalid type conversion result` (and could segfault when the error propagated through the native callback runtime under ExUnit).

`scalar_word/1` now materializes `i64` against the type's own context. Adds a regression test converting an `ex.call` result (`!ex.dyn`) straight into `ex.return`.