### PR TITLE
shadow: mix shadow.tune_report for paste-ready tuning evidence

### DIFF
--- a/lib/beaver/shadow/tune_report.ex
+++ b/lib/beaver/shadow/tune_report.ex
@@ -1,0 +1,149 @@
+defmodule Beaver.Shadow.TuneReport do
+  @moduledoc """
+  Renders a Shadow Wavefront tuning measurement as paste-ready Markdown.
+
+  Combines the CPU-only tuning run (`Beaver.Shadow.Tuning.run/3`), the
+  per-config crash probes (`Beaver.Shadow.Probe.probe_many/2`), and the
+  environment facts (LLVM revision, Triton prebuilt dir, target) into a
+  report that can be pasted into upstream Triton issues or RFC discussions.
+  """
+
+  alias Beaver.Shadow.Probe
+  alias Beaver.Shadow.Tuning
+
+  defstruct [
+    :fixture,
+    :generated_at,
+    :llvm_revision,
+    :prebuilt_dir,
+    :target,
+    :config_space_digest,
+    :records,
+    :winner,
+    :probes
+  ]
+
+  @type t() :: %__MODULE__{
+          fixture: atom(),
+          generated_at: DateTime.t(),
+          llvm_revision: String.t() | nil,
+          prebuilt_dir: String.t() | nil,
+          target: String.t(),
+          config_space_digest: String.t(),
+          records: [Tuning.Record.t()],
+          winner: Tuning.Record.t() | nil,
+          probes: [%{config: Tuning.Config.t(), result: Probe.Result.t()}]
+        }
+
+  @doc "Measures a config space and its crash probes for one corpus fixture."
+  @spec generate(atom(), [Tuning.Config.t()], keyword()) :: t()
+  def generate(fixture_name, configs, opts \\ []) when is_atom(fixture_name) do
+    target = Keyword.get(opts, :target, "cuda:80")
+    run = Tuning.run(fixture_name, configs, target: target)
+
+    %__MODULE__{
+      fixture: fixture_name,
+      generated_at: DateTime.utc_now(),
+      llvm_revision: llvm_revision(),
+      prebuilt_dir: System.get_env("BEAVER_TRITON_PREBUILT_DIR"),
+      target: target,
+      config_space_digest: Tuning.configs_digest(configs),
+      records: run.records,
+      winner: run.winner,
+      probes: Probe.probe_many(fixture_name, configs)
+    }
+  end
+
+  @doc "Renders the measurement as Markdown."
+  @spec render(t()) :: String.t()
+  def render(%__MODULE__{} = report) do
+    """
+    ## Shadow Wavefront: Triton tuning measurement
+
+    - fixture: `#{report.fixture}`
+    - generated at: #{DateTime.to_iso8601(report.generated_at)}
+    - llvm revision: #{report.llvm_revision || "unknown"}
+    - triton prebuilt dir: `#{report.prebuilt_dir || "unset"}`
+    - target: `#{report.target}`
+    - config space digest: `#{report.config_space_digest}`
+
+    ### Config space
+
+    | index | num_warps | num_stages | num_ctas |
+    |---|---|---|---|
+    #{Enum.map_join(report.records, "\n", fn record -> config_row(record.config) end)}
+
+    ### Records
+
+    | index | status | baseline convert_layouts | optimized | reduction | lowers to LLVM | total_ns |
+    |---|---|---|---|---|---|---|
+    #{Enum.map_join(report.records, "\n", &record_row/1)}
+
+    ### Winner
+
+    #{winner_text(report.winner)}
+
+    ### Per-config probes
+
+    | index | num_warps | probe |
+    |---|---|---|
+    #{Enum.map_join(report.probes, "\n", &probe_row/1)}
+    """
+    |> String.trim_trailing()
+    |> Kernel.<>("\n")
+  end
+
+  defp config_row(config) do
+    "| #{config.index} | #{config.num_warps} | #{config.num_stages || "-"} | #{config.num_ctas || "-"} |"
+  end
+
+  defp record_row(record) do
+    proxy = record.structural_proxy
+
+    "| #{record.config.index} | #{record.status} | #{proxy_field(proxy, :baseline)} | " <>
+      "#{proxy_field(proxy, :optimized)} | #{reduction(proxy)} | " <>
+      "#{proxy_field(proxy, :lowered_to_llvm)} | " <>
+      "#{(record.timings && record.timings.total_ns) || "-"} |"
+  end
+
+  defp proxy_field(nil, _field), do: "-"
+  defp proxy_field(proxy, field), do: Map.get(proxy, field) || "-"
+
+  defp reduction(%{baseline: baseline, optimized: optimized}) when baseline > 0,
+    do: "-#{baseline - optimized}"
+
+  defp reduction(_proxy), do: "-"
+
+  defp winner_text(nil), do: "no winner (no config lowered to LLVM)"
+
+  defp winner_text(winner) do
+    proxy = winner.structural_proxy
+
+    "config #{winner.config.index} (num_warps #{winner.config.num_warps}) with " <>
+      "#{proxy.optimized} convert_layouts after optimization."
+  end
+
+  defp probe_row(%{config: config, result: result}) do
+    text =
+      case result.status do
+        :ok -> "ok"
+        :crash -> "crash (exit #{result.exit_code}) at `#{result.detail.last_pass}`"
+        :error -> "error: `#{result.detail}`"
+      end
+
+    "| #{config.index} | #{config.num_warps} | #{text} |"
+  end
+
+  defp llvm_revision do
+    case System.get_env("LLVM_CONFIG_PATH") do
+      nil ->
+        nil
+
+      llvm_config ->
+        case System.cmd(llvm_config, ["--version"], stderr_to_stdout: true) do
+          {output, 0} -> output |> String.split("\n") |> hd()
+          _ -> nil
+        end
+    end
+  end
+end

