### PR TITLE
ex: convert term construction and predicates via the Zig runtime ABI

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -17,12 +17,17 @@ defmodule Beaver.MLIR.Conversion.Ex do
       types converted)
 
   Term-universe ops (`ex.tuple`/`ex.list`/`ex.map`/`ex.binary` and the
-  `ex.is_*` predicates) are not converted yet: they require the Zig term
-  runtime ABI, which lands in the compiler repo (batata) rather than Beaver.
-  The plan rejects them explicitly instead of silently dropping them.
+  `ex.is_*` predicates) convert to calls into the Zig term runtime ABI, which
+  is implemented in the compiler repo (batata) rather than Beaver. The
+  declaration-first manifest (symbol names and C signatures) is mirrored in
+  `@term_intrinsics`; batata implements exactly these symbols.
 
-  The `ex` term types (`!ex.dyn`/`!ex.bound`/`!ex.unbound`) convert to a scalar
-  word type (`i64`) until the Zig term runtime lands.
+  The `ex` term types (`!ex.dyn`/`!ex.bound`/`!ex.unbound`) convert to a
+  64-bit tagged word (`i64`): low 3 bits hold the tag, the rest the payload.
+  Scalar integers are tagged in-place with `arith.shli` when they cross into
+  a term construction; values that are already term-typed pass through.
+  Containers are built with a fixed-arity cons chain followed by a
+  `*_from_list` intrinsic, so no variadic ABI or stack buffers are needed.
 
   `plan/1` returns a reusable `Beaver.MLIR.Conversion.Plan`; run it with
   `Beaver.MLIR.Conversion.Plan.run/2` and continue with the standard
