### PR TITLE
gpu: add ROCDL target attribute and rocdl packaging to gpu.binary

### DIFF
--- a/lib/beaver/mlir/dialect/gpu.ex
+++ b/lib/beaver/mlir/dialect/gpu.ex
@@ -58,12 +58,43 @@ defmodule Beaver.MLIR.Dialect.GPU do
   end
 
   @doc """
+  Construct a ROCDL target attribute from Elixir data.
+
+  Supported options:
+
+    * `:chip` - target chip, e.g. `"gfx90a"` (defaults to `"gfx900"`)
+    * `:triple` - target triple, e.g. `"amdgcn-amd-amdhsa"`
+    * `:features` - target features, e.g. `"+wavefrontsize64"`
+    * `:opt` - optimization level, an integer (defaults to `2`)
+    * `:abi` - ABI version, e.g. `"600"`
+
+  Returns a deferred attribute creator unless `ctx:` is given, following the
+  convention of `MLIR.Attribute.get/2`. The resulting attribute can be passed
+  to `package_binary!/3` as the target configuration of a `gpu.binary`.
+  """
+  def rocdl_target_attribute(opts \\ []) do
+    params =
+      opts
+      |> Keyword.take([:chip, :triple, :features, :opt, :abi])
+      |> Enum.map(fn
+        {:opt, value} -> "O = #{value}"
+        {name, value} when is_binary(value) -> ~s{#{name} = "#{value}"}
+        {name, value} -> "#{name} = #{value}"
+      end)
+
+    MLIR.Attribute.get("#rocdl.target<#{Enum.join(params, ", ")}>", opts)
+  end
+
+  @doc """
   Lower and package a module containing GPU kernels into a `gpu.binary`.
 
-  `targets` is an NVVM target attribute (from `nvvm_target_attribute/1`) or a
-  list of them; one `gpu.object` is produced per target. The target
-  configuration is attached to each lowered `gpu.module` as its `targets`
-  attribute, replacing hard-coded legacy pipeline options.
+  `targets` is an NVVM or ROCDL target attribute (from
+  `nvvm_target_attribute/1` or `rocdl_target_attribute/1`) or a list of them;
+  one `gpu.object` is produced per target. The conversion pass is selected
+  from the target dialect: `#nvvm.target` lowers through `convert-gpu-to-nvvm`
+  and `#rocdl.target` through `convert-gpu-to-rocdl`. The target configuration
+  is attached to each lowered `gpu.module` as its `targets` attribute,
+  replacing hard-coded legacy pipeline options.
 
   Options:
 
@@ -72,20 +103,24 @@ defmodule Beaver.MLIR.Dialect.GPU do
       requiring a CUDA toolkit.
 
   Returns the module with `gpu.launch`/`gpu.func` code replaced by `gpu.binary`
-  operations.
+  operations. Assembly (`:isa`) for both backends is generated entirely on CPU
+  by the LLVM NVPTX/AMDGPU targets bundled with the MLIR prebuilt.
   """
   def package_binary!(module, targets, opts \\ []) do
     format = Keyword.get(opts, :format, :isa)
     ctx = MLIR.context(module)
     MLIR.Context.register_translations(ctx)
 
+    targets = List.wrap(targets)
+    conversion = conversion_pass!(targets)
+
     lowered =
       module
       |> Beaver.Composer.append("gpu-kernel-outlining")
-      |> Beaver.Composer.nested("gpu.module", "convert-gpu-to-nvvm")
+      |> Beaver.Composer.nested("gpu.module", conversion)
       |> Beaver.Composer.run!()
 
-    targets_attr = MLIR.Attribute.array(List.wrap(targets), ctx: ctx)
+    targets_attr = MLIR.Attribute.array(targets, ctx: ctx)
 
     lowered
     |> MLIR.Module.body()
@@ -97,4 +132,17 @@ defmodule Beaver.MLIR.Dialect.GPU do
     |> Beaver.Composer.append("gpu-module-to-binary{format=#{format}}")
     |> Beaver.Composer.run!()
   end
+
+  defp conversion_pass!([target | _]) do
+    case target
+         |> MLIR.CAPI.mlirAttributeGetDialect()
+         |> MLIR.CAPI.mlirDialectGetNamespace()
+         |> MLIR.to_string() do
+      "nvvm" -> "convert-gpu-to-nvvm"
+      "rocdl" -> "convert-gpu-to-rocdl"
+      other -> raise ArgumentError, "unsupported GPU target attribute dialect: #{other}"
+    end
+  end
+
+  defp conversion_pass!([]), do: raise(ArgumentError, "at least one target attribute is required")
 end

--- a/test/gpu_binary_test.exs
+++ b/test/gpu_binary_test.exs
@@ -23,6 +23,28 @@ defmodule GPUBinaryTest do
     assert full =~ "O = 3"
   end
 
+  test "rocdl_target_attribute builds a target attribute from data", %{ctx: ctx} do
+    assert MLIR.to_string(GPU.rocdl_target_attribute(chip: "gfx90a", ctx: ctx)) ==
+             ~s{#rocdl.target<chip = "gfx90a">}
+
+    full =
+      GPU.rocdl_target_attribute(
+        chip: "gfx90a",
+        triple: "amdgcn-amd-amdhsa-pal",
+        features: "+wavefrontsize64",
+        opt: 3,
+        abi: "500",
+        ctx: ctx
+      )
+      |> MLIR.to_string()
+
+    assert full =~ ~s{chip = "gfx90a"}
+    assert full =~ ~s{triple = "amdgcn-amd-amdhsa-pal"}
+    assert full =~ ~s{features = "+wavefrontsize64"}
+    assert full =~ "O = 3"
+    assert full =~ ~s{abi = "500"}
+  end
+
   test "package_binary! produces a gpu.binary with one object per target", %{ctx: ctx} do
     module =
       File.read!("test/gpu-to-cubin.mlir")
@@ -38,6 +60,25 @@ defmodule GPUBinaryTest do
     assert ir =~ "gpu.binary @other_func_kernel"
     assert ir =~ ~s{#gpu.object<#nvvm.target<chip = "sm_80">}
     assert ir =~ ".entry other_func_kernel"
+    refute ir =~ "gpu.module"
+  end
+
+  test "package_binary! produces a rocdl gpu.binary with amdgcn assembly", %{ctx: ctx} do
+    module =
+      File.read!("test/gpu-to-cubin.mlir")
+      |> MLIR.Module.create!(ctx: ctx)
+
+    target = GPU.rocdl_target_attribute(chip: "gfx90a", ctx: ctx)
+
+    ir =
+      module
+      |> GPU.package_binary!(target, format: :isa)
+      |> MLIR.to_string()
+
+    assert ir =~ "gpu.binary @other_func_kernel"
+    assert ir =~ ~s{#gpu.object<#rocdl.target<chip = "gfx90a">}
+    assert ir =~ "amdgcn_target"
+    assert ir =~ "s_endpgm"
     refute ir =~ "gpu.module"
   end
 
@@ -58,6 +99,25 @@ defmodule GPUBinaryTest do
 
     assert ir =~ ~s{#gpu.object<#nvvm.target<chip = "sm_80">}
     assert ir =~ ~s{#gpu.object<#nvvm.target<chip = "sm_90">}
+  end
+
+  test "package_binary! packages multiple rocdl targets into one binary", %{ctx: ctx} do
+    module =
+      File.read!("test/gpu-to-cubin.mlir")
+      |> MLIR.Module.create!(ctx: ctx)
+
+    targets = [
+      GPU.rocdl_target_attribute(chip: "gfx90a", ctx: ctx),
+      GPU.rocdl_target_attribute(chip: "gfx90c", ctx: ctx)
+    ]
+
+    ir =
+      module
+      |> GPU.package_binary!(targets, format: :isa)
+      |> MLIR.to_string()
+
+    assert ir =~ ~s{#gpu.object<#rocdl.target<chip = "gfx90a">}
+    assert ir =~ ~s{#gpu.object<#rocdl.target<chip = "gfx90c">}
   end
 
   test "package_binary! accepts a standalone gpu.module", %{ctx: ctx} do
@@ -82,5 +142,41 @@ defmodule GPUBinaryTest do
 
     assert ir =~ "gpu.binary @kernels"
     assert ir =~ ~s{#gpu.object<#nvvm.target<chip = "sm_80">}
+  end
+
+  test "package_binary! accepts a standalone rocdl gpu.module", %{ctx: ctx} do
+    module =
+      MLIR.Module.create!(
+        """
+        gpu.module @kernels {
+          gpu.func @foo() {
+            gpu.return
+          }
+        }
+        """,
+        ctx: ctx
+      )
+
+    target = GPU.rocdl_target_attribute(chip: "gfx90a", ctx: ctx)
+
+    ir =
+      module
+      |> GPU.package_binary!(target, format: :isa)
+      |> MLIR.to_string()
+
+    assert ir =~ "gpu.binary @kernels"
+    assert ir =~ ~s{#gpu.object<#rocdl.target<chip = "gfx90a">}
+  end
+
+  test "package_binary! rejects unsupported target attributes", %{ctx: ctx} do
+    module =
+      File.read!("test/gpu-to-cubin.mlir")
+      |> MLIR.Module.create!(ctx: ctx)
+
+    target = MLIR.Attribute.integer(MLIR.Type.i32(ctx: ctx), 1)
+
+    assert_raise ArgumentError, ~r/unsupported GPU target attribute dialect/, fn ->
+      GPU.package_binary!(module, target)
+    end
   end
 end


### PR DESCRIPTION
Completes the ROCDL side of #459 / #533.

## What

- `Beaver.MLIR.Dialect.GPU.rocdl_target_attribute/1` constructs an `#rocdl.target` attribute from Elixir data (`:chip`, `:triple`, `:features`, `:opt`, `:abi`), mirroring `nvvm_target_attribute/1`.
- `package_binary!/3` now selects the lowering pass from the target dialect: `#nvvm.target` → `convert-gpu-to-nvvm`, `#rocdl.target` → `convert-gpu-to-rocdl`, and unsupported target attributes raise with a clear error.
- New CPU-only tests in `gpu_binary_test.exs`: attribute construction (including non-default `triple`/`abi`), single- and multi-target ROCDL packaging, standalone `gpu.module` inputs, and rejection of non-GPU target attributes.

## No hardware required

`format: :isa` for ROCDL emits AMDGCN assembly through the LLVM AMDGPU backend bundled with the MLIR prebuilt — verified output contains `.amdgcn_target`/GCN instructions like `s_endpgm`. Everything runs on CPU in CI; no AMD GPU or ROCm toolchain is needed.

## Acceptance criteria (#533)

- [x] A Beaver API constructs NVVM and ROCDL target configurations.
- [x] A module can produce a `gpu.binary` with multiple target objects (NVVM and ROCDL).
- [x] CI validates target IR on non-GPU runners (extended `gpu_binary_test.exs` CPU-only coverage).

Closes #533.