### PR TITLE
ex: expand case into nested if/cmp before conversion

### DIFF
--- a/lib/beaver/mlir/dialect/ex/expand_case.ex
+++ b/lib/beaver/mlir/dialect/ex/expand_case.ex
@@ -1,0 +1,304 @@
+defmodule Beaver.MLIR.Dialect.Ex.ExpandCase do
+  @moduledoc """
+  Expands `ex.case` into nested `ex.if`/`ex.cmp` before dialect conversion.
+
+  A case with clauses `[p1, p2, catch-all]` becomes:
+
+      ex.if ex.cmp(scrutinee, lit(p1), "eq") {
+        ... clause 1 body ...
+      } else {
+        ex.if ex.cmp(scrutinee, lit(p2), "eq") {
+          ... clause 2 body ...
+        } else {
+          ... catch-all body ...
+        }
+      }
+
+  This is an information-preserving IR-to-IR rewrite inside the `ex`
+  universe, so it belongs in the transform layer rather than lowering. Run it
+  after `MaterializeBoundVariables` and before
+  `Beaver.MLIR.Conversion.Ex.plan/1`.
+
+  The scalar slice supports single integer literal patterns per clause. Any
+  other pattern form or a guard raises `ArgumentError` explicitly instead of
+  being silently dropped.
+  """
+
+  alias Beaver.Changeset
+  alias Beaver.MLIR
+  alias Beaver.MLIR.{IRRewriter, RewriterBase}
+  alias Beaver.Walker
+
+  @spec run!(MLIR.Module.t() | MLIR.Operation.t()) :: MLIR.Module.t() | MLIR.Operation.t()
+  def run!(%MLIR.Module{} = module) do
+    module |> ex_funcs() |> Enum.each(&expand_func/1)
+    module
+  end
+
+  def run!(%MLIR.Operation{} = operation) do
+    if(MLIR.Operation.name(operation) == "ex.func",
+      do: [operation],
+      else: ex_funcs(operation)
+    )
+    |> Enum.each(&expand_func/1)
+
+    operation
+  end
+
+  defp ex_funcs(operation) do
+    operation
+    |> operations()
+    |> Enum.filter(&(MLIR.Operation.name(&1) == "ex.func"))
+  end
+
+  defp expand_func(ex_func) do
+    ex_func
+    |> operations()
+    |> Enum.filter(&(MLIR.Operation.name(&1) == "ex.case"))
+    |> Enum.each(&expand_case(&1, ex_func))
+  end
+
+  defp expand_case(ex_case, owner) do
+    context = MLIR.context(ex_case)
+    location = MLIR.Operation.location(ex_case)
+    [scrutinee] = ex_case |> Walker.operands() |> Enum.to_list()
+
+    result_types =
+      ex_case
+      |> Walker.results()
+      |> Enum.to_list()
+      |> Enum.map(&MLIR.Value.type/1)
+
+    [region] = ex_case |> Walker.regions() |> Enum.to_list()
+    clauses = region |> Walker.blocks() |> Enum.to_list()
+
+    IRRewriter.with_rewriter(owner, fn rewriter ->
+      {top_if, _} =
+        RewriterBase.with_insertion_point(rewriter, {:before, ex_case}, fn ->
+          top_if = build_chain(clauses, scrutinee, result_types, context, location, rewriter)
+          RewriterBase.insert(rewriter, top_if)
+          {top_if, :ok}
+        end)
+
+      RewriterBase.replace_op(rewriter, ex_case, MLIR.Operation.results(top_if) |> Enum.to_list())
+    end)
+
+    :ok
+  end
+
+  defp build_chain([clause], scrutinee, result_types, context, location, rewriter) do
+    patterns = clause_patterns(clause, rewriter)
+
+    if patterns == [] do
+      # Catch-all as the only clause: it is a plain body, but still needs a
+      # wrapper to carry results, so keep the shape uniform with nested cases.
+      build_single_catch_all(clause, result_types, context, location, rewriter)
+    else
+      build_if(clause, nil, scrutinee, patterns, result_types, context, location, rewriter)
+    end
+  end
+
+  defp build_chain([clause | rest], scrutinee, result_types, context, location, rewriter) do
+    patterns = clause_patterns(clause, rewriter)
+
+    if patterns == [] and rest != [] do
+      raise ArgumentError,
+            "ex.case catch-all clause must be last, got a clause without patterns before more clauses"
+    end
+
+    build_if(clause, rest, scrutinee, patterns, result_types, context, location, rewriter)
+  end
+
+  defp build_if(clause, rest, scrutinee, patterns, result_types, context, location, rewriter) do
+    case patterns do
+      [pattern] ->
+        cond = build_cond(scrutinee, pattern, context, location, rewriter)
+        then_region = move_clause_body(clause, context, location, rewriter)
+
+        else_region =
+          build_else(rest, scrutinee, result_types, context, location, rewriter)
+
+        create_if(cond, then_region, else_region, result_types, context, location)
+
+      [] ->
+        raise ArgumentError, "ex.case clause requires exactly one integer pattern"
+
+      _ ->
+        raise ArgumentError,
+              "ex.case clause with multiple patterns is unsupported in the scalar slice: #{inspect(patterns)}"
+    end
+  end
+
+  defp build_single_catch_all(clause, result_types, context, location, rewriter) do
+    then_region = move_clause_body(clause, context, location, rewriter)
+
+    # Always-true condition: 0 == 0
+    zero = build_lit(0, context, location, rewriter)
+    cond = build_cmp(zero, zero, "eq", context, location, rewriter)
+
+    else_region = MLIR.CAPI.mlirRegionCreate()
+    block = MLIR.Block.create([], [])
+    MLIR.CAPI.mlirRegionAppendOwnedBlock(else_region, block)
+
+    RewriterBase.with_insertion_point(rewriter, {:start, block}, fn ->
+      yield_op = create_yield([], context, location)
+      RewriterBase.insert(rewriter, yield_op)
+    end)
+
+    create_if(cond, then_region, else_region, result_types, context, location)
+  end
+
+  defp build_else(nil, _scrutinee, _result_types, _context, _location, _rewriter) do
+    raise ArgumentError, "ex.case without a catch-all clause is unsupported"
+  end
+
+  defp build_else([], _scrutinee, _result_types, _context, _location, _rewriter) do
+    raise ArgumentError, "ex.case without a catch-all clause is unsupported"
+  end
+
+  defp build_else([clause], scrutinee, result_types, context, location, rewriter) do
+    patterns = clause_patterns(clause, rewriter)
+
+    if patterns == [] do
+      move_clause_body(clause, context, location, rewriter)
+    else
+      inner =
+        build_if(clause, nil, scrutinee, patterns, result_types, context, location, rewriter)
+
+      wrap_region(inner, result_types, context, location, rewriter)
+    end
+  end
+
+  defp build_else([clause | rest], scrutinee, result_types, context, location, rewriter) do
+    patterns = clause_patterns(clause, rewriter)
+
+    if patterns == [] do
+      raise ArgumentError,
+            "ex.case catch-all clause must be last, got a clause without patterns before more clauses"
+    end
+
+    inner =
+      build_if(clause, rest, scrutinee, patterns, result_types, context, location, rewriter)
+
+    wrap_region(inner, result_types, context, location, rewriter)
+  end
+
+  defp wrap_region(inner, _result_types, context, location, rewriter) do
+    region = MLIR.CAPI.mlirRegionCreate()
+    block = MLIR.Block.create([], [])
+    MLIR.CAPI.mlirRegionAppendOwnedBlock(region, block)
+
+    RewriterBase.with_insertion_point(rewriter, {:start, block}, fn ->
+      RewriterBase.insert(rewriter, inner)
+      yield_op = create_yield(inner |> Walker.results() |> Enum.to_list(), context, location)
+      RewriterBase.insert(rewriter, yield_op)
+    end)
+
+    region
+  end
+
+  defp clause_patterns(clause, _rewriter) do
+    [clause_op | _rest] = clause |> Walker.operations() |> Enum.to_list()
+
+    unless MLIR.Operation.name(clause_op) == "ex.clause" do
+      raise ArgumentError,
+            "ex.case clause block must start with ex.clause, got #{MLIR.Operation.name(clause_op)}"
+    end
+
+    patterns =
+      clause_op
+      |> Walker.attributes()
+      |> then(& &1["patterns"])
+      |> case do
+        nil -> []
+        attribute -> attribute |> Enum.to_list()
+      end
+
+    case clause_op |> Walker.operands() |> Enum.to_list() do
+      [] ->
+        :ok
+
+      [_guard] ->
+        raise ArgumentError, "ex.case guards are unsupported in the scalar slice"
+    end
+
+    patterns
+  end
+
+  defp build_cond(scrutinee, pattern, context, location, rewriter) do
+    lit = build_lit(pattern, context, location, rewriter)
+    build_cmp(scrutinee, lit, "eq", context, location, rewriter)
+  end
+
+  defp build_lit(value, context, location, rewriter) do
+    lit_op =
+      %Changeset{name: "ex.lit", context: context, location: location}
+      |> Changeset.add_argument(value: MLIR.Attribute.integer(MLIR.Type.i64(), value))
+      |> Changeset.add_result(MLIR.Type.i64())
+      |> MLIR.Operation.create()
+
+    RewriterBase.insert(rewriter, lit_op)
+    lit_op |> Walker.results() |> Enum.to_list() |> hd()
+  end
+
+  defp build_cmp(left, right, predicate, context, location, rewriter) do
+    cmp_op =
+      %Changeset{name: "ex.cmp", context: context, location: location}
+      |> Changeset.add_argument([left, right])
+      |> Changeset.add_argument(predicate: MLIR.Attribute.string(predicate))
+      |> Changeset.add_result(MLIR.Type.i64())
+      |> MLIR.Operation.create()
+
+    RewriterBase.insert(rewriter, cmp_op)
+    cmp_op |> Walker.results() |> Enum.to_list() |> hd()
+  end
+
+  defp move_clause_body(clause, _context, _location, rewriter) do
+    [clause_op | _body] = clause |> Walker.operations() |> Enum.to_list()
+
+    if MLIR.Operation.name(clause_op) != "ex.clause" do
+      raise ArgumentError, "ex.case clause block must start with ex.clause"
+    end
+
+    terminator = MLIR.CAPI.mlirBlockGetTerminator(clause)
+
+    if MLIR.null?(terminator) or MLIR.Operation.name(terminator) != "ex.yield" do
+      raise ArgumentError, "ex.case clause body must end with ex.yield"
+    end
+
+    RewriterBase.erase_op(rewriter, clause_op)
+
+    region = MLIR.CAPI.mlirRegionCreate()
+    MLIR.CAPI.mlirBlockDetach(clause)
+    MLIR.CAPI.mlirRegionAppendOwnedBlock(region, clause)
+    region
+  end
+
+  defp create_if(cond, then_region, else_region, result_types, context, location) do
+    if_op =
+      %Changeset{name: "ex.if", context: context, location: location}
+      |> Changeset.add_argument(cond)
+      |> Changeset.add_argument(then_region)
+      |> Changeset.add_argument(else_region)
+      |> Changeset.add_result(result_types)
+      |> MLIR.Operation.create()
+
+    if_op
+  end
+
+  defp create_yield(values, context, location) do
+    %Changeset{name: "ex.yield", context: context, location: location}
+    |> Changeset.add_argument(values)
+    |> MLIR.Operation.create()
+  end
+
+  defp operations(operation) do
+    {_, operations} =
+      Walker.postwalk(operation, [], fn
+        %MLIR.Operation{} = op, acc -> {op, [op | acc]}
+        element, acc -> {element, acc}
+      end)
+
+    Enum.reverse(operations)
+  end
+end

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -4,6 +4,7 @@ defmodule ExConversionTest do
   alias Beaver.MLIR.Conversion.Ex
   alias Beaver.MLIR.Conversion.Plan
   alias Beaver.MLIR.Dialect.Ex.MaterializeBoundVariables