@@ -70,17 +75,35 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.return", &convert_return/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.var", &convert_var/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.func", &convert_func/3, version: "1.0")
-    |> Plan.add_conversion_pattern("ex.tuple", &reject_term_op/3, version: "1.0")
-    |> Plan.add_conversion_pattern("ex.list", &reject_term_op/3, version: "1.0")
-    |> Plan.add_conversion_pattern("ex.map", &reject_term_op/3, version: "1.0")
-    |> Plan.add_conversion_pattern("ex.binary", &reject_term_op/3, version: "1.0")
-    |> Plan.add_conversion_pattern("ex.is_integer", &reject_term_op/3, version: "1.0")
-    |> Plan.add_conversion_pattern("ex.is_atom", &reject_term_op/3, version: "1.0")
-    |> Plan.add_conversion_pattern("ex.is_binary", &reject_term_op/3, version: "1.0")
-    |> Plan.add_conversion_pattern("ex.is_list", &reject_term_op/3, version: "1.0")
-    |> Plan.add_conversion_pattern("ex.is_tuple", &reject_term_op/3, version: "1.0")
-    |> Plan.add_conversion_pattern("ex.is_map", &reject_term_op/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.box", &convert_box/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.tuple", &convert_term_tuple/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.list", &convert_term_list/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.map", &convert_term_map/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.binary", &convert_term_binary/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.is_integer", &convert_term_predicate/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.is_atom", &convert_term_predicate/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.is_binary", &convert_term_predicate/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.is_list", &convert_term_predicate/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.is_tuple", &convert_term_predicate/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.is_map", &convert_term_predicate/3, version: "1.0")
   end
+
+  # Declaration-first manifest of the Zig term runtime ABI: batata's
+  # `native/term_runtime.zig` exports exactly these C symbols.
+  @term_intrinsics %{
+    list_cons: "ex.term.list_cons",
+    tuple_from_list: "ex.term.tuple_from_list",
+    map_from_list: "ex.term.map_from_list",
+    binary_from_list: "ex.term.binary_from_list",
+    is_integer: "ex.term.is_integer",
+    is_atom: "ex.term.is_atom",
+    is_binary: "ex.term.is_binary",
+    is_list: "ex.term.is_list",
+    is_tuple: "ex.term.is_tuple",
+    is_map: "ex.term.is_map"
+  }
+
+  @term_types ~w(!ex.dyn !ex.bound !ex.unbound)
 
   @doc """
   Converts an `ex` term type to its scalar word representation.
@@ -235,11 +258,240 @@ defmodule Beaver.MLIR.Conversion.Ex do
     :ok
   end
 
-  defp reject_term_op(operation, _operands, _rewriter) do
-    raise ArgumentError,
-          "#{MLIR.Operation.name(operation)} requires the Zig term runtime ABI and is unsupported " <>
-            "in the scalar conversion plan"
+  defp convert_term_list(operation, operands, rewriter) do
+    base = insertion_point(operation, rewriter)
+    list = build_list(operands, operation, rewriter, base)
+    replace_with(rewriter, operation, list)
   end
+
+  defp convert_term_tuple(operation, operands, rewriter) do
+    base = insertion_point(operation, rewriter)
+    list = build_list(operands, operation, rewriter, base)
+
+    tuple = emit_runtime_call(operation, rewriter, base, @term_intrinsics.tuple_from_list, [list])
+
+    replace_with(rewriter, operation, tuple)
+  end
+
+  defp convert_term_map(operation, operands, rewriter) do
+    base = insertion_point(operation, rewriter)
+
+    if rem(length(operands), 2) != 0 do
+      raise ArgumentError,
+            "ex.map requires an even number of key/value operands, got #{length(operands)}"
+    end
+
+    list = build_list(operands, operation, rewriter, base)
+    map = emit_runtime_call(operation, rewriter, base, @term_intrinsics.map_from_list, [list])
+    replace_with(rewriter, operation, map)
+  end
+
+  defp convert_term_binary(operation, operands, rewriter) do
+    base = insertion_point(operation, rewriter)
+    list = build_list(operands, operation, rewriter, base)
+
+    binary =
+      emit_runtime_call(operation, rewriter, base, @term_intrinsics.binary_from_list, [list])
+
+    replace_with(rewriter, operation, binary)
+  end
+
+  defp convert_term_predicate(operation, [operand], rewriter) do
+    base = insertion_point(operation, rewriter)
+
+    word =
+      case operation |> Walker.operands() |> Enum.to_list() do
+        [original] -> maybe_tag(original, operand, operation, base)
+        _ -> operand
+      end
+
+    intrinsic =
+      operation
+      |> MLIR.Operation.name()
+      |> predicate_intrinsic()
+
+    result = emit_runtime_call(operation, rewriter, base, intrinsic, [word])
+    replace_with(rewriter, operation, result)
+  end
+
+  defp convert_box(operation, [operand], rewriter) do
+    base = insertion_point(operation, rewriter)
+
+    word =
+      case operation |> Walker.operands() |> Enum.to_list() do
+        [original] -> maybe_tag(original, operand, operation, base)
+        _ -> operand
+      end
+
+    replace_with(rewriter, operation, word)
+  end
+
+  defp predicate_intrinsic("ex.is_integer"), do: @term_intrinsics.is_integer
+  defp predicate_intrinsic("ex.is_atom"), do: @term_intrinsics.is_atom
+  defp predicate_intrinsic("ex.is_binary"), do: @term_intrinsics.is_binary
+  defp predicate_intrinsic("ex.is_list"), do: @term_intrinsics.is_list
+  defp predicate_intrinsic("ex.is_tuple"), do: @term_intrinsics.is_tuple
+  defp predicate_intrinsic("ex.is_map"), do: @term_intrinsics.is_map
+
+  defp insertion_point(operation, rewriter) do
+    base = MLIR.ConversionPatternRewriter.as_base(rewriter)
+    MLIR.RewriterBase.set_insertion_point_before(base, operation)
+    base
+  end
+
+  defp replace_with(rewriter, operation, value) do
+    MLIR.ConversionPatternRewriter.replace_op(rewriter, operation, value)
+    :ok
+  end
+
+  defp maybe_tag(original, converted, operation, base) do
+    if term_type?(MLIR.Value.type(original)) do
+      converted
+    else
+      tag_integer(converted, operation, base)
+    end
+  end
+
+  # Tags a scalar i64 as an immediate integer term: word = value << 3 with the
+  # low 3 bits (tag 0b000) left as the integer tag.
+  defp tag_integer(value, operation, base) do
+    three = emit_constant(3, operation, base)
+
+    shl =
+      %Changeset{
+        name: "arith.shli",
+        context: MLIR.context(operation),
+        location: MLIR.Operation.location(operation)
+      }
+      |> Changeset.add_argument([value, MLIR.Operation.result(three, 0)])
+      |> Changeset.add_result(MLIR.Type.i64())
+      |> MLIR.Operation.create()
+
+    MLIR.RewriterBase.insert(base, shl)
+    MLIR.RewriterBase.set_insertion_point_after(base, shl)
+    MLIR.Operation.result(shl, 0)
+  end
+
+  # Builds a proper list word by consing words onto nil. Nil is the atom term
+  # with id 0: tag 0b001 | (0 << 3) = 1.
+  defp build_list([], operation, _rewriter, base) do
+    emit_constant(1, operation, base) |> MLIR.Operation.result(0)
+  end
+
+  defp build_list(words, operation, rewriter, base) do
+    words
+    |> Enum.reverse()
+    |> Enum.reduce(emit_constant(1, operation, base) |> MLIR.Operation.result(0), fn
+      word, tail ->
+        emit_runtime_call(operation, rewriter, base, @term_intrinsics.list_cons, [word, tail])
+    end)
+  end
+
+  defp emit_constant(value, operation, base) do
+    constant =
+      %Changeset{
+        name: "arith.constant",
+        context: MLIR.context(operation),
+        location: MLIR.Operation.location(operation)
+      }
+      |> Changeset.add_argument(value: MLIR.Attribute.integer(MLIR.Type.i64(), value))
+      |> Changeset.add_result(MLIR.Type.i64())
+      |> MLIR.Operation.create()
+
+    MLIR.RewriterBase.insert(base, constant)
+    MLIR.RewriterBase.set_insertion_point_after(base, constant)
+    constant
+  end
+
+  defp emit_runtime_call(operation, rewriter, base, symbol, args) do
+    ensure_intrinsic_declaration(operation, rewriter, symbol)
+    MLIR.RewriterBase.set_insertion_point_before(base, operation)
+
+    call =
+      %Changeset{
+        name: "func.call",
+        context: MLIR.context(operation),
+        location: MLIR.Operation.location(operation)
+      }
+      |> Changeset.add_argument(args)
+      |> Changeset.add_argument(
+        callee: MLIR.Attribute.flat_symbol_ref(symbol, ctx: MLIR.context(operation))
+      )
+      |> Changeset.add_result(MLIR.Type.i64())
+      |> MLIR.Operation.create()
+
+    MLIR.RewriterBase.insert(base, call)
+    MLIR.RewriterBase.set_insertion_point_after(base, call)
+    MLIR.Operation.result(call, 0)
+  end
+
+  # `func.call` requires the callee symbol to exist, so each intrinsic gets a
+  # public `func.func` declaration (no body) at module scope. At link time the
+  # Zig term runtime shared library satisfies the symbols.
+  defp ensure_intrinsic_declaration(operation, rewriter, symbol) do
+    module_op =
+      Stream.iterate(operation, &MLIR.Operation.parent/1)
+      |> Enum.find(fn op -> op |> MLIR.Operation.parent() |> MLIR.null?() end)
+
+    body = module_body(module_op)
+
+    unless declaration_exists?(body, symbol) do
+      base = MLIR.ConversionPatternRewriter.as_base(rewriter)
+      MLIR.RewriterBase.set_insertion_point_to_end(base, body)
+
+      declaration =
+        %Changeset{
+          name: "func.func",
+          context: MLIR.context(operation),
+          location: MLIR.Operation.location(operation)
+        }
+        |> Changeset.add_argument(sym_name: MLIR.Attribute.string(symbol))
+        |> Changeset.add_argument(sym_visibility: MLIR.Attribute.string("private"))
+        |> Changeset.add_argument(function_type: intrinsic_function_type(symbol))
+        |> Changeset.add_argument(MLIR.CAPI.mlirRegionCreate())
+        |> MLIR.Operation.create()
+
+      MLIR.RewriterBase.insert(base, declaration)
+    end
+
+    :ok
+  end
+
+  defp declaration_exists?(body, symbol) do
+    body
+    |> Walker.operations()
+    |> Enum.to_list()
+    |> Enum.any?(fn op ->
+      MLIR.Operation.name(op) == "func.func" and
+        case op |> MLIR.Operation.fetch("sym_name") do
+          {:ok, attribute} ->
+            attribute |> MLIR.CAPI.mlirStringAttrGetValue() |> MLIR.to_string() == symbol
+
+          :error ->
+            false
+        end
+    end)
+  end
+
+  defp module_body(module_op) do
+    module_op
+    |> Walker.regions()
+    |> Enum.to_list()
+    |> hd()
+    |> Walker.blocks()
+    |> Enum.to_list()
+    |> hd()
+  end
+
+  defp intrinsic_function_type("ex.term.list_cons") do
+    MLIR.Type.function([MLIR.Type.i64(), MLIR.Type.i64()], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type(_symbol) do
+    MLIR.Type.function([MLIR.Type.i64()], [MLIR.Type.i64()])
+  end
+
+  defp term_type?(type), do: MLIR.to_string(type) in @term_types
 
   defp cmp_i_predicate("eq"), do: cmp_i_predicate_attr(0)
   defp cmp_i_predicate("ne"), do: cmp_i_predicate_attr(1)

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -89,16 +89,19 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop clause(guard = optional(any())),
     attributes: [patterns: any()]
 
-  defop tuple(elements = variadic(any())),
+  defop box(value = any()),
     results: [result: base(dyn())]
 
-  defop list(elements = variadic(any())),
+  defop tuple(elements = variadic(base(dyn()))),
     results: [result: base(dyn())]
 
-  defop map(entries = variadic(any())),
+  defop list(elements = variadic(base(dyn()))),
     results: [result: base(dyn())]
 
-  defop binary(segments = variadic(any())),
+  defop map(entries = variadic(base(dyn()))),
+    results: [result: base(dyn())]
+
+  defop binary(segments = variadic(base(dyn()))),
     results: [result: base(dyn())]
 
   defop is_integer(value = any()),

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -303,27 +303,118 @@ defmodule ExConversionTest do
     end
   end
 
-  test "rejects term-universe ops until the Zig runtime ABI lands", %{ctx: ctx} do
+  defp term_module!(module_source, ctx) do
     Beaver.Slang.load(ctx, ExDialect)
 
+    MLIR.Module.create!(module_source, ctx: ctx)
+    |> MLIR.verify!()
+  end
+
+  test "converts term construction and predicates to Zig runtime ABI calls", %{ctx: ctx} do
     module =
-      MLIR.Module.create!(
+      term_module!(
         ~S"""
         module {
           "ex.func"() ({
           ^bb0:
             %0 = "ex.lit"() {value = 1 : i64} : () -> i64
-            %1 = "ex.tuple"(%0) {operandSegmentSizes = array<i32: 1>} : (i64) -> !ex.dyn
+            %1 = "ex.lit"() {value = 2 : i64} : () -> i64
+            %2 = "ex.box"(%0) : (i64) -> !ex.dyn
+            %3 = "ex.box"(%1) : (i64) -> !ex.dyn
+            %4 = "ex.tuple"(%2, %3) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
+            %5 = "ex.is_tuple"(%4) : (!ex.dyn) -> i64
+            "ex.return"(%5) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+          }) {sym_name = "main"} : () -> ()
+        }
+        """,
+        ctx
+      )
+
+    assert {:ok, _module, []} = Plan.run(Ex.plan(), module)
+
+    rendered = MLIR.to_string(module, generic: true)
+    assert rendered =~ "ex.term.list_cons"
+    assert rendered =~ "ex.term.tuple_from_list"
+    assert rendered =~ "ex.term.is_tuple"
+    # scalar operands are tagged as immediate integer terms before construction
+    assert rendered =~ "arith.shli"
+  end
+
+  test "converts list, map and binary construction to runtime ABI calls", %{ctx: ctx} do
+    module =
+      term_module!(
+        ~S"""
+        module {
+          "ex.func"() ({
+          ^bb0:
+            %0 = "ex.lit"() {value = 1 : i64} : () -> i64
+            %1 = "ex.lit"() {value = 2 : i64} : () -> i64
+            %2 = "ex.box"(%0) : (i64) -> !ex.dyn
+            %3 = "ex.box"(%1) : (i64) -> !ex.dyn
+            %4 = "ex.list"(%2, %3) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
+            %5 = "ex.map"(%2, %3) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
+            %6 = "ex.binary"(%2, %3) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
+            %7 = "ex.is_list"(%4) : (!ex.dyn) -> i64
+            "ex.return"(%7) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+          }) {sym_name = "main"} : () -> ()
+        }
+        """,
+        ctx
+      )
+
+    assert {:ok, _module, []} = Plan.run(Ex.plan(), module)
+
+    rendered = MLIR.to_string(module, generic: true)
+    assert rendered =~ "ex.term.list_cons"
+    assert rendered =~ "ex.term.map_from_list"
+    assert rendered =~ "ex.term.binary_from_list"
+    assert rendered =~ "ex.term.is_list"
+  end
+
+  test "passes nested term operands through without re-tagging", %{ctx: ctx} do
+    module =
+      term_module!(
+        ~S"""
+        module {
+          "ex.func"() ({
+          ^bb0:
+            %0 = "ex.lit"() {value = 1 : i64} : () -> i64
+            %1 = "ex.box"(%0) : (i64) -> !ex.dyn
+            %2 = "ex.tuple"(%1) {operandSegmentSizes = array<i32: 1>} : (!ex.dyn) -> !ex.dyn
+            %3 = "ex.tuple"(%2) {operandSegmentSizes = array<i32: 1>} : (!ex.dyn) -> !ex.dyn
+            %4 = "ex.is_tuple"(%3) : (!ex.dyn) -> i64
+            "ex.return"(%4) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+          }) {sym_name = "main"} : () -> ()
+        }
+        """,
+        ctx
+      )
+
+    assert {:ok, _module, []} = Plan.run(Ex.plan(), module)
+
+    rendered = MLIR.to_string(module, generic: true)
+    assert rendered =~ "ex.term.tuple_from_list"
+    assert rendered =~ "ex.term.is_tuple"
+  end
+
+  test "rejects ex.map with an odd number of entries", %{ctx: ctx} do
+    module =
+      term_module!(
+        ~S"""
+        module {
+          "ex.func"() ({
+          ^bb0:
+            %0 = "ex.lit"() {value = 1 : i64} : () -> i64
+            %1 = "ex.box"(%0) : (i64) -> !ex.dyn
+            %2 = "ex.map"(%1) {operandSegmentSizes = array<i32: 1>} : (!ex.dyn) -> !ex.dyn
             "ex.return"() {operandSegmentSizes = array<i32: 0>} : () -> ()
           }) {sym_name = "main"} : () -> ()
         }
         """,
-        ctx: ctx
+        ctx
       )
-      |> MLIR.verify!()
 
     assert {:error, %MLIR.Conversion.Error{} = error} = Plan.run(Ex.plan(), module)
-    assert Exception.message(error) =~ "ex.tuple"
-    assert Exception.message(error) =~ "Zig term runtime"
+    assert Exception.message(error) =~ "even number"
   end
 end

--- a/test/ex_dialect_test.exs
+++ b/test/ex_dialect_test.exs
@@ -64,17 +64,19 @@ defmodule ExDialectTest do
     ^bb0:
       %0 = "ex.lit"() {value = 1 : i64} : () -> i64
       %1 = "ex.lit"() {value = 2 : i64} : () -> i64
-      %2 = "ex.tuple"(%0, %1) {operandSegmentSizes = array<i32: 2>} : (i64, i64) -> !ex.dyn
-      %3 = "ex.list"(%0, %1) {operandSegmentSizes = array<i32: 2>} : (i64, i64) -> !ex.dyn
-      %4 = "ex.map"(%0, %1) {operandSegmentSizes = array<i32: 2>} : (i64, i64) -> !ex.dyn
-      %5 = "ex.binary"(%0) {operandSegmentSizes = array<i32: 1>} : (i64) -> !ex.dyn
-      %6 = "ex.is_tuple"(%2) : (!ex.dyn) -> i64
-      %7 = "ex.is_list"(%3) : (!ex.dyn) -> i64
-      %8 = "ex.is_map"(%4) : (!ex.dyn) -> i64
-      %9 = "ex.is_binary"(%5) : (!ex.dyn) -> i64
-      %10 = "ex.is_integer"(%0) : (i64) -> i64
-      %11 = "ex.is_atom"(%0) : (i64) -> i64
-      "ex.return"(%6) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+      %2 = "ex.box"(%0) : (i64) -> !ex.dyn
+      %3 = "ex.box"(%1) : (i64) -> !ex.dyn
+      %4 = "ex.tuple"(%2, %3) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
+      %5 = "ex.list"(%2, %3) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
+      %6 = "ex.map"(%2, %3) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
+      %7 = "ex.binary"(%2) {operandSegmentSizes = array<i32: 1>} : (!ex.dyn) -> !ex.dyn
+      %8 = "ex.is_tuple"(%4) : (!ex.dyn) -> i64
+      %9 = "ex.is_list"(%5) : (!ex.dyn) -> i64
+      %10 = "ex.is_map"(%6) : (!ex.dyn) -> i64
+      %11 = "ex.is_binary"(%7) : (!ex.dyn) -> i64
+      %12 = "ex.is_integer"(%0) : (i64) -> i64
+      %13 = "ex.is_atom"(%0) : (i64) -> i64
+      "ex.return"(%8) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
     }) {sym_name = "main"} : () -> ()
   }
   """
@@ -288,20 +290,28 @@ defmodule ExDialectTest do
                   Ex.lit(value: Attribute.integer(Type.i64(), 2)) >>>
                     Type.i64()
 
+                one_boxed =
+                  Ex.box(value: one) >>>
+                    Ex.dyn()
+
+                two_boxed =
+                  Ex.box(value: two) >>>
+                    Ex.dyn()
+
                 tuple =
-                  Ex.tuple(elements: [one, two], operandSegmentSizes: :infer) >>>
+                  Ex.tuple(elements: [one_boxed, two_boxed], operandSegmentSizes: :infer) >>>
                     Ex.dyn()
 
                 list =
-                  Ex.list(elements: [one, two], operandSegmentSizes: :infer) >>>
+                  Ex.list(elements: [one_boxed, two_boxed], operandSegmentSizes: :infer) >>>
                     Ex.dyn()
 
                 map =
-                  Ex.map(entries: [one, two], operandSegmentSizes: :infer) >>>
+                  Ex.map(entries: [one_boxed, two_boxed], operandSegmentSizes: :infer) >>>
                     Ex.dyn()
 
                 bin =
-                  Ex.binary(segments: [one], operandSegmentSizes: :infer) >>>
+                  Ex.binary(segments: [one_boxed], operandSegmentSizes: :infer) >>>
                     Ex.dyn()
 
                 _is_tuple =
@@ -333,6 +343,7 @@ defmodule ExDialectTest do
       |> MLIR.verify!()
 
     rendered = MLIR.to_string(module, generic: true)
+    assert rendered =~ ~s{"ex.box"}
     assert rendered =~ ~s{"ex.tuple"}
     assert rendered =~ ~s{"ex.list"}
     assert rendered =~ ~s{"ex.map"}


### PR DESCRIPTION
Completes the beaver side of [tsai/beaver#17](http://localhost:3000/tsai/beaver/issues/17) (stacked after #521–#526).

## What

Replaces the explicit rejection of term-universe ops in `Beaver.MLIR.Conversion.Ex` with real lowering to the declaration-first Zig term runtime ABI:

- new `ex.box` op marks the scalar → term boundary; term construction ops (`ex.tuple`/`ex.list`/`ex.map`/`ex.binary`) now take `!ex.dyn` operands uniformly (IRDL variadic constraints are homogeneous, so mixed i64/`!ex.dyn` operands cannot be verified);
- `ex.box` lowers to an in-place tagged word (`arith.shli` by 3, int tag 0b000) and is a no-op for values that are already terms;
- containers lower to a fixed-arity cons chain plus `tuple_from_list`/`map_from_list`/`binary_from_list` — no variadic ABI or stack buffers;
- `ex.is_*` predicates lower to `ex.term.is_*` runtime calls;
- intrinsics get private `func.func` declarations (no body) at module scope so `func.call` verifies and func-to-llvm emits external references resolved by the batata runtime shared library at JIT time.

## Tests

`test/ex_conversion_test.exs` and `test/ex_dialect_test.exs` updated: term construction/predicates now convert successfully (previously rejected), including nested terms and the odd-map rejection.