### PR TITLE
test: cover transform.apply_patterns apply_cse in the schedule DSL

### DIFF
--- a/guides/transform-autotuning.md
+++ b/guides/transform-autotuning.md
@@ -95,6 +95,34 @@ Elixir file and line as an MLIR location. The caller owns `transform_ir` and
 `schedule_context` and must destroy the module before the context after the
 search is complete.
 
+### Applying patterns with CSE
+
+`transform.apply_patterns` runs a greedy pattern driver on the body of its
+target. The upstream operation carries an `apply_cse` unit attribute: when
+set, common subexpression elimination is interleaved with pattern application
+until a fixpoint, so duplicated subexpressions are folded into a single
+definition. The DSL passes the upstream spelling through unchanged.
+
+```elixir
+defschedule canonicalize_with_cse do
+  sequence "__transform_main", [root >>> any_op()] do
+    apply_cse = MLIR.Attribute.unit(ctx: Beaver.Env.context())
+
+    Transform.apply_patterns(target: root, apply_cse: apply_cse) do
+      region do
+        block do
+          Transform.apply_patterns_canonicalization()
+        end
+      end
+    end >>> []
+  end
+end
+```
+
+Omitting the `apply_cse` attribute runs the same patterns without the CSE
+interleaving. Both variants are ordinary Transform IR, so they round-trip
+through text and bytecode and resolve and execute like any other schedule.
+
 Discovery and enumeration are deterministic. An alternatives choice is visited
 before choices in its regions, and choices from unselected regions do not
 inflate the candidate set.

--- a/test/transform_schedule_dsl_test.exs
+++ b/test/transform_schedule_dsl_test.exs
@@ -393,8 +393,7 @@ defmodule Beaver.MLIR.Transform.Schedule.DSLTest do
     module
     |> MLIR.Module.body()
     |> Beaver.Walker.operations()
-    |> Enum.map(&MLIR.to_string/1)
-    |> Enum.join()
+    |> Enum.map_join(&MLIR.to_string/1)
     |> then(&(length(String.split(&1, "arith.addi")) - 1))
   end
 

--- a/test/transform_schedule_dsl_test.exs
+++ b/test/transform_schedule_dsl_test.exs
@@ -124,6 +124,36 @@ defmodule Beaver.MLIR.Transform.Schedule.DSLTest do
     end
   end
 
+  defmodule CseSchedule do
+    use DSL
+
+    defschedule cse_schedule do
+      sequence "__transform_main", [root >>> any_op()] do
+        apply_cse = MLIR.Attribute.unit(ctx: Beaver.Env.context())
+
+        Transform.apply_patterns target: root, apply_cse: apply_cse do
+          region do
+            block do
+              Transform.apply_patterns_canonicalization()
+            end
+          end
+        end >>> []
+      end
+    end
+
+    defschedule plain_patterns_schedule do
+      sequence "__transform_main", [root >>> any_op()] do
+        Transform.apply_patterns target: root do
+          region do
+            block do
+              Transform.apply_patterns_canonicalization()
+            end
+          end
+        end >>> []
+      end
+    end
+  end
+
   defmodule InvalidDeclarations do
     use DSL
 
@@ -155,6 +185,17 @@ defmodule Beaver.MLIR.Transform.Schedule.DSLTest do
     func.func @matmul_op(%A: tensor<16x16xf32>, %B: tensor<16x16xf32>, %C: tensor<16x16xf32>) -> tensor<16x16xf32> {
       %0 = linalg.matmul ins(%A, %B : tensor<16x16xf32>, tensor<16x16xf32>) outs(%C : tensor<16x16xf32>) -> tensor<16x16xf32>
       return %0 : tensor<16x16xf32>
+    }
+  }
+  """
+
+  @cse_payload """
+  module {
+    func.func @duplicated(%a: i32, %b: i32) -> i32 {
+      %0 = arith.addi %a, %b : i32
+      %1 = arith.addi %a, %b : i32
+      %2 = arith.addi %0, %1 : i32
+      return %2 : i32
     }
   }
   """
@@ -346,6 +387,64 @@ defmodule Beaver.MLIR.Transform.Schedule.DSLTest do
     assert first.cache == :miss
     assert second.cache == :hit
     assert first.metadata.transform_schedule == Schedule.cache_identity(resolved)
+  end
+
+  defp count_arith_addi(module) do
+    module
+    |> MLIR.Module.body()
+    |> Beaver.Walker.operations()
+    |> Enum.map(&MLIR.to_string/1)
+    |> Enum.join()
+    |> then(&(length(String.split(&1, "arith.addi")) - 1))
+  end
+
+  test "apply_patterns with apply_cse removes duplicated subexpressions", %{ctx: ctx} do
+    schedule = own(CseSchedule.cse_schedule(ctx: ctx))
+    assert {:ok, resolved} = Schedule.resolve(schedule, %{})
+
+    payload = own(MLIR.Module.create!(@cse_payload, ctx: ctx))
+    assert count_arith_addi(payload) == 3
+
+    assert {:ok, result} = MLIR.Transform.execute(payload, resolved)
+
+    assert count_arith_addi(result.payload) == 2
+
+    # The folded value is reused: the remaining addi feeds itself.
+    assert MLIR.to_string(result.payload) =~ "arith.addi %0, %0"
+  end
+
+  test "apply_patterns without apply_cse keeps duplicated subexpressions", %{ctx: ctx} do
+    schedule = own(CseSchedule.plain_patterns_schedule(ctx: ctx))
+
+    assert {:ok, resolved} = Schedule.resolve(schedule, %{})
+
+    payload = own(MLIR.Module.create!(@cse_payload, ctx: ctx))
+
+    assert {:ok, result} = MLIR.Transform.execute(payload, resolved)
+
+    assert count_arith_addi(result.payload) == 3
+  end
+
+  test "apply_cse schedules round-trip through text and bytecode", %{ctx: ctx} do
+    schedule = own(CseSchedule.cse_schedule(ctx: ctx))
+
+    text = MLIR.to_string(schedule)
+    bytecode = MLIR.Bytecode.write!(schedule)
+    assert text =~ ~s(transform.apply_patterns)
+    assert text =~ "{apply_cse}"
+
+    for round_trip <- [
+          MLIR.Module.create!(text, ctx: ctx),
+          MLIR.Module.create!(bytecode, ctx: ctx)
+        ] do
+      round_trip = own(round_trip)
+      assert {:ok, resolved} = Schedule.resolve(round_trip, %{})
+
+      payload = own(MLIR.Module.create!(@cse_payload, ctx: ctx))
+      assert {:ok, result} = MLIR.Transform.execute(payload, resolved)
+
+      assert count_arith_addi(result.payload) == 2
+    end
   end
 
   defp own(module) do


### PR DESCRIPTION
Regression coverage for the upstream `apply_cse` fix (LLVM commit `bacfe2950f82`, 2026-07-29): a `defschedule` carrying `transform.apply_patterns ... {apply_cse}` through the existing SSA syntax must actually eliminate duplicated subexpressions when executed, and the same schedule without the attribute must keep them.

- New `CseSchedule` fixtures spell the upstream operation with the existing DSL `region`/`block` macros, no new DSL keyword.
- The payload contains a duplicated `arith.addi`; with `apply_cse` the folded value is reused, without it the duplication survives.
- Both variants resolve through `Schedule.resolve/3` and execute through `Transform.execute/3`, and round-trip through text and bytecode.
- `guides/transform-autotuning.md` now documents the `apply_cse` option in the DSL pattern-authoring section.

Closes #519.