### PR TITLE
ex: add cmp/if/yield control flow ops to the dialect

### DIFF
--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -14,6 +14,9 @@ defmodule Beaver.MLIR.Dialect.Ex do
   The dialect is defined entirely with `Beaver.Slang` and replaces the native
   TableGen `elixir` dialect prototype. Load it into a context with
   `Beaver.Slang.load/2`.
+
+  The `ex.if` op is declared as `defop if(...)`; the parentheses are required
+  by the Slang `defop` DSL and are not an Elixir `if/2` call.
   """
 
   use Beaver.Slang, name: "ex"
@@ -74,6 +77,7 @@ defmodule Beaver.MLIR.Dialect.Ex do
         results: [result: all_of([base("!builtin.integer"), any()])],
         attributes: [predicate: ^cmp_predicate_value]
 
+  # credo:disable-for-next-line Credo.Check.Readability.ParenthesesInCondition
   defop if(cond = all_of([base("!builtin.integer"), any()])),
     results: [result: variadic(any())],
     regions: [:any, :any]

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -30,6 +30,10 @@ defmodule Beaver.MLIR.Dialect.Ex do
     base("#builtin.string")
   end
 
+  defconstraint cmp_predicate_value do
+    base("#builtin.string")
+  end
+
   defop lit(),
     results: [result: all_of([base("!builtin.integer"), any()])],
     attributes: [value: ^integer_value]
@@ -62,6 +66,19 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop call(args = variadic(any())),
     results: [result: base(dyn())],
     attributes: [callee: ^callee_value, arity: ^integer_value]
+
+  defop cmp(
+          left = all_of([base("!builtin.integer"), any()]),
+          right = all_of([base("!builtin.integer"), any()])
+        ),
+        results: [result: all_of([base("!builtin.integer"), any()])],
+        attributes: [predicate: ^cmp_predicate_value]
+
+  defop if(cond = all_of([base("!builtin.integer"), any()])),
+    results: [result: variadic(any())],
+    regions: [:any, :any]
+
+  defop yield(values = variadic(any())), traits: [:terminator]
 
   defop func(),
     attributes: [sym_name: base("#builtin.string")],

--- a/test/ex_dialect_test.exs
+++ b/test/ex_dialect_test.exs
@@ -21,6 +21,23 @@ defmodule ExDialectTest do
   }
   """
 
+  @control_flow_module ~S"""
+  module {
+    "ex.func"() ({
+    ^bb0:
+      %0 = "ex.lit"() {value = 1 : i64} : () -> i64
+      %1 = "ex.lit"() {value = 2 : i64} : () -> i64
+      %2 = "ex.cmp"(%0, %1) {predicate = "slt"} : (i64, i64) -> i64
+      %3 = "ex.if"(%2) ({
+        "ex.yield"(%0) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+      }, {
+        "ex.yield"(%1) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+      }) {operandSegmentSizes = array<i32: 1>} : (i64) -> i64
+      "ex.return"(%3) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+    }) {sym_name = "main"} : () -> ()
+  }
+  """
+
   test "emits a named IRDL schema for the scalar subset", %{ctx: ctx} do
     schema = Ex.__slang_dialect__(ctx) |> MLIR.verify!()
     rendered = MLIR.to_string(schema, generic: true)
@@ -47,6 +64,7 @@ defmodule ExDialectTest do
 
   test "loads the dialect and attaches dynamic traits", %{ctx: ctx} do
     assert Ex.__slang_traits__() == [
+             {"yield", [:terminator]},
              {"func", [:isolated_from_above]},
              {"return", [:terminator]}
            ]
@@ -105,6 +123,57 @@ defmodule ExDialectTest do
     assert MLIR.to_string(module, generic: true) =~ ~s{"ex.return"}
   end
 
+  test "constructs control flow ops with the Beaver DSL", %{ctx: ctx} do
+    Beaver.Slang.load(ctx, Ex)
+
+    module =
+      mlir ctx: ctx do
+        module do
+          Ex.func sym_name: Attribute.string("main") do
+            region do
+              block do
+                one =
+                  Ex.lit(value: Attribute.integer(Type.i64(), 1)) >>>
+                    Type.i64()
+
+                two =
+                  Ex.lit(value: Attribute.integer(Type.i64(), 2)) >>>
+                    Type.i64()
+
+                cond =
+                  Ex.cmp(left: one, right: two, predicate: Attribute.string("slt")) >>>
+                    Type.i64()
+
+                result =
+                  Ex.if cond: cond, operandSegmentSizes: :infer do
+                    region do
+                      block do
+                        Ex.yield(values: one, operandSegmentSizes: :infer) >>> []
+                      end
+                    end
+
+                    region do
+                      block do
+                        Ex.yield(values: two, operandSegmentSizes: :infer) >>> []
+                      end
+                    end
+                  end >>>
+                    Type.i64()
+
+                Ex.return(result) >>> []
+              end
+            end
+          end >>> []
+        end
+      end
+      |> MLIR.verify!()
+
+    rendered = MLIR.to_string(module, generic: true)
+    assert rendered =~ ~s{"ex.cmp"}
+    assert rendered =~ ~s{"ex.if"}
+    assert rendered =~ ~s{"ex.yield"}
+  end
+
   test "rejects invalid attributes and terminator placement", %{ctx: ctx} do
     Beaver.Slang.load(ctx, Ex)
 
@@ -139,6 +208,28 @@ defmodule ExDialectTest do
     Beaver.Slang.load(ctx, Ex)
 
     original = MLIR.Module.create!(@scalar_module, ctx: ctx) |> MLIR.verify!()
+
+    bytecode = MLIR.Bytecode.write!(original)
+    fresh_ctx = MLIR.Context.create()
+    on_exit(fn -> MLIR.Context.destroy(fresh_ctx) end)
+
+    assert Ex
+           |> then(&Beaver.Slang.load(fresh_ctx, &1))
+           |> MLIR.LogicalResult.success?()
+
+    bytecode_roundtrip =
+      bytecode
+      |> MLIR.Bytecode.read!(ctx: fresh_ctx)
+      |> MLIR.verify!()
+
+    assert MLIR.to_string(bytecode_roundtrip, generic: true) ==
+             MLIR.to_string(original, generic: true)
+  end
+
+  test "round-trips control flow ops through bytecode", %{ctx: ctx} do
+    Beaver.Slang.load(ctx, Ex)
+
+    original = MLIR.Module.create!(@control_flow_module, ctx: ctx) |> MLIR.verify!()
 
     bytecode = MLIR.Bytecode.write!(original)
     fresh_ctx = MLIR.Context.create()


### PR DESCRIPTION
M2 control flow entry points for the ex dialect, per [tsai/beaver#6](http://localhost:3000/tsai/beaver/issues/6):

- `ex.cmp` - integer comparison with a string predicate attribute (`slt`/...), operands and result constrained to builtin integers
- `ex.if` - two regions (then/else), variadic results, condition operand
- `ex.yield` - region terminator for `ex.if` bodies

All ops are declared in Slang with IRDL constraints. Tests cover DSL construction and bytecode round-trip.

Follow-up PR (stacked): `ex.cmp/if/yield -> arith/scf` conversion patterns.