### PR TITLE
shadow: Triton attention fixture and CPU-only corpus baselines

### DIFF
--- a/lib/beaver/shadow/corpus.ex
+++ b/lib/beaver/shadow/corpus.ex
@@ -1,0 +1,68 @@
+defmodule Beaver.Shadow.Corpus do
+  @moduledoc """
+  The TTGIR/TTIR corpus that drives Shadow Wavefront measurements.
+
+  Each entry pins a fixture file plus the structural facts observed on the
+  pinned Triton prebuilt (LLVM revision recorded by
+  `Beaver.MLIR.Experiment` receipts at run time). `baseline`/`optimized` are
+  the `ttg.convert_layout` counts before and after
+  `tritongpu-remove-layout-conversions`; asserting them makes the CPU-only
+  baseline receipts reproducible across runs and revisions.
+
+  `:matmul` and `:attention` are TTIR kernels that lower through the full
+  NVIDIA pipeline. `:remat` is an already-lowered TTGIR slice (a backward
+  pass with `scf.for` + remat-style `ttg.convert_layout`s) used as the
+  regression probe for triton-lang/triton#11026; it is audited in place
+  because the pinned prebuilt cannot lower it to LLVM (see the probe task).
+  """
+
+  @fixtures [
+    %{
+      name: :matmul,
+      file: "ttgir_matmul.mlir",
+      dialect: :ttir,
+      baseline: 24,
+      optimized: 5,
+      lowered_to_llvm: true
+    },
+    %{
+      name: :attention,
+      file: "ttir_attention.mlir",
+      dialect: :ttir,
+      baseline: 34,
+      optimized: 5,
+      lowered_to_llvm: true
+    },
+    %{
+      name: :remat,
+      file: "ttgir_convert_layout.mlir",
+      dialect: :ttgir,
+      baseline: 4,
+      optimized: 1,
+      lowered_to_llvm: false
+    }
+  ]
+
+  @type fixture() :: %{
+          name: atom(),
+          file: String.t(),
+          dialect: :ttir | :ttgir,
+          baseline: non_neg_integer(),
+          optimized: non_neg_integer(),
+          lowered_to_llvm: boolean()
+        }
+
+  @spec fixtures() :: [fixture()]
+  def fixtures, do: @fixtures
+
+  @spec fixture(atom()) :: fixture()
+  def fixture(name) when is_atom(name) do
+    Enum.find(@fixtures, &(&1.name == name)) ||
+      raise ArgumentError, "unknown corpus fixture: #{inspect(name)}"
+  end
+
+  @spec fixture_path(atom()) :: Path.t()
+  def fixture_path(name) do
+    Path.expand("fixtures/triton/#{fixture(name).file}", "test")
+  end
+end

