### PR TITLE
Include native partition libs in prebuilt NIF archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,12 @@ jobs:
             --connect-timeout 2 http://127.0.0.1:8000/mix.exs > /dev/null
           MIX_ENV=prod mix elixir_make.checksum --all --ignore-unavailable --only-local --print
           mix clean
+          # Simulate a fresh user install: drop every build leftover so the
+          # loader can only resolve dependencies from the prebuilt archive
+          # extracted into _build/test (mix clean does not remove the zig
+          # cache, and its relative .zig-cache/o/<hash> entries sit before
+          # $ORIGIN in the NIF's RUNPATH).
+          rm -rf _build/prod _build/test .zig-cache
           mix test --exclude vulkan --exclude todo
       - name: Publish archives and packages
         uses: softprops/action-gh-release@v3

--- a/mix.exs
+++ b/mix.exs
@@ -31,6 +31,7 @@ defmodule Beaver.MixProject do
         make_precompiler_priv_paths: [
           "lib/libmlir*",
           "lib/libBeaver*",
+          "lib/libbeaver_*",
           "lib/libMLIRBeaver*",
           "*.ex",
           "*.json",


### PR DESCRIPTION
Fixes the prebuilt NIF packaging bug that keeps breaking the `NIF 27.3 - ubuntu` job with `:not_loaded` at `mix test` time.

## Two distinct problems

### 1. Tarball missing the native partition libraries

`build.zig` ships four partition libraries with **lowercase** names (`libbeaver_core`, `libbeaver_conversion`, `libbeaver_callback_bridge`, `libbeaver_rewrite_pattern`), but `make_precompiler_priv_paths` only matched the uppercase `lib/libBeaver*` (the NIF shim). So `libBeaverNIF.so`'s `DT_NEEDED` partitions were never in the archive and could not resolve on a clean machine.

**Fix:** add `"lib/libbeaver_*"` to `make_precompiler_priv_paths`.

### 2. The ubuntu test was not a clean-room run

Even with the partitions bundled, ubuntu still failed with `libMLIRBeaver.so.24.0: cannot open shared object file`. Root cause found with on-runner diagnostics (`readelf` + `ldd` of the extracted archive):

- `libBeaverNIF.so`'s RUNPATH starts with **relative** `.zig-cache/o/<hash>` entries (zig emits one per cached partition artifact) **before** `$ORIGIN`.
- Relative RUNPATH entries resolve against the process CWD — the checkout root on the runner.
- The leftover zig cache from the build step contains the partition libs (but no `libMLIRBeaver.so.24.0`), so the loader loads the partitions from there and then can't find `libMLIRBeaver.so.24.0` next to them.
- `mix clean` does not remove `.zig-cache` (the elixir_make clean callback is skipped when the dep isn't loaded), so the leftover cache survived.

**Fix:** the test step now drops `_build/prod`, `_build/test` and `.zig-cache` before `mix test`, forcing the loader to resolve everything from the archive extracted into `_build/test` via `$ORIGIN` — exactly what a real user gets.

## Verification

Reproduced the full flow locally on macOS against the fixed tarball: `mix elixir_make.precompile` (archive now contains all 4 partition dylibs), fresh `_build/test`, served over `http.server`, `mix elixir_make.checksum`, then `mix test --exclude vulkan --exclude todo` → **288 passed**, NIF loaded purely from the extracted archive.

The LLVM/MLIR runtime libraries are intentionally not bundled: `libMLIRBeaver` statically links LLVM/MLIR (its dynamic section only references system libs), so shipping ~1 GB of dylibs per platform is unnecessary dead weight.