### PR TITLE
fix: complete conversion worker cleanup before notifying the BEAM

### DIFF
--- a/native/src/conversion.zig
+++ b/native/src/conversion.zig
@@ -644,10 +644,13 @@ const TypeConverterWorker = struct {
     fn run(self: *@This()) void {
         const registration = self.registration;
         const owned_environment = self.environment;
-        defer e.enif_release_resource(registration);
-        defer e.enif_free_env(owned_environment);
         defer std.heap.smp_allocator.destroy(self);
-        const environment = e.enif_alloc_env() orelse return;
+        const environment = e.enif_alloc_env() orelse {
+            e.enif_free_env(owned_environment);
+            e.enif_release_resource(registration);
+            std.heap.smp_allocator.destroy(self);
+            return;
+        };
         defer e.enif_free_env(environment);
 
         const io = std.Options.debug_io;
@@ -657,13 +660,19 @@ const TypeConverterWorker = struct {
         else
             c.mlirTypeConverterConvertType(self.registration.converter, self.type_);
         self.registration.mutex.unlock(io);
+        // Complete native cleanup before notifying the BEAM: once
+        // `type_converter_done` is delivered the receiver may tear down the
+        // context, so nothing may reference it afterwards.
+        const id_term = e.enif_make_copy(environment, self.id);
+        e.enif_free_env(owned_environment);
+        e.enif_release_resource(registration);
         var terms = [_]beam.term{
             beam.make_atom(environment, "type_converter_done"),
-            e.enif_make_copy(environment, self.id),
+            id_term,
             if (c.mlirTypeIsNull(converted))
                 beam.make_nil(environment)
             else
-                mlir_capi.Type.resource.make_kind(environment, converted) catch beam.make_nil(environment),
+            mlir_capi.Type.resource.make_kind(environment, converted) catch beam.make_nil(environment),
         };
         _ = beam.send_advanced(null, self.recipient, environment, beam.make_tuple(environment, &terms));
     }
@@ -885,12 +894,15 @@ const ConversionWorker = struct {
         const owns_patterns = self.owns_patterns;
         var config_owned = true;
         var patterns_owned = owns_patterns;
-        defer e.enif_release_resource(target);
-        defer e.enif_free_env(owned_environment);
-        defer if (config_owned) c.mlirConversionConfigDestroy(config);
-        defer if (patterns_owned) c.mlirFrozenRewritePatternSetDestroy(patterns);
         defer std.heap.smp_allocator.destroy(self);
-        const environment = e.enif_alloc_env() orelse return;
+        const environment = e.enif_alloc_env() orelse {
+            if (patterns_owned) c.mlirFrozenRewritePatternSetDestroy(patterns);
+            if (config_owned) c.mlirConversionConfigDestroy(config);
+            e.enif_free_env(owned_environment);
+            e.enif_release_resource(target);
+            std.heap.smp_allocator.destroy(self);
+            return;
+        };
         defer e.enif_free_env(environment);
 
         const io = std.Options.debug_io;
@@ -916,12 +928,20 @@ const ConversionWorker = struct {
             c.mlirFrozenRewritePatternSetDestroy(patterns);
             patterns_owned = false;
         }
-        c.mlirConversionConfigDestroy(config);
-        config_owned = false;
+        if (config_owned) {
+            c.mlirConversionConfigDestroy(config);
+            config_owned = false;
+        }
+        // Complete native cleanup before notifying the BEAM: once
+        // `conversion_done` is delivered the receiver may destroy the MLIR
+        // context, so nothing may reference it afterwards.
+        const id_term = e.enif_make_copy(environment, self.id);
+        e.enif_free_env(owned_environment);
+        e.enif_release_resource(target);
 
         var terms = [_]beam.term{
             beam.make_atom(environment, "conversion_done"),
-            e.enif_make_copy(environment, self.id),
+            id_term,
             result orelse beam.make_nil(environment),
         };
         _ = beam.send_advanced(null, self.recipient, environment, beam.make_tuple(environment, &terms));

--- a/native/src/conversion.zig
+++ b/native/src/conversion.zig
@@ -672,7 +672,7 @@ const TypeConverterWorker = struct {
             if (c.mlirTypeIsNull(converted))
                 beam.make_nil(environment)
             else
-            mlir_capi.Type.resource.make_kind(environment, converted) catch beam.make_nil(environment),
+                mlir_capi.Type.resource.make_kind(environment, converted) catch beam.make_nil(environment),
         };
         _ = beam.send_advanced(null, self.recipient, environment, beam.make_tuple(environment, &terms));
     }


### PR DESCRIPTION
The async conversion worker sent `conversion_done` before finishing its deferred cleanup: after the BEAM receives the message it may destroy the MLIR context (e.g. an ExUnit `on_exit` teardown) while the worker thread is still releasing the conversion target / frozen patterns / config that reference that context — a use-after-free race that segfaults the VM.

This moves all native cleanup (pattern/config destruction, target resource release, owned environment free) ahead of the `conversion_done` /`type_converter_done` message, so nothing references the context once the receiver is notified. When a conversion callback raises, the failure now surfaces as a normal Elixir exception instead of a VM crash.

Verified: a failing conversion (callback raising) previously segfaulted deterministically under ExUnit; with this fix it fails cleanly 5/5 runs. Beaver conversion tests still pass (16/16).