### PR TITLE
GPU: NVVM target attribute + gpu.binary packaging (minimal path for #459)

### DIFF
--- a/lib/beaver/mlir/dialect/gpu.ex
+++ b/lib/beaver/mlir/dialect/gpu.ex
@@ -29,4 +29,72 @@ defmodule Beaver.MLIR.Dialect.GPU do
   def container_module_attribute_name do
     MLIR.CAPI.beaverGetContainerModuleAttrName() |> to_string() |> String.to_atom()
   end
+
+  @doc """
+  Construct an NVVM target attribute from Elixir data.
+
+  Supported options:
+
+    * `:chip` - target chip, e.g. `"sm_80"`
+    * `:triple` - target triple, e.g. `"nvptx64-nvidia-cuda"`
+    * `:features` - target features, e.g. `"+ptx80"`
+    * `:opt` - optimization level, an integer
+
+  Returns a deferred attribute creator unless `ctx:` is given, following the
+  convention of `MLIR.Attribute.get/2`. The resulting attribute can be passed
+  to `package_binary!/3` as the target configuration of a `gpu.binary`.
+  """
+  def nvvm_target_attribute(opts \\ []) do
+    params =
+      opts
+      |> Keyword.take([:chip, :triple, :features, :opt])
+      |> Enum.map(fn
+        {:opt, value} -> "O = #{value}"
+        {name, value} when is_binary(value) -> ~s{#{name} = "#{value}"}
+        {name, value} -> "#{name} = #{value}"
+      end)
+
+    MLIR.Attribute.get("#nvvm.target<#{Enum.join(params, ", ")}>", opts)
+  end
+
+  @doc """
+  Lower and package a module containing GPU kernels into a `gpu.binary`.
+
+  `targets` is an NVVM target attribute (from `nvvm_target_attribute/1`) or a
+  list of them; one `gpu.object` is produced per target. The target
+  configuration is attached to each lowered `gpu.module` as its `targets`
+  attribute, replacing hard-coded legacy pipeline options.
+
+  Options:
+
+    * `:format` - binary format passed to `gpu-module-to-binary`. Defaults to
+      `:isa` (PTX assembly), which is generated entirely on CPU without
+      requiring a CUDA toolkit.
+
+  Returns the module with `gpu.launch`/`gpu.func` code replaced by `gpu.binary`
+  operations.
+  """
+  def package_binary!(module, targets, opts \\ []) do
+    format = Keyword.get(opts, :format, :isa)
+    ctx = MLIR.context(module)
+    MLIR.Context.register_translations(ctx)
+
+    lowered =
+      module
+      |> Beaver.Composer.append("gpu-kernel-outlining")
+      |> Beaver.Composer.nested("gpu.module", "convert-gpu-to-nvvm")
+      |> Beaver.Composer.run!()
+
+    targets_attr = MLIR.Attribute.array(List.wrap(targets), ctx: ctx)
+
+    lowered
+    |> MLIR.Module.body()
+    |> Beaver.Walker.operations()
+    |> Enum.filter(&(MLIR.Operation.name(&1) == "gpu.module"))
+    |> Enum.each(&MLIR.Operation.get_and_update(&1, "targets", fn _ -> {nil, targets_attr} end))
+
+    lowered
+    |> Beaver.Composer.append("gpu-module-to-binary{format=#{format}}")
+    |> Beaver.Composer.run!()
+  end
 end

--- a/test/gpu_binary_test.exs
+++ b/test/gpu_binary_test.exs
@@ -1,0 +1,86 @@
+defmodule GPUBinaryTest do
+  use Beaver.Case, async: true
+  use Beaver
+  alias Beaver.MLIR
+  alias Beaver.MLIR.Dialect.GPU
+
+  test "nvvm_target_attribute builds a target attribute from data", %{ctx: ctx} do
+    assert MLIR.to_string(GPU.nvvm_target_attribute(chip: "sm_80", ctx: ctx)) ==
+             ~s{#nvvm.target<chip = "sm_80">}
+
+    full =
+      GPU.nvvm_target_attribute(
+        chip: "sm_80",
+        triple: "nvptx64-nvidia-cuda",
+        features: "+ptx80",
+        opt: 3,
+        ctx: ctx
+      )
+      |> MLIR.to_string()
+
+    assert full =~ ~s{chip = "sm_80"}
+    assert full =~ ~s{features = "+ptx80"}
+    assert full =~ "O = 3"
+  end
+
+  test "package_binary! produces a gpu.binary with one object per target", %{ctx: ctx} do
+    module =
+      File.read!("test/gpu-to-cubin.mlir")
+      |> MLIR.Module.create!(ctx: ctx)
+
+    target = GPU.nvvm_target_attribute(chip: "sm_80", ctx: ctx)
+
+    ir =
+      module
+      |> GPU.package_binary!(target, format: :isa)
+      |> MLIR.to_string()
+
+    assert ir =~ "gpu.binary @other_func_kernel"
+    assert ir =~ ~s{#gpu.object<#nvvm.target<chip = "sm_80">}
+    assert ir =~ ".entry other_func_kernel"
+    refute ir =~ "gpu.module"
+  end
+
+  test "package_binary! packages multiple target objects into one binary", %{ctx: ctx} do
+    module =
+      File.read!("test/gpu-to-cubin.mlir")
+      |> MLIR.Module.create!(ctx: ctx)
+
+    targets = [
+      GPU.nvvm_target_attribute(chip: "sm_80", ctx: ctx),
+      GPU.nvvm_target_attribute(chip: "sm_90", ctx: ctx)
+    ]
+
+    ir =
+      module
+      |> GPU.package_binary!(targets, format: :isa)
+      |> MLIR.to_string()
+
+    assert ir =~ ~s{#gpu.object<#nvvm.target<chip = "sm_80">}
+    assert ir =~ ~s{#gpu.object<#nvvm.target<chip = "sm_90">}
+  end
+
+  test "package_binary! accepts a standalone gpu.module", %{ctx: ctx} do
+    module =
+      MLIR.Module.create!(
+        """
+        gpu.module @kernels {
+          gpu.func @foo() {
+            gpu.return
+          }
+        }
+        """,
+        ctx: ctx
+      )
+
+    target = GPU.nvvm_target_attribute(chip: "sm_80", ctx: ctx)
+
+    ir =
+      module
+      |> GPU.package_binary!(target, format: :isa)
+      |> MLIR.to_string()
+
+    assert ir =~ "gpu.binary @kernels"
+    assert ir =~ ~s{#gpu.object<#nvvm.target<chip = "sm_80">}
+  end
+end

--- a/test/gpu_test.exs
+++ b/test/gpu_test.exs
@@ -2,32 +2,35 @@ defmodule GPUTest do
   use Beaver.Case, async: true
   use Beaver
   alias Beaver.MLIR
+  alias Beaver.MLIR.Dialect.GPU
   doctest Beaver.MLIR.Dialect.GPU
 
   @moduletag :cuda
 
   test "fatbin", %{ctx: ctx} do
-    MLIR.Context.register_translations(ctx)
     # trap sigchld when running ptxas to generate fatbin
     System.trap_signal(:sigchld, fn -> :ok end)
 
-    assert File.read!("test/gpu-to-cubin.mlir")
-           |> MLIR.Module.create!(ctx: ctx)
-           |> Beaver.Composer.append(
-             "gpu-lower-to-nvvm-pipeline{cubin-format=fatbin cubin-chip=sm_80}"
-           )
-           |> Beaver.Composer.run!()
+    module =
+      File.read!("test/gpu-to-cubin.mlir")
+      |> MLIR.Module.create!(ctx: ctx)
+
+    target = GPU.nvvm_target_attribute(chip: "sm_80", ctx: ctx)
+
+    assert module
+           |> GPU.package_binary!(target, format: :fatbin)
            |> to_string() =~ "gpu.binary @other_func_kernel"
   end
 
   test "isa", %{ctx: ctx} do
-    MLIR.Context.register_translations(ctx)
+    module =
+      File.read!("test/gpu-to-cubin.mlir")
+      |> MLIR.Module.create!(ctx: ctx)
 
-    assert MLIR.Module.create!(File.read!("test/gpu-to-cubin.mlir"), ctx: ctx)
-           |> Beaver.Composer.append(
-             "gpu-lower-to-nvvm-pipeline{cubin-format=isa cubin-chip=sm_80}"
-           )
-           |> Beaver.Composer.run!()
+    target = GPU.nvvm_target_attribute(chip: "sm_80", ctx: ctx)
+
+    assert module
+           |> GPU.package_binary!(target, format: :isa)
            |> to_string() =~ "gpu.binary @other_func_kernel"
   end
 end


### PR DESCRIPTION
Closes the first acceptance criteria of #459 with a data-driven GPU target surface.

## What

- `Beaver.MLIR.Dialect.GPU.nvvm_target_attribute/1` constructs an `#nvvm.target` attribute from Elixir options (`chip`, `triple`, `features`, `opt`).
- `Beaver.MLIR.Dialect.GPU.package_binary!/3` runs the modern target-attribute-driven flow: `gpu-kernel-outlining` → `convert-gpu-to-nvvm` → attach `targets` → `gpu-module-to-binary`, producing a `gpu.binary` with one `gpu.object` per target. No hard-coded legacy pipeline strings.
- Existing `gpu_test.exs` fatbin/isa tests are migrated from `gpu-lower-to-nvvm-pipeline{cubin-format=... cubin-chip=...}` to the new API.
- New CPU-only tests in `gpu_binary_test.exs`: attribute construction, single- and multi-target packaging, and standalone `gpu.module` inputs.

## Acceptance criteria coverage (#459)

- [x] A Beaver API constructs NVVM target configurations.
- [x] A module can produce a `gpu.binary` with multiple target objects.
- [x] Existing CUDA tests migrate away from hard-coded legacy pipeline details.
- [x] Tests validate IR and packaging without requiring physical GPU hardware (PTX/isa format runs fully on CPU).

ROCDL target configuration is left as follow-up.

## Test plan

- `mix test test/gpu_binary_test.exs test/gpu_test.exs` — 8 passed (fatbin runs when `ptxas` is available).
- Full suite: 307 passed, 0 failed (excluding the `cuda_runtime` lane, which requires `libmlir_cuda_runtime.so` not present in the eudsl prebuilt).