### PR TITLE
shadow: tuning receipts and AutotuneListener-compatible events

### DIFF
--- a/lib/beaver/mlir/shadow/optimization_trial.ex
+++ b/lib/beaver/mlir/shadow/optimization_trial.ex
@@ -52,13 +52,16 @@ defmodule Beaver.Shadow.OptimizationTrial do
   @spec run(MLIR.Module.t(), keyword()) :: Result.t()
   def run(%MLIR.Module{} = module, opts \\ []) do
     target = Keyword.get(opts, :target, "cuda:80")
+    num_warps = Keyword.get(opts, :num_warps, 4)
     source_text = MLIR.to_string(module)
     context = MLIR.context(module)
     gpu? = Keyword.get(opts, :gpu, false)
 
     baseline =
       module
-      |> Beaver.Composer.append("convert-triton-to-tritongpu{target=#{target}}")
+      |> Beaver.Composer.append(
+        "convert-triton-to-tritongpu{target=#{target}, num-warps=#{num_warps}}"
+      )
       |> Beaver.Composer.run!()
 
     baseline_count = audit_count(baseline)

--- a/lib/beaver/mlir/triton.ex
+++ b/lib/beaver/mlir/triton.ex
@@ -63,12 +63,15 @@ defmodule Beaver.Triton do
   @spec compile_to_llvm(MLIR.Module.t(), keyword()) :: MLIR.Module.t()
   def compile_to_llvm(%MLIR.Module{} = module, opts \\ []) do
     target = Keyword.get(opts, :target, "cuda:80")