+  alias Beaver.MLIR.Dialect.Ex.ExpandCase
   alias Beaver.MLIR.Dialect.Ex, as: ExDialect
 
   @moduletag :smoke
@@ -50,6 +51,30 @@ defmodule ExConversionTest do
         "ex.yield"(%1) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
       }) {operandSegmentSizes = array<i32: 1>} : (i64) -> i64
       "ex.return"(%3) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+    }) {sym_name = "main"} : () -> ()
+  }
+  """
+
+  @case_module ~S"""
+  module {
+    "ex.func"() ({
+    ^bb0:
+      %0 = "ex.lit"() {value = 1 : i64} : () -> i64
+      %1 = "ex.case"(%0) ({
+      ^bb0:
+        "ex.clause"() {patterns = array<i64: 1>} : () -> ()
+        %2 = "ex.lit"() {value = 10 : i64} : () -> i64
+        "ex.yield"(%2) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+      ^bb1:
+        "ex.clause"() {patterns = array<i64: 2>} : () -> ()
+        %3 = "ex.lit"() {value = 20 : i64} : () -> i64
+        "ex.yield"(%3) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+      ^bb2:
+        "ex.clause"() {patterns = array<i64>} : () -> ()
+        %4 = "ex.lit"() {value = 30 : i64} : () -> i64
+        "ex.yield"(%4) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+      }) {operandSegmentSizes = array<i32: 1>} : (i64) -> i64
+      "ex.return"(%1) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
     }) {sym_name = "main"} : () -> ()
   }
   """
@@ -224,5 +249,57 @@ defmodule ExConversionTest do
 
     assert {:error, %MLIR.Conversion.Error{} = error} = Plan.run(Ex.plan(), module)
     assert Exception.message(error) =~ "ex.cmp"
+  end
+
+  test "expands ex.case into nested ex.if and lowers to scf", %{ctx: ctx} do
+    Beaver.Slang.load(ctx, ExDialect)
+
+    module =
+      MLIR.Module.create!(@case_module, ctx: ctx)
+      |> MLIR.verify!()
+
+    module = ExpandCase.run!(module)
+    expanded = MLIR.to_string(module, generic: true)
+    refute expanded =~ ~s{"ex.case"}
+    refute expanded =~ ~s{"ex.clause"}
+    assert expanded =~ ~s{"ex.if"}
+    assert expanded =~ ~s{"ex.cmp"}
+
+    converted = Plan.run!(Ex.plan(), module)
+
+    rendered = MLIR.to_string(converted, generic: true)
+    refute rendered =~ "ex."
+    assert rendered =~ "arith.cmpi"
+    assert rendered =~ "scf.if"
+    assert rendered =~ "scf.yield"
+  end
+
+  test "rejects a case without a catch-all clause", %{ctx: ctx} do
+    Beaver.Slang.load(ctx, ExDialect)
+
+    module =
+      MLIR.Module.create!(
+        ~S"""
+        module {
+          "ex.func"() ({
+          ^bb0:
+            %0 = "ex.lit"() {value = 1 : i64} : () -> i64
+            %1 = "ex.case"(%0) ({
+            ^bb0:
+              "ex.clause"() {patterns = array<i64: 1>} : () -> ()
+              %2 = "ex.lit"() {value = 10 : i64} : () -> i64
+              "ex.yield"(%2) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+            }) {operandSegmentSizes = array<i32: 1>} : (i64) -> i64
+            "ex.return"(%1) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+          }) {sym_name = "main"} : () -> ()
+        }
+        """,
+        ctx: ctx
+      )
+      |> MLIR.verify!()
+
+    assert_raise ArgumentError, ~r/without a catch-all/, fn ->
+      ExpandCase.run!(module)
+    end
   end
 end


### PR DESCRIPTION
M2 pattern-matching lowering for the ex dialect (stacked on #523), per [tsai/beaver#6](http://localhost:3000/tsai/beaver/issues/6):

- `ExpandCase` pass: information-preserving IR-to-IR rewrite expanding `ex.case` into nested `ex.if`/`ex.cmp` chains in the transform layer (per tsai/beaver#16)
- Each clause with a single integer literal pattern becomes an `ex.if` guarded by `ex.cmp(eq)`; the final catch-all becomes the innermost else
- Clause bodies move intact and stay terminated by `ex.yield`, then lower via the existing patterns to `scf.if`/`arith.cmpi`
- Guards, multiple patterns, and non-literal patterns raise explicitly

Tests cover the full expand + convert path and the no-catch-all rejection.
