### PR TITLE
shadow: mix shadow.report for paste-ready measurement evidence

### DIFF
--- a/lib/beaver/shadow/report.ex
+++ b/lib/beaver/shadow/report.ex
@@ -1,0 +1,172 @@
+defmodule Beaver.Shadow.Report do
+  @moduledoc """
+  Gathers Shadow Wavefront measurement facts for the Triton corpus and renders
+  them as Markdown ready to paste into upstream issues or pull requests.
+
+  TTIR fixtures are measured through `Beaver.Shadow.OptimizationTrial`
+  (baseline/optimized `ttg.convert_layout` counts and whether they lower to
+  LLVM). TTGIR fixtures are audited in place and probed through
+  `Beaver.Shadow.Probe`, so a pinned-prebuilt crash shows up as a failure
+  receipt with the offending pass.
+  """
+
+  alias Beaver.MLIR
+  alias Beaver.MLIR.Triton.LayoutAudit
+  alias Beaver.Shadow.{Corpus, OptimizationTrial, Probe}
+
+  defstruct [:generated_at, :llvm_revision, :prebuilt_dir, :fixtures]
+
+  @type fixture_measure() :: %{
+          name: atom(),
+          dialect: :ttir | :ttgir,
+          baseline: non_neg_integer(),
+          optimized: non_neg_integer(),
+          lowered_to_llvm: boolean() | nil,
+          probe: Probe.Result.t() | nil
+        }
+
+  @type t() :: %__MODULE__{
+          generated_at: DateTime.t(),
+          llvm_revision: String.t() | nil,
+          prebuilt_dir: String.t() | nil,
+          fixtures: [fixture_measure()]
+        }
+
+  @doc """
+  Measures every corpus fixture and returns the collected facts.
+
+  Requires a Triton-enabled native build (`BEAVER_TRITON_PREBUILT_DIR`).
+  """
+  @spec generate() :: t()
+  def generate do
+    %__MODULE__{
+      generated_at: DateTime.utc_now(),
+      llvm_revision: llvm_revision(),
+      prebuilt_dir: System.get_env("BEAVER_TRITON_PREBUILT_DIR"),
+      fixtures: Enum.map(Corpus.fixtures(), &measure/1)
+    }
+  end
+
+  @doc "Renders the collected facts as a Markdown report."
+  @spec render(t()) :: String.t()
+  def render(%__MODULE__{} = report) do
+    """
+    ## Shadow Wavefront: Triton layout measurement
+
+    - generated at: #{DateTime.to_iso8601(report.generated_at)}
+    - llvm revision: #{report.llvm_revision || "unknown"}
+    - triton prebuilt dir: `#{report.prebuilt_dir || "unset"}`
+
+    | fixture | dialect | baseline convert_layouts | optimized | reduction | lowers to LLVM | probe |
+    |---|---|---|---|---|---|---|
+    #{Enum.map_join(report.fixtures, "\n", &row/1)}
+    """
+    |> String.trim_trailing()
+    |> Kernel.<>("\n")
+  end
+
+  defp row(fixture) do
+    reduction =
+      case {fixture.baseline, fixture.optimized} do
+        {baseline, optimized} when baseline > 0 -> "-#{baseline - optimized}"
+        _ -> "-"
+      end
+
+    lowered =
+      case fixture.lowered_to_llvm do
+        true -> "yes"
+        false -> "no"
+        nil -> "-"
+      end
+
+    probe =
+      case fixture.probe do
+        %Probe.Result{status: :crash} = probe ->
+          "crash (exit #{probe.exit_code}) at `#{probe.detail.last_pass}`"
+
+        %Probe.Result{status: :ok} ->
+          "ok"
+
+        %Probe.Result{status: :error, detail: message} ->
+          "error: `#{message}`"
+
+        nil ->
+          "-"
+      end
+
+    "| #{fixture.name} | #{fixture.dialect} | #{fixture.baseline} | #{fixture.optimized} | " <>
+      "#{reduction} | #{lowered} | #{probe} |"
+  end
+
+  defp measure(%{dialect: :ttir} = fixture) do
+    context = MLIR.Context.create(all_dialects: false)
+
+    result =
+      try do
+        Beaver.Triton.register(context)
+
+        module = MLIR.Module.create!(File.read!(Corpus.fixture_path(fixture.name)), ctx: context)
+        trial = OptimizationTrial.run(module)
+
+        %{
+          name: fixture.name,
+          dialect: :ttir,
+          baseline: trial.baseline,
+          optimized: trial.optimized,
+          lowered_to_llvm: trial.lowered_to_llvm,
+          probe: nil
+        }
+      after
+        MLIR.Context.destroy(context)
+      end
+
+    result
+  end
+
+  defp measure(%{dialect: :ttgir} = fixture) do
+    context = MLIR.Context.create(all_dialects: false)
+
+    counts =
+      try do
+        Beaver.Triton.register(context)
+
+        module = MLIR.Module.create!(File.read!(Corpus.fixture_path(fixture.name)), ctx: context)
+        baseline = LayoutAudit.audit(module).operation_count
+
+        optimized =
+          module
+          |> Beaver.Composer.append("tritongpu-remove-layout-conversions")
+          |> Beaver.Composer.run!()
+          |> LayoutAudit.audit()
+          |> Map.fetch!(:operation_count)
+
+        {baseline, optimized}
+      after
+        MLIR.Context.destroy(context)
+      end
+
+    {baseline, optimized} = counts
+
+    %{
+      name: fixture.name,
+      dialect: :ttgir,
+      baseline: baseline,
+      optimized: optimized,
+      lowered_to_llvm: false,
+      probe: Probe.run(fixture.name)
+    }
+  end
+
+  defp llvm_revision do
+    case System.get_env("LLVM_CONFIG_PATH") do
+      nil ->
+        nil
+
+      llvm_config ->
+        case System.cmd(llvm_config, ["--version"], stderr_to_stdout: true) do
+          {output, 0} -> output |> String.split("\n") |> hd()
+          _ -> nil
+        end
+    end
+  end
+end