--- a/test/fixtures/triton/ttir_attention.mlir
+++ b/test/fixtures/triton/ttir_attention.mlir
@@ -1,0 +1,100 @@
+// Generated from the flash-attention-style forward kernel in
+// triton-lang/triton python frontend 3.4.0
+// (N_CTX=64, BLOCK_M=BLOCK_N=64, HEAD_DIM=64, num_warps=4, target sm_80).
+// The kernel keeps online-softmax accumulators (m_i/l_i) as scf.for
+// iter_args and uses tt.dot for the QK^T and PV matmuls, so lowering
+// produces a realistic mix of layout conversions inside the loop.
+//
+// RUN: triton-opt %s -convert-triton-to-tritongpu=target=cuda:80 -tritongpu-remove-layout-conversions -canonicalize | FileCheck %s
+module {
+  tt.func public @attn_fwd(%arg0: !tt.ptr<f32> , %arg1: !tt.ptr<f32> , %arg2: !tt.ptr<f32> , %arg3: f32 , %arg4: !tt.ptr<f32> , %arg5: i32 , %arg6: i32 , %arg7: i32 , %arg8: i32 , %arg9: i32 , %arg10: i32 , %arg11: i32 , %arg12: i32 , %arg13: i32 , %arg14: i32 , %arg15: i32 , %arg16: i32 , %arg17: i32 , %arg18: i32 , %arg19: i32 , %arg20: i32 ) attributes {noinline = false} {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x1xf32> 
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<64x64xf32> 
+    %cst_1 = arith.constant dense<1.000000e+00> : tensor<64xf32> 
+    %cst_2 = arith.constant dense<0.000000e+00> : tensor<64xf32> 
+    %cst_3 = arith.constant dense<0xFF800000> : tensor<64xf32> 
+    %c64_i32 = arith.constant 64 : i32 
+    %0 = tt.get_program_id x : i32 
+    %1 = arith.muli %0, %c64_i32 : i32 
+    %2 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32> 
+    %3 = tt.splat %1 : i32 -> tensor<64xi32> 
+    %4 = arith.addi %3, %2 : tensor<64xi32> 
+    %5 = tt.expand_dims %4 {axis = 1 : i32} : tensor<64xi32> -> tensor<64x1xi32> 
+    %6 = tt.splat %arg7 : i32 -> tensor<64x1xi32> 
+    %7 = arith.muli %5, %6 : tensor<64x1xi32> 
+    %8 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<64x1x!tt.ptr<f32>> 
+    %9 = tt.addptr %8, %7 : tensor<64x1x!tt.ptr<f32>>, tensor<64x1xi32> 
+    %10 = tt.expand_dims %2 {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32> 
+    %11 = tt.splat %arg8 : i32 -> tensor<1x64xi32> 
+    %12 = arith.muli %10, %11 : tensor<1x64xi32> 
+    %13 = tt.broadcast %9 : tensor<64x1x!tt.ptr<f32>> -> tensor<64x64x!tt.ptr<f32>> 
+    %14 = tt.broadcast %12 : tensor<1x64xi32> -> tensor<64x64xi32> 
+    %15 = tt.addptr %13, %14 : tensor<64x64x!tt.ptr<f32>>, tensor<64x64xi32> 
+    %16 = tt.load %15 : tensor<64x64x!tt.ptr<f32>> 
+    %17 = tt.splat %arg11 : i32 -> tensor<1x64xi32> 
+    %18 = arith.muli %10, %17 : tensor<1x64xi32> 
+    %19 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<1x64x!tt.ptr<f32>> 
+    %20 = tt.addptr %19, %18 : tensor<1x64x!tt.ptr<f32>>, tensor<1x64xi32> 
+    %21 = tt.expand_dims %2 {axis = 1 : i32} : tensor<64xi32> -> tensor<64x1xi32> 
+    %22 = tt.splat %arg12 : i32 -> tensor<64x1xi32> 
+    %23 = arith.muli %21, %22 : tensor<64x1xi32> 
+    %24 = tt.broadcast %20 : tensor<1x64x!tt.ptr<f32>> -> tensor<64x64x!tt.ptr<f32>> 
+    %25 = tt.broadcast %23 : tensor<64x1xi32> -> tensor<64x64xi32> 
+    %26 = tt.addptr %24, %25 : tensor<64x64x!tt.ptr<f32>>, tensor<64x64xi32> 
+    %27 = tt.splat %arg15 : i32 -> tensor<64x1xi32> 
+    %28 = arith.muli %21, %27 : tensor<64x1xi32> 
+    %29 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<64x1x!tt.ptr<f32>> 
+    %30 = tt.addptr %29, %28 : tensor<64x1x!tt.ptr<f32>>, tensor<64x1xi32> 
+    %31 = tt.splat %arg16 : i32 -> tensor<1x64xi32> 
+    %32 = arith.muli %10, %31 : tensor<1x64xi32> 
+    %33 = tt.broadcast %30 : tensor<64x1x!tt.ptr<f32>> -> tensor<64x64x!tt.ptr<f32>> 
+    %34 = tt.broadcast %32 : tensor<1x64xi32> -> tensor<64x64xi32> 
+    %35 = tt.addptr %33, %34 : tensor<64x64x!tt.ptr<f32>>, tensor<64x64xi32> 
+    %36 = tt.load %26 : tensor<64x64x!tt.ptr<f32>> 
+    %37 = tt.dot %16, %36, %cst_0, inputPrecision = tf32 : tensor<64x64xf32> * tensor<64x64xf32> -> tensor<64x64xf32> 
+    %38 = tt.splat %arg3 : f32 -> tensor<64x64xf32> 
+    %39 = arith.mulf %37, %38 : tensor<64x64xf32> 
+    %40 = "tt.reduce"(%39) <{axis = 1 : i32}> ({
+    ^bb0(%arg21: f32 , %arg22: f32 ):
+      %72 = arith.maxnumf %arg21, %arg22 : f32 
+      tt.reduce.return %72 : f32 
+    }) : (tensor<64x64xf32>) -> tensor<64xf32> 
+    %41 = arith.maxnumf %40, %cst_3 : tensor<64xf32> 
+    %42 = tt.expand_dims %41 {axis = 1 : i32} : tensor<64xf32> -> tensor<64x1xf32> 
+    %43 = tt.broadcast %42 : tensor<64x1xf32> -> tensor<64x64xf32> 
+    %44 = arith.subf %39, %43 : tensor<64x64xf32> 
+    %45 = math.exp %44 : tensor<64x64xf32> 
+    %46 = "tt.reduce"(%45) <{axis = 1 : i32}> ({
+    ^bb0(%arg21: f32 , %arg22: f32 ):
+      %72 = arith.addf %arg21, %arg22 : f32 
+      tt.reduce.return %72 : f32 
+    }) : (tensor<64x64xf32>) -> tensor<64xf32> 
+    %47 = arith.subf %cst_3, %41 : tensor<64xf32> 
+    %48 = math.exp %47 : tensor<64xf32> 
+    %49 = arith.mulf %48, %cst_2 : tensor<64xf32> 
+    %50 = arith.addf %49, %46 : tensor<64xf32> 
+    %51 = tt.expand_dims %48 {axis = 1 : i32} : tensor<64xf32> -> tensor<64x1xf32> 
+    %52 = arith.mulf %51, %cst : tensor<64x1xf32> 
+    %53 = tt.broadcast %52 : tensor<64x1xf32> -> tensor<64x64xf32> 
+    %54 = tt.load %35 : tensor<64x64x!tt.ptr<f32>> 
+    %55 = tt.dot %45, %54, %53, inputPrecision = tf32 : tensor<64x64xf32> * tensor<64x64xf32> -> tensor<64x64xf32> 
+    %56 = arith.cmpf oeq, %41, %cst_3 : tensor<64xf32> 
+    %57 = arith.select %56, %cst_2, %41 : tensor<64xi1>, tensor<64xf32> 
+    %58 = arith.cmpf oeq, %57, %cst_2 : tensor<64xf32> 
+    %59 = arith.select %58, %cst_1, %50 : tensor<64xi1>, tensor<64xf32> 
+    %60 = tt.expand_dims %59 {axis = 1 : i32} : tensor<64xf32> -> tensor<64x1xf32> 
+    %61 = tt.broadcast %60 : tensor<64x1xf32> -> tensor<64x64xf32> 
+    %62 = arith.divf %55, %61 : tensor<64x64xf32> 
+    %63 = tt.splat %arg19 : i32 -> tensor<64x1xi32> 
+    %64 = arith.muli %21, %63 : tensor<64x1xi32> 
+    %65 = tt.splat %arg4 : !tt.ptr<f32> -> tensor<64x1x!tt.ptr<f32>> 
+    %66 = tt.addptr %65, %64 : tensor<64x1x!tt.ptr<f32>>, tensor<64x1xi32> 
+    %67 = tt.splat %arg20 : i32 -> tensor<1x64xi32> 
+    %68 = arith.muli %10, %67 : tensor<1x64xi32> 
+    %69 = tt.broadcast %66 : tensor<64x1x!tt.ptr<f32>> -> tensor<64x64x!tt.ptr<f32>> 
+    %70 = tt.broadcast %68 : tensor<1x64xi32> -> tensor<64x64xi32> 
+    %71 = tt.addptr %69, %70 : tensor<64x64x!tt.ptr<f32>>, tensor<64x64xi32> 
+    tt.store %71, %62 : tensor<64x64x!tt.ptr<f32>> 
+    tt.return 
+  } 
+} 

--- a/test/shadow_corpus_test.exs
+++ b/test/shadow_corpus_test.exs
@@ -1,0 +1,68 @@
+defmodule Beaver.Shadow.CorpusTest do
+  use ExUnit.Case, async: true
+
+  alias Beaver.MLIR
+  alias Beaver.MLIR.Triton.LayoutAudit
+  alias Beaver.Shadow.Corpus
+  alias Beaver.Shadow.OptimizationTrial
+
+  @triton_enabled System.get_env("BEAVER_TRITON_PREBUILT_DIR") != nil
+
+  describe "fixture entries" do
+    test "all fixtures are committed" do
+      for fixture <- Corpus.fixtures() do
+        assert File.exists?(Corpus.fixture_path(fixture.name)),
+               "missing fixture #{fixture.file}"
+      end
+    end
+
+    test "attention fixture contains the flash-attention pattern" do
+      source = File.read!(Corpus.fixture_path(:attention))
+      assert source =~ "tt.func public @attn_fwd"
+      assert source =~ "tt.dot"
+      assert source =~ "scf.for"
+      assert source =~ "tt.reduce"
+    end
+  end
+
+  @tag :triton
+  @tag skip: !@triton_enabled
+  test "TTIR fixtures reproduce the recorded baseline and optimized counts" do
+    context = MLIR.Context.create(all_dialects: false)
+    on_exit(fn -> MLIR.Context.destroy(context) end)
+    Beaver.Triton.register(context)
+
+    for fixture <- Corpus.fixtures(), fixture.dialect == :ttir do
+      module = MLIR.Module.create!(File.read!(Corpus.fixture_path(fixture.name)), ctx: context)
+      on_exit(fn -> MLIR.Module.destroy(module) end)
+
+      result = OptimizationTrial.run(module)
+
+      assert result.baseline == fixture.baseline, "baseline for #{fixture.name}"
+      assert result.optimized == fixture.optimized, "optimized for #{fixture.name}"
+      assert result.reduced
+      assert result.lowered_to_llvm == fixture.lowered_to_llvm
+    end
+  end
+
+  @tag :triton
+  @tag skip: !@triton_enabled
+  test "remat fixture audits to the recorded counts" do
+    context = MLIR.Context.create(all_dialects: false)
+    on_exit(fn -> MLIR.Context.destroy(context) end)
+    Beaver.Triton.register(context)
+
+    fixture = Corpus.fixture(:remat)
+    module = MLIR.Module.create!(File.read!(Corpus.fixture_path(:remat)), ctx: context)
+    on_exit(fn -> MLIR.Module.destroy(module) end)
+
+    assert LayoutAudit.audit(module).operation_count == fixture.baseline
+
+    optimized =
+      module
+      |> Beaver.Composer.append("tritongpu-remove-layout-conversions")
+      |> Beaver.Composer.run!()
+
+    assert LayoutAudit.audit(optimized).operation_count == fixture.optimized
+  end
+end


### PR DESCRIPTION
Forgejo #20 slice 1.

- Adds `test/fixtures/triton/ttir_attention.mlir`: flash-attention-style TTIR generated from the Triton 3.4.0 python frontend (online-softmax accumulators as scf.for iter_args, tt.dot for QK^T and PV).
- Adds `Beaver.Shadow.Corpus`: pinned fixture facts (dialect, baseline/optimized ttg.convert_layout counts, lowering capability).
- Corpus test pins the CPU-only counts on the Triton prebuilt lane: matmul 24->5, attention 34->5, remat (TTGIR) 4->1.