### PR TITLE
ex: add sub/mul ops and function arguments to the scalar slice

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -6,9 +6,12 @@ defmodule Beaver.MLIR.Conversion.Ex do
 
     * `ex.lit` -> `arith.constant`
     * `ex.add` -> `arith.addi`
+    * `ex.sub` -> `arith.subi`
+    * `ex.mul` -> `arith.muli`
     * `ex.call` -> `func.call`
     * `ex.return` -> `func.return`
-    * `ex.func` -> `func.func` (body region moved, `ex.return` types converted)
+    * `ex.func` -> `func.func` (body region moved, argument and `ex.return`
+      types converted)
 
   The `ex` term types (`!ex.dyn`/`!ex.bound`/`!ex.unbound`) convert to a scalar
   word type (`i64`) until the Zig term runtime lands.
@@ -50,6 +53,8 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion(&convert_type/1, version: "1.0")
     |> Plan.add_conversion_pattern("ex.lit", &convert_lit/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.add", &convert_add/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.sub", &convert_sub/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.mul", &convert_mul/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.call", &convert_call/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.return", &convert_return/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.var", &convert_var/3, version: "1.0")
@@ -100,6 +105,18 @@ defmodule Beaver.MLIR.Conversion.Ex do
   end
 
   defp convert_add(operation, [left, right], rewriter) do
+    convert_binary("arith.addi", operation, [left, right], rewriter)
+  end
+
+  defp convert_sub(operation, [left, right], rewriter) do
+    convert_binary("arith.subi", operation, [left, right], rewriter)
+  end
+
+  defp convert_mul(operation, [left, right], rewriter) do
+    convert_binary("arith.muli", operation, [left, right], rewriter)
+  end
+
+  defp convert_binary(arith_op, operation, [left, right], rewriter) do
     context = MLIR.context(operation)
     base = MLIR.ConversionPatternRewriter.as_base(rewriter)
     location = MLIR.Operation.location(operation)
@@ -107,7 +124,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     result_type = result |> MLIR.Value.type() |> convert_type()
 
     add =
-      %Changeset{name: "arith.addi", context: context, location: location}
+      %Changeset{name: arith_op, context: context, location: location}
       |> Changeset.add_argument([left, right])
       |> Changeset.add_result(result_type)
       |> MLIR.Operation.create()
@@ -201,7 +218,13 @@ defmodule Beaver.MLIR.Conversion.Ex do
       |> Enum.to_list()
       |> Enum.map(&(&1 |> MLIR.Value.type() |> convert_type()))
 
-    function_type = MLIR.Type.function([], return_types)
+    arg_types =
+      block
+      |> Walker.arguments()
+      |> Enum.to_list()
+      |> Enum.map(&(&1 |> MLIR.Value.type() |> convert_type()))
+
+    function_type = MLIR.Type.function(arg_types, return_types)
 
     func =
       %Changeset{name: "func.func", context: context, location: location}

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -47,13 +47,25 @@ defmodule Beaver.MLIR.Dialect.Ex do
         ),
         results: [result: all_of([base("!builtin.integer"), any()])]
 
+  defop sub(
+          left = all_of([base("!builtin.integer"), any()]),
+          right = all_of([base("!builtin.integer"), any()])
+        ),
+        results: [result: all_of([base("!builtin.integer"), any()])]
+
+  defop mul(
+          left = all_of([base("!builtin.integer"), any()]),
+          right = all_of([base("!builtin.integer"), any()])
+        ),
+        results: [result: all_of([base("!builtin.integer"), any()])]
+
   defop call(args = variadic(any())),
     results: [result: base(dyn())],
     attributes: [callee: ^callee_value, arity: ^integer_value]
 
   defop func(),
     attributes: [sym_name: base("#builtin.string")],
-    regions: [body: {:region, args: [], size: 1}],
+    regions: [body: {:region, size: 1}],
     traits: [:isolated_from_above]
 
   defop return(value = optional(any())), traits: [:terminator]

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -139,4 +139,33 @@ defmodule ExConversionTest do
     assert rendered =~ "func.call"
     assert rendered =~ "func.return"
   end
+
+  test "lowers sub/mul and function arguments", %{ctx: ctx} do
+    Beaver.Slang.load(ctx, ExDialect)
+
+    module =
+      MLIR.Module.create!(
+        ~S"""
+        module {
+          "ex.func"() ({
+          ^bb0(%arg0: i64, %arg1: i64):
+            %0 = "ex.mul"(%arg0, %arg1) : (i64, i64) -> i64
+            %1 = "ex.sub"(%0, %arg0) : (i64, i64) -> i64
+            "ex.return"(%1) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+          }) {sym_name = "main"} : () -> ()
+        }
+        """,
+        ctx: ctx
+      )
+      |> MLIR.verify!()
+
+    converted = Plan.run!(Ex.plan(), module)
+
+    rendered = MLIR.to_string(converted, generic: true)
+    refute rendered =~ "ex."
+    assert rendered =~ ~s{function_type = (i64, i64) -> i64, sym_name = "main"}
+    assert rendered =~ "^bb0(%arg0: i64, %arg1: i64)"
+    assert rendered =~ "arith.muli"
+    assert rendered =~ "arith.subi"
+  end
 end


### PR DESCRIPTION
Expands the ex scalar slice:

- New `ex.sub` / `ex.mul` ops (same integer constraints as `ex.add`), lowered to `arith.subi` / `arith.muli`.
- `ex.func` no longer constrains its body region arguments (`args: []` removed), so functions can carry block arguments; `convert_func` now builds the `func.func` type from the body block's argument types.

Test covers a function with two `i64` arguments using `ex.mul`/`ex.sub` end to end (verified locally, 11/11 conversion + dialect tests).