### PR TITLE
shadow: probe_many for per-config crash isolation

### DIFF
--- a/lib/beaver/shadow/probe.ex
+++ b/lib/beaver/shadow/probe.ex
@@ -15,6 +15,7 @@ defmodule Beaver.Shadow.Probe do
 
   alias Beaver.MLIR
   alias Beaver.Shadow.Corpus
+  alias Beaver.Shadow.Tuning
 
   @child_prefix "SHADOW_PROBE "
   @marker_env "SHADOW_PROBE_MARKER"
@@ -39,13 +40,13 @@ defmodule Beaver.Shadow.Probe do
   Returns a `Beaver.Shadow.Probe.Result`; the caller's process never sees the
   child's native crash.
   """
-  @spec run(atom()) :: Result.t()
-  def run(fixture_name) when is_atom(fixture_name) do
+  @spec run(atom(), keyword()) :: Result.t()
+  def run(fixture_name, opts \\ []) when is_atom(fixture_name) do
     fixture = Corpus.fixture(fixture_name)
     marker = marker_path()
 
     {output, exit_code} =
-      System.cmd(elixir_executable(), child_args(fixture_name),
+      System.cmd(elixir_executable(), child_args(fixture_name, opts),
         stderr_to_stdout: true,
         cd: System.tmp_dir!(),
         env: [{@marker_env, marker}]
@@ -72,20 +73,36 @@ defmodule Beaver.Shadow.Probe do
     result
   end
 
+  @doc """
+  Probes every `Beaver.Shadow.Tuning.Config` in a fresh child BEAM and
+  returns one result per config, so a config space stays isolated and
+  attributed even when some configs crash the native passes.
+  """
+  @spec probe_many(atom(), [Tuning.Config.t()]) :: [
+          %{config: Tuning.Config.t(), result: Result.t()}
+        ]
+  def probe_many(fixture_name, configs) when is_atom(fixture_name) and is_list(configs) do
+    Enum.map(configs, fn config ->
+      %{config: config, result: run(fixture_name, num_warps: config.num_warps)}
+    end)
+  end
+
   defp elixir_executable do
     System.find_executable("elixir") ||
       raise ArgumentError, "elixir executable not found for the probe subprocess"
   end
 
-  defp child_args(fixture_name) do
+  defp child_args(fixture_name, opts) do
     code_paths =
       :code.get_path()
       |> Enum.filter(&File.dir?/1)
       |> Enum.flat_map(&["-pa", List.to_string(&1)])
 
+    num_warps = Keyword.get(opts, :num_warps, 4)
+
     expression = """
     Application.ensure_all_started(:beaver)
-    result = Beaver.Shadow.Probe.evaluate(:#{fixture_name})
+    result = Beaver.Shadow.Probe.evaluate(:#{fixture_name}, num_warps: #{num_warps})
     IO.puts("SHADOW_PROBE " <> JSON.encode!(result))
     """
 
@@ -98,9 +115,10 @@ defmodule Beaver.Shadow.Probe do
   Updates `@marker_env` before each pipeline pass so a native crash can be
   attributed to the pass that was running.
   """
-  @spec evaluate(atom()) :: map()
-  def evaluate(fixture_name) when is_atom(fixture_name) do
+  @spec evaluate(atom(), keyword()) :: map()
+  def evaluate(fixture_name, opts \\ []) when is_atom(fixture_name) do
     fixture = Corpus.fixture(fixture_name)
+    num_warps = Keyword.get(opts, :num_warps, 4)
     context = MLIR.Context.create(all_dialects: false)
 
     try do
@@ -109,7 +127,7 @@ defmodule Beaver.Shadow.Probe do
       module =
         MLIR.Module.create!(File.read!(Corpus.fixture_path(fixture.name)), ctx: context)
 
-      pipeline = lowering_pipeline(fixture.dialect)
+      pipeline = lowering_pipeline(fixture.dialect, num_warps)
 
       lowered =
         Enum.reduce_while(pipeline, module, fn pass, acc ->
@@ -139,9 +157,15 @@ defmodule Beaver.Shadow.Probe do
     end
   end
 
-  defp lowering_pipeline(:ttir) do
+  defp lowering_pipeline(dialect, num_warps) do
+    convert =
+      case dialect do
+        :ttir -> "convert-triton-to-tritongpu{target=cuda:80, num-warps=#{num_warps}}"
+        :ttgir -> nil
+      end
+
     [
-      "convert-triton-to-tritongpu{target=cuda:80}",
+      convert,
       "tritongpu-coalesce",
       "tritongpu-F32DotTC",
       "triton-nvidia-gpu-plan-cta",
@@ -165,11 +189,7 @@ defmodule Beaver.Shadow.Probe do
       "convert-nvvm-to-llvm",
       "canonicalize"
     ]
-  end
-
-  defp lowering_pipeline(:ttgir) do
-    pipeline = lowering_pipeline(:ttir)
-    List.delete(pipeline, "convert-triton-to-tritongpu{target=cuda:80}")
+    |> Enum.reject(&is_nil/1)
   end
 
   defp marker_path do

--- a/test/shadow_probe_test.exs
+++ b/test/shadow_probe_test.exs
@@ -2,6 +2,7 @@ defmodule Beaver.Shadow.ProbeTest do
   use ExUnit.Case, async: true
 
   alias Beaver.Shadow.Probe
+  alias Beaver.Shadow.Tuning
 
   @triton_enabled System.get_env("BEAVER_TRITON_PREBUILT_DIR") != nil
 
@@ -26,5 +27,43 @@ defmodule Beaver.Shadow.ProbeTest do
     assert result.status == :crash
     assert result.exit_code != 0
     assert result.detail.last_pass == "tritongpu-accelerate-matmul"
+  end
+
+  @tag :triton
+  @tag skip: !@triton_enabled
+  test "probe_many isolates every config in its own child BEAM" do
+    configs = [
+      %Tuning.Config{index: 0, num_warps: 2},
+      %Tuning.Config{index: 1, num_warps: 4},
+      %Tuning.Config{index: 2, num_warps: 8}
+    ]
+
+    results = Probe.probe_many(:matmul, configs)
+
+    assert length(results) == 3
+
+    for %{config: config, result: result} <- results do
+      assert result.status == :ok, "config #{config.num_warps}: #{inspect(result)}"
+      assert result.detail.llvm_func
+    end
+  end
+
+  @tag :triton
+  @tag skip: !@triton_enabled
+  test "probe_many records per-config failure receipts for the remat fixture" do
+    configs = [
+      %Tuning.Config{index: 0, num_warps: 2},
+      %Tuning.Config{index: 1, num_warps: 4}
+    ]
+
+    results = Probe.probe_many(:remat, configs)
+
+    assert length(results) == 2
+
+    for %{config: config, result: result} <- results do
+      assert result.status == :crash, "config #{config.num_warps}: #{inspect(result)}"
+      assert result.exit_code != 0
+      assert result.detail.last_pass == "tritongpu-accelerate-matmul"
+    end
   end
 end


### PR DESCRIPTION
Forgejo #21 slice 3.

- `Probe.run/2` and evaluate/2 accept num_warps, threaded into convert-triton-to-tritongpu;
- `Probe.probe_many/2` maps tuning configs to per-config child-BEAM results;
- demo: matmul num_warps [2,4,8] all lower to llvm.func; the remat TTGIR slice crashes accelerate-matmul (exit 139) in every config, each recorded as its own failure receipt.