### PR TITLE
ci: use local checkout as docker build context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,6 +280,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
+          context: workflow-source
           push: ${{ secrets.DOCKERHUB_TOKEN != '' }}
           tags: ${{ vars.DOCKERHUB_USERNAME }}/beaver-livebook-${{ matrix.image.suffix }}:latest
           cache-from: type=registry,ref=${{ vars.DOCKERHUB_USERNAME }}/beaver-livebook-${{ matrix.image.suffix }}:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,7 +287,7 @@ jobs:
           cache-to: type=inline
           platforms: |
             ${{ matrix.image.platform }}
-          file: docker/livebook.dockerfile
+          file: workflow-source/docker/livebook.dockerfile
           build-args: |
             LLVM_EUDSL_ASSET_NAME=${{ steps.llvm.outputs.LLVM_PREBUILT_ASSET_NAME }}
             ZIG_URL=${{ matrix.image.zig }}


### PR DESCRIPTION
## Problem

Docker build jobs (amd64/arm64) in the `Build precompiled NIFs` workflow fail with:

```
ERROR: failed to build: failed to stat policy file docker/livebook.dockerfile.rego: failed to load cache key: repository does not contain ref refs/pull/539/merge
```

`docker/build-push-action` defaults to the **git context** (`https://github.com/<owner>/<repo>.git#<ref>`) when no `context` input is given. For `pull_request` events the ref is `refs/pull/<n>/merge`, which GitHub deletes as soon as the PR is merged. When a run starts right as the PR is being merged (e.g. a stacked-merge triggered synchronize event), buildx re-fetches the ref at build time and fails because it no longer exists.

## Fix

Point the build at the already-checked-out `workflow-source` directory instead of letting the action re-fetch from the git ref:

```yaml
context: workflow-source
```

The job already checks out the repo there, so the Dockerfile and `scripts/` files resolve against local files and the build no longer depends on the transient `refs/pull/<n>/merge` ref.

## Verification

- YAML parses cleanly
- `file: docker/livebook.dockerfile` stays relative to the new context
- Dockerfile `COPY ./scripts/...` paths resolve under `workflow-source/`