### PR TITLE
ci: publish NIF archives to per-version releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,13 @@ jobs:
           files: |
             *.tar.gz
           tag_name: ${{ needs.generate_id.outputs.formatted_date }}
+      - name: Publish archives to version tag
+        uses: softprops/action-gh-release@v3
+        if: ${{ github.event_name != 'pull_request' && github.repository == 'beaver-lodge/beaver' && startsWith(github.ref, 'refs/tags/v') }}
+        with:
+          files: |
+            *.tar.gz
+          tag_name: ${{ github.ref_name }}
       - name: Test dev compile
         if: ${{ github.event_name != 'pull_request' && github.repository == 'beaver-lodge/beaver' }}
         env:
@@ -220,6 +227,13 @@ jobs:
           files: |
             beaver/*.tar.gz
           tag_name: ${{ needs.generate_id.outputs.formatted_date }}
+      - name: Publish archives to version tag
+        uses: softprops/action-gh-release@v3
+        if: ${{ github.event_name != 'pull_request' && github.repository == 'beaver-lodge/beaver' && matrix.image.platform == 'linux/arm64/v8' && startsWith(github.ref, 'refs/tags/v') }}
+        with:
+          files: |
+            beaver/*.tar.gz
+          tag_name: ${{ github.ref_name }}
       - name: Build x86
         if: ${{ matrix.image.platform == 'linux/amd64' }}
         run: docker run -v $PWD:/src -w /src/beaver ${{ vars.DOCKERHUB_USERNAME }}/beaver-livebook-${{ matrix.image.suffix }}:latest bash scripts/build-for-publish.sh
@@ -236,7 +250,6 @@ jobs:
       contents: read
     env:
       HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
-      BEAVER_ARTEFACT_URL: https://github.com/beaver-lodge/beaver/releases/download/${{ needs.generate_id.outputs.formatted_date }}/@{artefact_filename}
     steps:
       - uses: actions/checkout@v4
         name: Check-out beaver
@@ -248,15 +261,14 @@ jobs:
       - run: mix local.hex --force
       - name: Align version and prebuilt URL
         run: |
-          sed -i.bak 's/-dev//g' mix.exs && rm -f mix.exs.bak
-          sed -i.bak "s#beaver-prebuilt/releases/download/[0-9-]*#beaver/releases/download/${{ needs.generate_id.outputs.formatted_date }}#" mix.exs && rm -f mix.exs.bak
-      - name: Verify tag/version alignment
-        run: |
           set -euo pipefail
+          sed -i.bak 's/-dev//g' mix.exs && rm -f mix.exs.bak
           VERSION="$(
             elixir -e 'source = File.read!("mix.exs"); [v] = Regex.run(~r/version: "([^"]+)"/, source, capture: :all_but_first); IO.puts(v)'
           )"
           test "${{ github.ref_name }}" = "v$VERSION"
+          sed -i.bak "s#beaver-prebuilt/releases/download/[0-9-]*#beaver/releases/download/v${VERSION}#" mix.exs && rm -f mix.exs.bak
+          echo "BEAVER_ARTEFACT_URL=https://github.com/beaver-lodge/beaver/releases/download/v${VERSION}/@{artefact_filename}" >> "$GITHUB_ENV"
       - name: Install dependencies
         run: mix deps.get
       - name: Generate NIF checksums from this release


### PR DESCRIPTION
Follow-up to #509: on a `v*` tag push, also upload the prebuilt NIF archives to a GitHub release named after the tag (e.g. `v0.4.8`), and make `hex_publish` point the published Hex package at that version-scoped URL.

## Why

`elixir_make`'s URL template only supports `@{artefact_filename}` (no `@{version}`), so the prebuilt download URL must be baked into `mix.exs` at publish time. Publishing the archives under the version tag gives:

- A stable, predictable URL: `https://github.com/beaver-lodge/beaver/releases/download/v0.4.8/@{artefact_filename}`
- A per-version release that permanently holds exactly that version's tarballs
- The date-tag release remains for main-branch runs and the `Test dev compile` smoke test

## Changes

- `build_release` and `docker_build` (arm64): new `Publish archives to version tag` step, `if: startsWith(github.ref, 'refs/tags/v')`, uploading the same tarballs to `tag_name: ${{ github.ref_name }}`
- `hex_publish`:
  - computes `VERSION` once, verifies `github.ref_name == "v$VERSION"`, rewrites `make_precompiler_url` to `.../releases/download/v${VERSION}/@{artefact_filename}`
  - exports the same URL as `BEAVER_ARTEFACT_URL` (via `$GITHUB_ENV`) so `mix elixir_make.checksum` generates checksums against the exact release users download from
  - drops the job-level date-tag `BEAVER_ARTEFACT_URL` env

## Release flow after this

1. Push tag `v0.4.8` → release workflow builds NIF archives and publishes them to both the date-tag and `v0.4.8` releases
2. `hex_publish` publishes Beaver 0.4.8 to Hex.pm with `make_precompiler_url` → `.../releases/download/v0.4.8/@{artefact_filename}`
3. Hex users' `mix deps.get` downloads the NIF from the stable `v0.4.8` release