--- a/lib/mix/tasks/shadow.tune_report.ex
+++ b/lib/mix/tasks/shadow.tune_report.ex
@@ -1,0 +1,40 @@
+defmodule Mix.Tasks.Shadow.TuneReport do
+  use Mix.Task
+
+  @shortdoc "Emits a Shadow Wavefront tuning measurement report as Markdown"
+
+  @moduledoc """
+  Measures a corpus fixture across a config space and prints a paste-ready
+  Markdown report (environment facts, records, winner, per-config crash
+  probes).
+
+      $ mix shadow.tune_report matmul
+
+  Requires a Triton-enabled native build (`BEAVER_TRITON_PREBUILT_DIR` set).
+  """
+
+  @impl true
+  def run([fixture_name]) do
+    Mix.Task.run("app.start")
+
+    fixture = fixture_name |> String.to_existing_atom() |> Beaver.Shadow.Corpus.fixture()
+    configs = default_configs()
+
+    fixture.name
+    |> Beaver.Shadow.TuneReport.generate(configs)
+    |> Beaver.Shadow.TuneReport.render()
+    |> IO.puts()
+  end
+
+  def run(_) do
+    IO.puts("usage: mix shadow.tune_report <fixture>")
+  end
+
+  defp default_configs do
+    [
+      %Beaver.Shadow.Tuning.Config{index: 0, num_warps: 2},
+      %Beaver.Shadow.Tuning.Config{index: 1, num_warps: 4},
+      %Beaver.Shadow.Tuning.Config{index: 2, num_warps: 8}
+    ]
+  end
+end

