### PR TITLE
ex: reject term-universe ops until the Zig runtime ABI lands

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -16,6 +16,11 @@ defmodule Beaver.MLIR.Conversion.Ex do
     * `ex.func` -> `func.func` (body region moved, argument and `ex.return`
       types converted)
 
+  Term-universe ops (`ex.tuple`/`ex.list`/`ex.map`/`ex.binary` and the
+  `ex.is_*` predicates) are not converted yet: they require the Zig term
+  runtime ABI, which lands in the compiler repo (batata) rather than Beaver.
+  The plan rejects them explicitly instead of silently dropping them.
+
   The `ex` term types (`!ex.dyn`/`!ex.bound`/`!ex.unbound`) convert to a scalar
   word type (`i64`) until the Zig term runtime lands.
 
@@ -65,6 +70,16 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.return", &convert_return/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.var", &convert_var/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.func", &convert_func/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.tuple", &reject_term_op/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.list", &reject_term_op/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.map", &reject_term_op/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.binary", &reject_term_op/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.is_integer", &reject_term_op/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.is_atom", &reject_term_op/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.is_binary", &reject_term_op/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.is_list", &reject_term_op/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.is_tuple", &reject_term_op/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.is_map", &reject_term_op/3, version: "1.0")
   end
 
   @doc """
@@ -218,6 +233,12 @@ defmodule Beaver.MLIR.Conversion.Ex do
     MLIR.RewriterBase.insert(base, yield)
     MLIR.ConversionPatternRewriter.replace_op(rewriter, operation, yield)
     :ok
+  end
+
+  defp reject_term_op(operation, _operands, _rewriter) do
+    raise ArgumentError,
+          "#{MLIR.Operation.name(operation)} requires the Zig term runtime ABI and is unsupported " <>
+            "in the scalar conversion plan"
   end
 
   defp cmp_i_predicate("eq"), do: cmp_i_predicate_attr(0)

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -302,4 +302,28 @@ defmodule ExConversionTest do
       ExpandCase.run!(module)
     end
   end
+
+  test "rejects term-universe ops until the Zig runtime ABI lands", %{ctx: ctx} do
+    Beaver.Slang.load(ctx, ExDialect)
+
+    module =
+      MLIR.Module.create!(
+        ~S"""
+        module {
+          "ex.func"() ({
+          ^bb0:
+            %0 = "ex.lit"() {value = 1 : i64} : () -> i64
+            %1 = "ex.tuple"(%0) {operandSegmentSizes = array<i32: 1>} : (i64) -> !ex.dyn
+            "ex.return"() {operandSegmentSizes = array<i32: 0>} : () -> ()
+          }) {sym_name = "main"} : () -> ()
+        }
+        """,
+        ctx: ctx
+      )
+      |> MLIR.verify!()
+
+    assert {:error, %MLIR.Conversion.Error{} = error} = Plan.run(Ex.plan(), module)
+    assert Exception.message(error) =~ "ex.tuple"
+    assert Exception.message(error) =~ "Zig term runtime"
+  end
 end


### PR DESCRIPTION
M2 term-universe conversion boundary for the ex dialect (stacked on #525), per [tsai/beaver#6](http://localhost:3000/tsai/beaver/issues/6):

- `ex.tuple` / `ex.list` / `ex.map` / `ex.binary` and the `ex.is_*` predicates require the Zig term runtime ABI, which lives in the compiler repo (batata) rather than Beaver
- The conversion plan registers explicit rejection patterns so these ops fail loudly instead of being silently dropped, honoring the unsupported-report discipline

Tests cover the rejection path.
