### PR TITLE
shadow: auditable structural pruning for tuning configs

### DIFF
--- a/lib/beaver/shadow/tuning.ex
+++ b/lib/beaver/shadow/tuning.ex
@@ -83,13 +83,27 @@ defmodule Beaver.Shadow.Tuning do
 
   defmodule Run do
     @moduledoc "One tuning pass over a config space."
-    @enforce_keys [:kernel_digest, :records, :winner]
-    defstruct [:kernel_digest, :records, :winner]
+    @enforce_keys [:fixture, :kernel_digest, :records, :winner]
+    defstruct [:fixture, :kernel_digest, :records, :winner]
 
     @type t() :: %__MODULE__{
+            fixture: atom(),
             kernel_digest: String.t(),
             records: [Record.t()],
             winner: Record.t() | nil
+          }
+  end
+
+  defmodule Prune do
+    @moduledoc "A structural pruning decision with its audit trail."
+    @enforce_keys [:fixture, :config_space_digest, :decisions, :kept]
+    defstruct [:fixture, :config_space_digest, :decisions, :kept]
+
+    @type t() :: %__MODULE__{
+            fixture: atom(),
+            config_space_digest: String.t(),
+            decisions: [map()],
+            kept: [Config.t()]
           }
   end
 
@@ -159,7 +173,12 @@ defmodule Beaver.Shadow.Tuning do
         if is_function(on_exit), do: on_exit.()
       end
 
-    %Run{kernel_digest: kernel_digest, records: records, winner: pick_winner(records)}
+    %Run{
+      fixture: fixture.name,
+      kernel_digest: kernel_digest,
+      records: records,
+      winner: pick_winner(records)
+    }
   end
 
   @doc "Stable identity of a tuning record; observations are excluded."
@@ -210,11 +229,44 @@ defmodule Beaver.Shadow.Tuning do
     |> List.first()
   end
 