--- a/test/shadow_tune_report_test.exs
+++ b/test/shadow_tune_report_test.exs
@@ -1,0 +1,115 @@
+defmodule Beaver.Shadow.TuneReportTest do
+  use ExUnit.Case, async: true
+
+  alias Beaver.Shadow.Probe.Result
+  alias Beaver.Shadow.TuneReport
+  alias Beaver.Shadow.Tuning
+  alias Beaver.Shadow.Tuning.{Config, Record, Run}
+
+  @triton_enabled System.get_env("BEAVER_TRITON_PREBUILT_DIR") != nil
+
+  defp sample_run do
+    configs = [
+      %Config{index: 0, num_warps: 2},
+      %Config{index: 1, num_warps: 4},
+      %Config{index: 2, num_warps: 8}
+    ]
+
+    record = fn config, optimized, status ->
+      %Record{
+        format: Tuning.format(),
+        kernel_digest: String.duplicate("a", 64),
+        target: "cuda:80",
+        capability: nil,
+        config_space_digest: Tuning.configs_digest(configs),
+        config: config,
+        status: status,
+        failure: nil,
+        structural_proxy: %{
+          baseline: 24,
+          optimized: optimized,
+          reduction: 24 - optimized,
+          lowered_to_llvm: true
+        },
+        timings: %{total_ns: 1_000_000}
+      }
+    end
+
+    records = [
+      record.(Enum.at(configs, 0), 5, :evaluated),
+      record.(Enum.at(configs, 1), 5, :evaluated),
+      record.(Enum.at(configs, 2), 4, :evaluated)
+    ]
+
+    %Run{
+      fixture: :matmul,
+      kernel_digest: String.duplicate("a", 64),
+      records: records,
+      winner: List.last(records)
+    }
+  end
+
+  describe "render/1" do
+    test "includes environment facts, records, winner, and probes" do
+      run = sample_run()
+
+      report = %TuneReport{
+        fixture: :matmul,
+        generated_at: ~U[2026-08-08 00:00:00Z],
+        llvm_revision: "LLVM version 24.0.0git",
+        prebuilt_dir: "/tmp/prebuilt",
+        target: "cuda:80",
+        config_space_digest: Tuning.configs_digest(run.records |> Enum.map(& &1.config)),
+        records: run.records,
+        winner: run.winner,
+        probes: [
+          %{
+            config: %Config{index: 0, num_warps: 2},
+            result: %Result{fixture: :matmul, status: :ok, detail: %{llvm_func: true}}
+          },
+          %{
+            config: %Config{index: 1, num_warps: 4},
+            result: %Result{
+              fixture: :matmul,
+              status: :crash,
+              exit_code: 139,
+              detail: %{last_pass: "tritongpu-accelerate-matmul"}
+            }
+          }
+        ]
+      }
+
+      rendered = TuneReport.render(report)
+
+      assert rendered =~ "llvm revision: LLVM version 24.0.0git"
+      assert rendered =~ "triton prebuilt dir: `/tmp/prebuilt`"
+      assert rendered =~ "| 0 | 2 | - | - |"
+      assert rendered =~ "| 2 | evaluated | 24 | 4 | -20 | true | 1000000 |"
+      assert rendered =~ "### Winner" and rendered =~ "num_warps 8"
+      assert rendered =~ "| 0 | 2 | ok |"
+      assert rendered =~ "| 1 | 4 | crash (exit 139) at `tritongpu-accelerate-matmul` |"
+    end
+  end
+
+  @tag :triton
+  @tag skip: !@triton_enabled
+  test "generate/0 measures a config space and probes on the corpus" do
+    configs = [
+      %Config{index: 0, num_warps: 2},
+      %Config{index: 1, num_warps: 4},
+      %Config{index: 2, num_warps: 8}
+    ]
+
+    report = TuneReport.generate(:matmul, configs)
+
+    assert report.llvm_revision != nil
+    assert length(report.records) == 3
+    assert report.winner.status == :evaluated
+    assert length(report.probes) == 3
+    assert Enum.all?(report.probes, &(&1.result.status == :ok))
+
+    rendered = TuneReport.render(report)
+    assert rendered =~ "## Shadow Wavefront: Triton tuning measurement"
+    assert rendered =~ "| 0 | evaluated | 24 | 5 | -19 |"
+  end
+end


### PR DESCRIPTION
Forgejo #21 slice 5.

- `Beaver.Shadow.TuneReport.generate/3` combines `Tuning.run/3` with `Probe.probe_many/2` and LLVM/prebuilt facts;
- `mix shadow.tune_report <fixture>` prints the Markdown report (environment facts, config space, records, winner, per-config crash probes) ready to paste into upstream Triton issues.