+    num_warps = Keyword.get(opts, :num_warps, 4)
     remove_layouts? = Keyword.get(opts, :remove_layout_conversions, true)
     from_ttgir? = Keyword.get(opts, :from_ttgir, false)
 
     ttgpu_pipeline =
       [
-        unless(from_ttgir?, do: "convert-triton-to-tritongpu{target=#{target}}"),
+        unless(from_ttgir?,
+          do: "convert-triton-to-tritongpu{target=#{target}, num-warps=#{num_warps}}"
+        ),
         "tritongpu-coalesce",
         "tritongpu-F32DotTC",
         "triton-nvidia-gpu-plan-cta",

--- a/lib/beaver/shadow/tuning.ex
+++ b/lib/beaver/shadow/tuning.ex
@@ -1,0 +1,370 @@
+defmodule Beaver.Shadow.Tuning do
+  @moduledoc """
+  Tuning receipts for Triton-style config spaces.
+
+  This is the Shadow Wavefront answer to the Triton autotuner
+  infrastructure gaps (triton-lang/triton#4020, #11174, vllm#37188,
+  pytorch#186886): an external reference schema that makes three things
+  first-class:
+
+  1. **decision/observation separation** — a tuning record's identity only
+     contains stable facts (kernel digest, target, config space digest,
+     config, winner); durations never enter it, which is the precondition for
+     portable, replayable cache keys;
+  2. **failure as data** — per-config failures are recorded structurally
+     (kind + reason), so a crashing config is evidence instead of a process
+     kill (see `Beaver.Shadow.Probe.probe_many/2` for the isolated execution);
+  3. **structural proxy auditability** — `ttg.convert_layout` counts and
+     lowering capability are standard record fields, so pruning decisions can
+     be audited and regressed without a GPU.
+
+  The record is deliberately CPU-only: `run/3` evaluates every config through
+  `Beaver.Shadow.OptimizationTrial` without launching kernels.
+  """
+
+  alias Beaver.MLIR
+  alias Beaver.Shadow.Corpus
+  alias Beaver.Shadow.OptimizationTrial
+
+  @format 1
+
+  defmodule Config do
+    @moduledoc "One tuning candidate, mirroring the stable parts of `triton.Config`."
+    @enforce_keys [:index, :num_warps]
+    defstruct [:index, :num_warps, :num_stages, :num_ctas]
+
+    @type t() :: %__MODULE__{
+            index: non_neg_integer(),
+            num_warps: pos_integer(),
+            num_stages: pos_integer() | nil,
+            num_ctas: pos_integer() | nil
+          }
+
+    @doc "Stable digest of one config (does not depend on observations)."
+    @spec digest(t()) :: String.t()
+    def digest(%__MODULE__{} = config) do
+      config
+      |> Map.from_struct()
+      |> :erlang.term_to_binary()
+      |> then(&:crypto.hash(:sha256, &1))
+      |> Base.encode16(case: :lower)
+    end
+  end
+
+  defmodule Record do
+    @moduledoc "One tuning evaluation: provenance + decision + observations."
+    @enforce_keys [:format, :kernel_digest, :config_space_digest, :config, :status]
+    defstruct [
+      :format,
+      :kernel_digest,
+      :target,
+      :capability,
+      :config_space_digest,
+      :config,
+      :status,
+      :failure,
+      :structural_proxy,
+      :timings
+    ]
+
+    @type t() :: %__MODULE__{
+            format: pos_integer(),
+            kernel_digest: String.t(),
+            target: String.t() | nil,
+            capability: term() | nil,
+            config_space_digest: String.t(),
+            config: Config.t(),
+            status: :evaluated | :failed,
+            failure: map() | nil,
+            structural_proxy: map() | nil,
+            timings: map() | nil
+          }
+  end
+
+  defmodule Run do
+    @moduledoc "One tuning pass over a config space."
+    @enforce_keys [:kernel_digest, :records, :winner]
+    defstruct [:kernel_digest, :records, :winner]
+
+    @type t() :: %__MODULE__{
+            kernel_digest: String.t(),
+            records: [Record.t()],
+            winner: Record.t() | nil
+          }
+  end
+
+  defmodule Event do
+    @moduledoc """
+    A JSON event isomorphic to triton's `AutotuneListener` protocol.
+
+    The six upstream fields (`fn`, `key`, `best_config`, `configs_timings`,
+    `duration`, `cache_hit`) map one-to-one; `structural_proxy` and `failure`
+    are the extensions the upstream protocol is missing.
+    """
+    @enforce_keys [:fn, :key, :best_config, :configs_timings, :cache_hit]
+    defstruct [
+      :fn,
+      :key,
+      :best_config,
+      :configs_timings,
+      :duration,
+      :cache_hit,
+      :structural_proxy,
+      :failure
+    ]
+
+    @type t() :: %__MODULE__{
+            fn: String.t(),
+            key: term(),
+            best_config: Config.t() | nil,
+            configs_timings: [{Config.t(), [non_neg_integer()]}],
+            duration: non_neg_integer() | nil,
+            cache_hit: boolean(),
+            structural_proxy: map() | nil,
+            failure: map() | nil
+          }
+  end
+
+  @doc "Current tuning record schema version."
+  def format, do: @format
+
+  @doc """
+  Runs a CPU-only tuning pass over `configs` for a corpus fixture.
+
+  Every config is evaluated through `OptimizationTrial` (baseline/optimized
+  `ttg.convert_layout` counts + lowering capability), recorded with its
+  config-space provenance, and the winner is picked by the structural proxy
+  (lowering capable first, then fewest optimized conversions). Durations are
+  observations and never enter `identity/1`.
+  """
+  @spec run(atom(), [Config.t()], keyword()) :: Run.t()
+  def run(fixture_name, configs, opts \\ []) when is_atom(fixture_name) do
+    fixture = Corpus.fixture(fixture_name)
+    target = Keyword.get(opts, :target, "cuda:80")
+    config_space_digest = configs_digest(configs)
+    kernel_digest = kernel_digest(fixture)
+
+    context = MLIR.Context.create(all_dialects: false)
+    on_exit = Keyword.get(opts, :on_exit)
+
+    records =
+      try do
+        Beaver.Triton.register(context)
+
+        Enum.map(configs, fn config ->
+          evaluate(fixture, config, context, target, config_space_digest, kernel_digest)
+        end)
+      after
+        MLIR.Context.destroy(context)
+        if is_function(on_exit), do: on_exit.()
+      end
+
+    %Run{kernel_digest: kernel_digest, records: records, winner: pick_winner(records)}
+  end
+
+  @doc "Stable identity of a tuning record; observations are excluded."
+  @spec identity(Record.t()) :: String.t()
+  def identity(%Record{} = record) do
+    record
+    |> stable_facts()
+    |> then(&:crypto.hash(:sha256, :erlang.term_to_binary(&1)))
+    |> Base.encode16(case: :lower)
+  end
+
+  @doc "The identity-bearing fields of a tuning record."
+  @spec stable_facts(Record.t()) :: map()
+  def stable_facts(%Record{} = record) do
+    %{
+      format: record.format,
+      kernel_digest: record.kernel_digest,
+      target: record.target,
+      capability: record.capability,
+      config_space_digest: record.config_space_digest,
+      config_index: record.config.index,
+      config_digest: Config.digest(record.config),
+      status: record.status,
+      failure_kind: if(record.failure, do: record.failure.kind, else: nil),
+      structural_proxy: record.structural_proxy
+    }
+  end
+
+  @doc "Stable digest of a config space (ordered, index-independent)."
+  @spec configs_digest([Config.t()]) :: String.t()
+  def configs_digest(configs) when is_list(configs) do
+    configs
+    |> Enum.map(&{&1.num_warps, &1.num_stages, &1.num_ctas})
+    |> :erlang.term_to_binary()
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.encode16(case: :lower)
+  end
+
+  @doc "Picks the winner by the structural proxy: lowering capable, fewest conversions."
+  @spec pick_winner([Record.t()]) :: Record.t() | nil
+  def pick_winner(records) do
+    records
+    |> Enum.filter(&(&1.status == :evaluated))
+    |> Enum.sort_by(fn record ->
+      proxy = record.structural_proxy
+      {not proxy.lowered_to_llvm, proxy.optimized}
+    end)
+    |> List.first()
+  end
+
+  @doc "Encodes a tuning run as JSON text."
+  @spec encode!(Run.t()) :: String.t()
+  def encode!(%Run{} = run) do
+    %{
+      "format" => @format,
+      "kernel_digest" => run.kernel_digest,
+      "records" => Enum.map(run.records, &record_to_map/1),
+      "winner_index" => if(run.winner, do: run.winner.config.index, else: nil)
+    }
+    |> JSON.encode!()
+  end
+
+  @doc "Decodes JSON text produced by `encode!/1`."
+  @spec decode!(String.t()) :: Run.t()
+  def decode!(json) when is_binary(json) do
+    map = JSON.decode!(json)
+
+    records =
+      Enum.map(map["records"], fn record_map ->
+        record_map
+        |> Map.new(fn
+          {"config", value} -> {:config, config_from_map(value)}
+          {"status", value} -> {:status, String.to_existing_atom(value)}
+          {key, value} -> {String.to_existing_atom(key), deep_atomize(value)}
+        end)
+        |> then(&struct!(Record, &1))
+      end)
+
+    winner =
+      Enum.find(records, &(&1.config.index == map["winner_index"]))
+
+    %Run{kernel_digest: map["kernel_digest"], records: records, winner: winner}
+  end
+
+  @doc "Builds an AutotuneListener-isomorphic event from a tuning run."
+  @spec event(Run.t(), keyword()) :: Event.t()
+  def event(%Run{} = run, opts \\ []) do
+    fn_name = Keyword.get(opts, :fn_name, "corpus_kernel")
+
+    %Event{
+      fn: fn_name,
+      key:
+        {run.kernel_digest, run.records |> List.first() |> then(&(&1 && &1.config_space_digest))},
+      best_config: if(run.winner, do: run.winner.config, else: nil),
+      configs_timings:
+        Enum.map(run.records, fn record ->
+          {record.config, if(record.timings, do: [record.timings.total_ns], else: [])}
+        end),
+      duration: total_duration(run.records),
+      cache_hit: false,
+      structural_proxy:
+        run.records
+        |> Enum.filter(& &1.structural_proxy)
+        |> Map.new(fn record -> {record.config.index, record.structural_proxy} end),
+      failure:
+        run.records
+        |> Enum.filter(&(&1.status == :failed))
+        |> Enum.map(fn record ->
+          %{config_index: record.config.index, failure: record.failure}
+        end)
+    }
+  end
+
+  defp evaluate(fixture, config, context, target, config_space_digest, kernel_digest) do
+    started = System.monotonic_time()
+
+    try do
+      module = MLIR.Module.create!(File.read!(Corpus.fixture_path(fixture.name)), ctx: context)
+
+      result =
+        OptimizationTrial.run(module,
+          target: target,
+          num_warps: config.num_warps,
+          gpu: false
+        )
+
+      proxy = %{
+        baseline: result.baseline,
+        optimized: result.optimized,
+        reduction: result.baseline - result.optimized,
+        lowered_to_llvm: result.lowered_to_llvm
+      }
+
+      %Record{
+        format: @format,
+        kernel_digest: kernel_digest,
+        target: target,
+        capability: nil,
+        config_space_digest: config_space_digest,
+        config: config,
+        status: if(result.lowered_to_llvm, do: :evaluated, else: :failed),
+        failure:
+          if(result.lowered_to_llvm,
+            do: nil,
+            else: %{kind: :lowering_failed, reason: "no llvm.func produced"}
+          ),
+        structural_proxy: proxy,
+        timings: %{total_ns: System.monotonic_time() - started}
+      }
+    rescue
+      exception ->
+        %Record{
+          format: @format,
+          kernel_digest: kernel_digest,
+          target: target,
+          capability: nil,
+          config_space_digest: config_space_digest,
+          config: config,
+          status: :failed,
+          failure: %{kind: :evaluation_error, reason: Exception.message(exception)},
+          structural_proxy: nil,
+          timings: %{total_ns: System.monotonic_time() - started}
+        }
+    end
+  end
+
+  defp kernel_digest(fixture) do
+    fixture
+    |> Map.fetch!(:name)
+    |> Corpus.fixture_path()
+    |> File.read!()
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.encode16(case: :lower)
+  end
+
+  defp total_duration(records) do
+    records
+    |> Enum.map(& &1.timings)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.map(& &1.total_ns)
+    |> Enum.sum()
+    |> case do
+      0 -> nil
+      total -> total
+    end
+  end
+
+  defp record_to_map(record) do
+    record
+    |> Map.from_struct()
+    |> Map.update!(:config, &Map.from_struct/1)
+  end
+
+  defp config_from_map(map) do
+    map
+    |> Map.new(fn {key, value} -> {String.to_existing_atom(key), value} end)
+    |> then(&struct!(Config, &1))
+  end
+
+  defp deep_atomize(map) when is_map(map) do
+    Map.new(map, fn {key, value} ->
+      {String.to_existing_atom(key), deep_atomize(value)}
+    end)
+  end
+
+  defp deep_atomize(list) when is_list(list), do: Enum.map(list, &deep_atomize/1)
+  defp deep_atomize(value), do: value
+end

--- a/test/shadow_tuning_test.exs
+++ b/test/shadow_tuning_test.exs
@@ -2,7 +2,7 @@ defmodule Beaver.Shadow.TuningTest do
   use ExUnit.Case, async: true
 
   alias Beaver.Shadow.Tuning
-  alias Beaver.Shadow.Tuning.{Config, Event, Record, Run}
+  alias Beaver.Shadow.Tuning.{Config, Record, Run}
 
   @triton_enabled System.get_env("BEAVER_TRITON_PREBUILT_DIR") != nil
 

--- a/test/shadow_tuning_test.exs
+++ b/test/shadow_tuning_test.exs
@@ -1,0 +1,157 @@
+defmodule Beaver.Shadow.TuningTest do
+  use ExUnit.Case, async: true
+
+  alias Beaver.Shadow.Tuning
+  alias Beaver.Shadow.Tuning.{Config, Event, Record, Run}
+
+  @triton_enabled System.get_env("BEAVER_TRITON_PREBUILT_DIR") != nil
+
+  defp sample_configs do
+    [
+      %Config{index: 0, num_warps: 2},
+      %Config{index: 1, num_warps: 4},
+      %Config{index: 2, num_warps: 8, num_stages: 2}
+    ]
+  end
+
+  defp sample_record(overrides \\ %{}) do
+    base = %Record{
+      format: Tuning.format(),
+      kernel_digest: "a" <> String.duplicate("0", 63),
+      target: "cuda:80",
+      capability: nil,
+      config_space_digest: Tuning.configs_digest(sample_configs()),
+      config: %Config{index: 1, num_warps: 4},
+      status: :evaluated,
+      failure: nil,
+      structural_proxy: %{baseline: 24, optimized: 5, reduction: 19, lowered_to_llvm: true},
+      timings: %{total_ns: 1_000_000}
+    }
+
+    struct!(Record, Map.merge(Map.from_struct(base), overrides))
+  end
+
+  describe "config" do
+    test "digest is stable and depends on the config fields" do
+      a = %Config{index: 0, num_warps: 4}
+      b = %Config{index: 0, num_warps: 4}
+      c = %Config{index: 0, num_warps: 8}
+
+      assert Config.digest(a) == Config.digest(b)
+      refute Config.digest(a) == Config.digest(c)
+    end
+  end
+
+  describe "record identity" do
+    test "excludes durations and observations" do
+      fast = sample_record(%{timings: %{total_ns: 1}})
+      slow = sample_record(%{timings: %{total_ns: 99_999_999}})
+
+      assert Tuning.identity(fast) == Tuning.identity(slow)
+      refute fast.timings == slow.timings
+    end
+
+    test "includes the structural proxy and config provenance" do
+      proxy_a =
+        sample_record(%{
+          structural_proxy: %{baseline: 24, optimized: 5, reduction: 19, lowered_to_llvm: true}
+        })
+
+      proxy_b =
+        sample_record(%{
+          structural_proxy: %{baseline: 24, optimized: 4, reduction: 20, lowered_to_llvm: true}
+        })
+
+      refute Tuning.identity(proxy_a) == Tuning.identity(proxy_b)
+    end
+  end
+
+  describe "config space digest" do
+    test "is index-independent" do
+      configs = sample_configs()
+      reindexed = Enum.map(configs, &%{&1 | index: 99})
+
+      assert Tuning.configs_digest(configs) == Tuning.configs_digest(reindexed)
+    end
+  end
+
+  describe "JSON round-trip" do
+    test "encode!/decode! preserves the run" do
+      run = %Run{
+        kernel_digest: String.duplicate("b", 64),
+        records: [sample_record()],
+        winner: sample_record()
+      }
+
+      decoded = run |> Tuning.encode!() |> Tuning.decode!()
+
+      assert decoded.kernel_digest == run.kernel_digest
+      assert length(decoded.records) == 1
+      assert decoded.records |> hd() |> Map.get(:config) |> Map.get(:num_warps) == 4
+      assert decoded.winner.config.index == 1
+      assert decoded.winner.structural_proxy.optimized == 5
+    end
+  end
+
+  describe "AutotuneListener event" do
+    test "carries the six upstream fields plus extensions" do
+      run = %Run{
+        kernel_digest: String.duplicate("c", 64),
+        records: [
+          sample_record(),
+          sample_record(%{
+            config: %Config{index: 2, num_warps: 8},
+            status: :failed,
+            structural_proxy: nil,
+            failure: %{kind: :crash, reason: "segv"}
+          }),
+          sample_record(%{
+            status: :failed,
+            failure: %{kind: :lowering_failed, reason: "no llvm.func"}
+          })
+        ],
+        winner: sample_record()
+      }
+
+      event = Tuning.event(run, fn_name: "matmul_kernel")
+
+      # upstream protocol fields
+      assert event.fn == "matmul_kernel"
+      assert is_tuple(event.key)
+      assert event.best_config.num_warps == 4
+      assert is_list(event.configs_timings)
+      assert is_integer(event.duration) or is_nil(event.duration)
+      assert event.cache_hit == false
+
+      # extensions
+      assert is_map(event.structural_proxy)
+      assert length(event.failure) == 2
+    end
+  end
+
+  @tag :triton
+  @tag skip: !@triton_enabled
+  test "CPU-only config enumeration produces records and a structural winner" do
+    run = Tuning.run(:matmul, sample_configs())
+
+    assert run.kernel_digest |> byte_size() == 64
+    assert length(run.records) == 3
+
+    for record <- run.records do
+      assert record.format == Tuning.format()
+      assert record.status == :evaluated
+      assert record.structural_proxy.baseline == 24
+      assert is_boolean(record.structural_proxy.lowered_to_llvm)
+      assert record.timings.total_ns > 0
+    end
+
+    assert run.winner.status == :evaluated
+    assert run.winner.structural_proxy.optimized <= 5
+
+    # re-running with the same configs reproduces identical decisions
+    rerun = Tuning.run(:matmul, sample_configs())
+
+    assert Enum.map(run.records, &Tuning.identity/1) ==
+             Enum.map(rerun.records, &Tuning.identity/1)
+  end
+end


### PR DESCRIPTION
Forgejo #21 slice 1+2.

- `Beaver.Shadow.Tuning`: versioned Record (kernel digest, target, config space digest, config, status, failure, structural proxy, timings) with identity excluding observations, config-space digest, JSON round-trip, structural-proxy winner;
- `Tuning.Event`: JSON event isomorphic to triton's AutotuneListener protocol (fn/key/best_config/configs_timings/duration/cache_hit) plus structural_proxy/failure extensions;
- `OptimizationTrial`/compile_to_llvm pass num_warps through to convert-triton-to-tritongpu;
- CPU-only demo: matmul with num_warps [2,4,8] reproduces identical decisions across runs.