--- a/lib/beaver/shadow/report.ex
+++ b/lib/beaver/shadow/report.ex
@@ -80,23 +80,21 @@ defmodule Beaver.Shadow.Report do
       end
 
     probe =
-      case fixture.probe do
-        %Probe.Result{status: :crash} = probe ->
-          "crash (exit #{probe.exit_code}) at `#{probe.detail.last_pass}`"
-
-        %Probe.Result{status: :ok} ->
-          "ok"
-
-        %Probe.Result{status: :error, detail: message} ->
-          "error: `#{message}`"
-
-        nil ->
-          "-"
-      end
+      probe_text(fixture.probe)
 
     "| #{fixture.name} | #{fixture.dialect} | #{fixture.baseline} | #{fixture.optimized} | " <>
       "#{reduction} | #{lowered} | #{probe} |"
   end
+
+  defp probe_text(%Probe.Result{status: :crash} = probe) do
+    "crash (exit #{probe.exit_code}) at `#{probe.detail.last_pass}`"
+  end
+
+  defp probe_text(%Probe.Result{status: :ok}), do: "ok"
+
+  defp probe_text(%Probe.Result{status: :error, detail: message}), do: "error: `#{message}`"
+
+  defp probe_text(nil), do: "-"
 
   defp measure(%{dialect: :ttir} = fixture) do
     context = MLIR.Context.create(all_dialects: false)

--- a/lib/mix/tasks/shadow.report.ex
+++ b/lib/mix/tasks/shadow.report.ex
@@ -1,0 +1,20 @@
+defmodule Mix.Tasks.Shadow.Report do
+  use Mix.Task
+
+  @shortdoc "Emits a Shadow Wavefront Triton measurement report as Markdown"
+
+  @moduledoc """
+  Measures the Triton corpus and prints a Markdown report that can be pasted
+  into upstream issues or pull requests.
+
+      $ mix shadow.report
+
+  Requires a Triton-enabled native build (`BEAVER_TRITON_PREBUILT_DIR` set).
+  """
+
+  @impl true
+  def run(_args) do
+    Mix.Task.run("app.start")
+    Beaver.Shadow.Report.generate() |> Beaver.Shadow.Report.render() |> IO.puts()
+  end
+end

--- a/test/shadow_report_test.exs
+++ b/test/shadow_report_test.exs
@@ -1,0 +1,74 @@
+defmodule Beaver.Shadow.ReportTest do
+  use ExUnit.Case, async: true
+
+  alias Beaver.Shadow.Probe.Result
+  alias Beaver.Shadow.Report
+
+  @triton_enabled System.get_env("BEAVER_TRITON_PREBUILT_DIR") != nil
+
+  describe "render/1" do
+    test "renders a markdown table from collected facts" do
+      report = %Report{
+        generated_at: ~U[2026-08-08 00:00:00Z],
+        llvm_revision: "LLVM version 20.1.0",
+        prebuilt_dir: "/tmp/prebuilt",
+        fixtures: [
+          %{
+            name: :matmul,
+            dialect: :ttir,
+            baseline: 24,
+            optimized: 5,
+            lowered_to_llvm: true,
+            probe: nil
+          },
+          %{
+            name: :remat,
+            dialect: :ttgir,
+            baseline: 4,
+            optimized: 1,
+            lowered_to_llvm: false,
+            probe: %Result{
+              fixture: :remat,
+              status: :crash,
+              exit_code: 139,
+              detail: %{last_pass: "tritongpu-accelerate-matmul"}
+            }
+          }
+        ]
+      }
+
+      rendered = Report.render(report)
+
+      assert rendered =~ "| matmul | ttir | 24 | 5 | -19 | yes | - |"
+
+      assert rendered =~
+               "| remat | ttgir | 4 | 1 | -3 | no | crash (exit 139) at `tritongpu-accelerate-matmul` |"
+
+      assert rendered =~ "llvm revision: LLVM version 20.1.0"
+      assert rendered =~ "triton prebuilt dir: `/tmp/prebuilt`"
+    end
+  end
+
+  @tag :triton
+  @tag skip: !@triton_enabled
+  test "generate/0 measures the whole corpus" do
+    report = Report.generate()
+
+    assert is_binary(report.llvm_revision) and report.llvm_revision != ""
+    assert length(report.fixtures) == 3
+
+    matmul = Enum.find(report.fixtures, &(&1.name == :matmul))
+    assert matmul.baseline == 24
+    assert matmul.optimized == 5
+    assert matmul.lowered_to_llvm
+
+    attention = Enum.find(report.fixtures, &(&1.name == :attention))
+    assert attention.baseline == 34
+    assert attention.optimized == 5
+
+    remat = Enum.find(report.fixtures, &(&1.name == :remat))
+    assert remat.baseline == 4
+    assert remat.optimized == 1
+    assert remat.probe.status == :crash
+  end
+end


### PR DESCRIPTION
Forgejo #20 slice 4.

- `Beaver.Shadow.Report`: measures TTIR fixtures via OptimizationTrial and TTGIR fixtures via LayoutAudit + Probe, collecting LLVM revision and prebuilt facts.
- `mix shadow.report` prints a Markdown fixture table (baseline/optimized/reduction, lowering capability, probe status) ready to paste into upstream Triton issues.