### PR TITLE
Fix CUDA pointer encoding on 64-bit platforms

### DIFF
--- a/native/src/cuda_runner.zig
+++ b/native/src/cuda_runner.zig
@@ -21,6 +21,14 @@ const mutex = @import("mutex.zig");
 const CudaResult = c_int;
 const CuDevice = *anyopaque;
 
+/// Encodes an opaque pointer (CUDA module/function/device handles) as a BEAM
+/// unsigned 64-bit integer. `beam.make(usize, ...)` is unsuitable here because
+/// it routes through `enif_make_int`, which truncates to 32 bits on 64-bit
+/// platforms.
+fn make_ptr(env: beam.env, ptr: usize) beam.term {
+    return e.enif_make_uint64(env, @intCast(ptr));
+}
+
 const cuInitFn = *const fn (flags: c_uint) callconv(.c) CudaResult;
 const cuDeviceGetCountFn = *const fn (count: *c_int) callconv(.c) CudaResult;
 const cuDeviceGetFn = *const fn (device: *CuDevice, ordinal: c_int) callconv(.c) CudaResult;
@@ -224,7 +232,7 @@ pub fn cuda_module_load(env: beam.env, _: c_int, args: [*c]const beam.term) !bea
     var cu_module: ?*anyopaque = null;
     const result = d.cuModuleLoadData(&cu_module, ptx.ptr);
     if (result != 0) return cuResultError(env, "cuModuleLoadData", result);
-    return beam.make_ok_term(env, try beam.make(usize, env, @intFromPtr(cu_module.?)));
+    return beam.make_ok_term(env, make_ptr(env, @intFromPtr(cu_module.?)));
 }
 
 /// Returns `{:ok, function_handle}` for the kernel `name` in `module_handle`.
@@ -249,7 +257,7 @@ pub fn cuda_module_get_function(env: beam.env, _: c_int, args: [*c]const beam.te
         @ptrCast(name.ptr),
     );
     if (result != 0) return cuResultError(env, "cuModuleGetFunction", result);
-    return beam.make_ok_term(env, try beam.make(usize, env, @intFromPtr(function.?)));
+    return beam.make_ok_term(env, make_ptr(env, @intFromPtr(function.?)));
 }
 
 /// Unloads a CUDA module handle.
@@ -274,7 +282,7 @@ pub fn cuda_mem_alloc(env: beam.env, _: c_int, args: [*c]const beam.term) !beam.
     var ptr: usize = 0;
     const result = d.cuMemAlloc(&ptr, size);
     if (result != 0) return cuResultError(env, "cuMemAlloc", result);
-    return beam.make_ok_term(env, try beam.make(usize, env, ptr));
+    return beam.make_ok_term(env, make_ptr(env, ptr));
 }
 
 /// Frees a device allocation.


### PR DESCRIPTION
## Summary

Fix a 64-bit pointer truncation bug in the Zig CUDA runner (`native/src/cuda_runner.zig`).

CUDA module/function/device handles are opaque pointers. They were returned to the BEAM through `beam.make(usize, ...)`, which routes through `enif_make_int` — a 32-bit conversion. On 64-bit platforms the high bits are silently dropped and the NIF panics (`integer does not fit in destination type`).

All three pointer-returning entry points (`cuda_module_load`, `cuda_module_get_function`, `cuda_mem_alloc`) now encode handles with `enif_make_uint64`.

## Why

The bug only surfaces on machines with a real CUDA driver, which is why it survived until the first real-GPU run (RTX 5070, CUDA 13.1) during Shadow Wavefront validation. Without this fix the Zig runner cannot load a `gpu.binary` module or launch a kernel at all.

## Validation

- `mix compile --warnings-as-errors`
- `mix test test/cuda_runner_test.exs` — device discovery passes on RTX 5070
- The full launch path (module load → function lookup → `cuLaunchKernel`) was verified with this fix in the Shadow Wavefront GPU evaluator work.