+  @doc """
+  Prunes a config space with the structural proxy and returns an audit trail.
+
+  Configs are ranked by lowering capability first and optimized
+  `ttg.convert_layout` count second; the top `:max_keep` are kept. Every
+  decision records the structural facts that drove it, so the pruning is
+  auditable and regressable without a GPU.
+  """
+  @spec prune_by_structure(atom() | Run.t(), [Config.t()], keyword()) :: Prune.t()
+  def prune_by_structure(fixture_or_run, configs, opts \\ [])
+
+  def prune_by_structure(%Run{} = run, _configs, opts) do
+    max_keep = Keyword.get(opts, :max_keep, 2)
+    decisions = rank_decisions(run.records, max_keep)
+
+    %Prune{
+      fixture: run.fixture,
+      config_space_digest:
+        run.records
+        |> List.first()
+        |> then(&(&1 && &1.config_space_digest)),
+      decisions: decisions,
+      kept: decisions |> Enum.filter(& &1.keep) |> Enum.map(& &1.config)
+    }
+  end
+
+  def prune_by_structure(fixture_name, configs, opts) when is_atom(fixture_name) do
+    fixture_name
+    |> run(configs)
+    |> prune_by_structure(configs, opts)
+  end
+
   @doc "Encodes a tuning run as JSON text."
   @spec encode!(Run.t()) :: String.t()
   def encode!(%Run{} = run) do
     %{
       "format" => @format,
+      "fixture" => run.fixture,
       "kernel_digest" => run.kernel_digest,
       "records" => Enum.map(run.records, &record_to_map/1),
       "winner_index" => if(run.winner, do: run.winner.config.index, else: nil)
@@ -241,7 +293,12 @@ defmodule Beaver.Shadow.Tuning do
     winner =
       Enum.find(records, &(&1.config.index == map["winner_index"]))
 
-    %Run{kernel_digest: map["kernel_digest"], records: records, winner: winner}
+    %Run{
+      fixture: map["fixture"] |> String.to_existing_atom(),
+      kernel_digest: map["kernel_digest"],
+      records: records,
+      winner: winner
+    }
   end
 
   @doc "Builds an AutotuneListener-isomorphic event from a tuning run."
@@ -345,6 +402,46 @@ defmodule Beaver.Shadow.Tuning do
       0 -> nil
       total -> total
     end
+  end
+
+  defp rank_decisions(records, max_keep) do
+    records
+    |> Enum.sort_by(fn record ->
+      proxy = record.structural_proxy
+
+      case proxy do
+        nil -> {true, :infinity, record.config.index}
+        proxy -> {not proxy.lowered_to_llvm, proxy.optimized, record.config.index}
+      end
+    end)
+    |> Enum.with_index()
+    |> Enum.map(fn {record, rank} ->
+      %{
+        config: record.config,
+        structural_proxy: record.structural_proxy,
+        status: record.status,
+        rank: rank,
+        keep: rank < max_keep,
+        reason: prune_reason(record, rank, max_keep)
+      }
+    end)
+  end
+
+  defp prune_reason(record, rank, max_keep) when rank < max_keep do
+    case record.structural_proxy do
+      %{lowered_to_llvm: true, optimized: optimized} ->
+        "rank #{rank}: lowers to LLVM, #{optimized} convert_layouts"
+
+      nil ->
+        "rank #{rank}: no structural facts (failed)"
+
+      %{lowered_to_llvm: false} ->
+        "rank #{rank}: does not lower to LLVM"
+    end
+  end
+
+  defp prune_reason(_record, rank, max_keep) do
+    "pruned: rank #{rank} >= max_keep #{max_keep}"
   end
 
   defp record_to_map(record) do

--- a/test/shadow_tuning_test.exs
+++ b/test/shadow_tuning_test.exs
@@ -78,6 +78,7 @@ defmodule Beaver.Shadow.TuningTest do
   describe "JSON round-trip" do
     test "encode!/decode! preserves the run" do
       run = %Run{
+        fixture: :matmul,
         kernel_digest: String.duplicate("b", 64),
         records: [sample_record()],
         winner: sample_record()
@@ -86,6 +87,7 @@ defmodule Beaver.Shadow.TuningTest do
       decoded = run |> Tuning.encode!() |> Tuning.decode!()
 
       assert decoded.kernel_digest == run.kernel_digest
+      assert decoded.fixture == :matmul
       assert length(decoded.records) == 1
       assert decoded.records |> hd() |> Map.get(:config) |> Map.get(:num_warps) == 4
       assert decoded.winner.config.index == 1
@@ -96,6 +98,7 @@ defmodule Beaver.Shadow.TuningTest do
   describe "AutotuneListener event" do
     test "carries the six upstream fields plus extensions" do
       run = %Run{
+        fixture: :matmul,
         kernel_digest: String.duplicate("c", 64),
         records: [
           sample_record(),
@@ -129,6 +132,44 @@ defmodule Beaver.Shadow.TuningTest do
     end
   end
 
+  describe "prune_by_structure/3" do
+    test "ranks by lowering capability then convert_layout count and audits" do
+      run = %Run{
+        fixture: :matmul,
+        kernel_digest: String.duplicate("d", 64),
+        records: [
+          sample_record(%{
+            config: %Config{index: 0, num_warps: 2},
+            status: :failed,
+            structural_proxy: nil,
+            failure: %{kind: :lowering_failed, reason: "no llvm.func"}
+          }),
+          sample_record(%{
+            config: %Config{index: 1, num_warps: 4},
+            structural_proxy: %{baseline: 24, optimized: 5, reduction: 19, lowered_to_llvm: true}
+          }),
+          sample_record(%{
+            config: %Config{index: 2, num_warps: 8},
+            structural_proxy: %{baseline: 24, optimized: 4, reduction: 20, lowered_to_llvm: true}
+          })
+        ],
+        winner: nil
+      }
+
+      prune = Tuning.prune_by_structure(run, [], max_keep: 2)
+
+      assert prune.fixture == :matmul
+      assert Enum.map(prune.kept, & &1.num_warps) == [8, 4]
+      assert Enum.find(prune.decisions, &(&1.config.num_warps == 8)).keep
+      assert Enum.find(prune.decisions, &(&1.config.num_warps == 4)).keep
+
+      pruned = Enum.find(prune.decisions, &(&1.config.num_warps == 2))
+      refute pruned.keep
+      assert pruned.reason =~ "rank 2 >= max_keep 2"
+      assert pruned.status == :failed
+    end
+  end
+
   @tag :triton
   @tag skip: !@triton_enabled
   test "CPU-only config enumeration produces records and a structural winner" do
@@ -153,5 +194,20 @@ defmodule Beaver.Shadow.TuningTest do
 
     assert Enum.map(run.records, &Tuning.identity/1) ==
              Enum.map(rerun.records, &Tuning.identity/1)
+  end
+
+  @tag :triton
+  @tag skip: !@triton_enabled
+  test "structural pruning is CPU-only and auditable on the corpus" do
+    prune = Tuning.prune_by_structure(:matmul, sample_configs(), max_keep: 2)
+
+    assert prune.config_space_digest == Tuning.configs_digest(sample_configs())
+    assert length(prune.decisions) == 3
+    assert length(prune.kept) == 2
+
+    for decision <- prune.decisions do
+      assert decision.structural_proxy.baseline == 24
+      assert decision.reason =~ "convert_layouts" or decision.reason =~ "pruned"
+    end
   end
 end


### PR DESCRIPTION
Forgejo #21 slice 4.

- `Tuning.Run` carries the fixture identity so encoded runs round-trip;
- `Tuning.prune_by_structure/3` ranks configs by lowering capability then optimized convert_layout count, returning kept configs plus a per-config audit trail (rank, keep, reason), CPU-only and regressable without a GPU.