### PR TITLE
Serve prebuilt artifacts with python http.server instead of Caddy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,6 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  CADDY_VERSION: "2.11.4"
-
 jobs:
   generate_id:
     name: Generate ID of release
@@ -97,46 +94,23 @@ jobs:
       - name: Purge artifacts
         run: |
           mix clean
-      - name: Install Caddy
-        run: |
-          case "${RUNNER_OS}-${RUNNER_ARCH}" in
-            Linux-X64) caddy_platform="linux_amd64" ;;
-            Linux-ARM64) caddy_platform="linux_arm64" ;;
-            macOS-X64) caddy_platform="mac_amd64" ;;
-            macOS-ARM64) caddy_platform="mac_arm64" ;;
-            *) echo "unsupported Caddy platform: ${RUNNER_OS}-${RUNNER_ARCH}" >&2; exit 1 ;;
-          esac
-          caddy_asset="caddy_${CADDY_VERSION}_${caddy_platform}.tar.gz"
-          caddy_release="https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}"
-          curl --fail --location --retry 3 --silent --show-error \
-            "${caddy_release}/${caddy_asset}" \
-            --output "$RUNNER_TEMP/$caddy_asset"
-          curl --fail --location --retry 3 --silent --show-error \
-            "${caddy_release}/caddy_${CADDY_VERSION}_checksums.txt" \
-            | awk -v asset="$caddy_asset" '$2 == asset' \
-            > "$RUNNER_TEMP/caddy.sha512"
-          (cd "$RUNNER_TEMP" && shasum -a 512 --check caddy.sha512)
-          tar -xzf "$RUNNER_TEMP/$caddy_asset" -C "$RUNNER_TEMP" caddy
-          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
-      - name: Host prebuilt package with Caddy
-        run: |
-          caddy file-server --listen 127.0.0.1:8000 --root . \
-            > "$RUNNER_TEMP/caddy.log" 2>&1 &
-      - name: Wait for Caddy
-        run: |
-          for attempt in {1..15}; do
-            if curl --noproxy '*' --fail --silent --show-error \
-              --connect-timeout 2 http://127.0.0.1:8000/mix.exs > /dev/null; then
-              exit 0
-            fi
-            sleep 1
-          done
-          cat "$RUNNER_TEMP/caddy.log"
-          exit 1
       - name: Run tests with prebuilt
         env:
           BEAVER_ARTEFACT_URL: http://127.0.0.1:8000/@{artefact_filename}
         run: |
+          python3 -m http.server 8000 --bind 127.0.0.1 > "$RUNNER_TEMP/http-server.log" 2>&1 &
+          server_pid=$!
+          cleanup() { kill "$server_pid" 2>/dev/null || true; }
+          trap cleanup EXIT
+          for attempt in {1..15}; do
+            if curl --noproxy '*' --fail --silent --show-error \
+              --connect-timeout 2 http://127.0.0.1:8000/mix.exs > /dev/null; then
+              break
+            fi
+            sleep 1
+          done
+          curl --noproxy '*' --fail --silent --show-error \
+            --connect-timeout 2 http://127.0.0.1:8000/mix.exs > /dev/null
           MIX_ENV=prod mix elixir_make.checksum --all --ignore-unavailable --only-local --print
           mix clean
           mix test --exclude vulkan --exclude todo


### PR DESCRIPTION
Fixes the flaky Caddy steps in the prebuilt-NIF release job (`NIF 27.3 - ubuntu` has failed repeatedly with "Connection refused" against `127.0.0.1:8000`).

## Problem

- Caddy was downloaded and checksum-verified on every run, then started in a **separate step** from the tests that consume it. Background processes started with `&` in one step often don't survive or don't come up in time; the 15s wait loop then failed with connection refused (and the orphaned caddy was only killed at job cleanup).
- The server's lifetime and the tests' consumption were in different shells/steps, so there was no guarantee the server was alive when `mix elixir_make.checksum`/`mix test` queried it.

## Fix

Run the tests in the **same shell** as the server:

- Replace the "Install Caddy" / "Host prebuilt package with Caddy" / "Wait for Caddy" steps with a single "Run tests with prebuilt" step that starts `python3 -m http.server` (instant startup, no download, always present on runners), waits for it, runs the checksum/test steps, and kills the server in a cleanup trap.
- Drop the `CADDY_VERSION` env and all Caddy download/checksum logic.

## Note

This addresses the Caddy flake only. The same job has a separate, pre-existing failure: the prebuilt NIF tarball is missing `libMLIRBeaver.so.24.0`, so `mix test` fails with `:not_loaded` ("cannot open shared object file"). That packaging bug is tracked separately (follow-up PR).