### PR TITLE
shadow: structural-proxy correlation calibration on real GPU kernels

### DIFF
--- a/lib/beaver/shadow/corpus.ex
+++ b/lib/beaver/shadow/corpus.ex
@@ -40,6 +40,42 @@ defmodule Beaver.Shadow.Corpus do
       baseline: 4,
       optimized: 1,
       lowered_to_llvm: false
+    },
+    %{
+      name: :matmul_1024,
+      file: "ttir_matmul_1024.mlir",
+      dialect: :ttir,
+      baseline: 17,
+      optimized: 3,
+      lowered_to_llvm: true,
+      launch: %{
+        kernel_name: "matmul_kernel",
+        grid: {16, 16, 1},
+        block: {128, 1, 1},
+        shared_mem: 16_384,
+        samples: 10,
+        buffer_sizes: %{
+          a: 1024 * 1024 * 4,
+          b: 1024 * 1024 * 4,
+          c: 1024 * 1024 * 4
+        },
+        args_template: [
+          {:ptr, :a},
+          {:ptr, :b},
+          {:ptr, :c},
+          {:i64, 1024},
+          {:i64, 1024},
+          {:i64, 1024},
+          {:i64, 1024},
+          {:i64, 1},
+          {:i64, 1024},
+          {:i64, 1},
+          {:i64, 1024},
+          {:i64, 1},
+          {:ptr, 0},
+          {:ptr, 0}
+        ]
+      }
     }
   ]
 

--- a/lib/beaver/shadow/tune_report.ex
+++ b/lib/beaver/shadow/tune_report.ex
@@ -20,7 +20,9 @@ defmodule Beaver.Shadow.TuneReport do
     :config_space_digest,
     :records,
     :winner,
-    :probes
+    :probes,
+    :latency_winner,
+    :structural_vs_latency
   ]
 
   @type t() :: %__MODULE__{
@@ -32,14 +34,17 @@ defmodule Beaver.Shadow.TuneReport do
           config_space_digest: String.t(),
           records: [Tuning.Record.t()],
           winner: Tuning.Record.t() | nil,
-          probes: [%{config: Tuning.Config.t(), result: Probe.Result.t()}]
+          probes: [%{config: Tuning.Config.t(), result: Probe.Result.t()}],
+          latency_winner: Tuning.Record.t() | nil,
+          structural_vs_latency: float() | nil
         }
 
   @doc "Measures a config space and its crash probes for one corpus fixture."
   @spec generate(atom(), [Tuning.Config.t()], keyword()) :: t()
   def generate(fixture_name, configs, opts \\ []) when is_atom(fixture_name) do
     target = Keyword.get(opts, :target, "cuda:80")
-    run = Tuning.run(fixture_name, configs, target: target)
+    gpu? = Keyword.get(opts, :gpu, false)
+    run = Tuning.run(fixture_name, configs, target: target, gpu: gpu?)
 
     %__MODULE__{
       fixture: fixture_name,
@@ -50,7 +55,18 @@ defmodule Beaver.Shadow.TuneReport do
       config_space_digest: Tuning.configs_digest(configs),
       records: run.records,
       winner: run.winner,
-      probes: Probe.probe_many(fixture_name, configs)
+      probes: Probe.probe_many(fixture_name, configs),
+      latency_winner: Tuning.pick_winner_by_latency(run.records),
+      structural_vs_latency:
+        if(gpu?,
+          do:
+            Tuning.correlation(
+              run.records,
+              fn record -> record.structural_proxy && record.structural_proxy.optimized end,
+              fn record -> record.timings && record.timings.gpu_ns end
+            ),
+          else: nil
+        )
     }
   end
 
@@ -75,13 +91,21 @@ defmodule Beaver.Shadow.TuneReport do
 
     ### Records
 
-    | index | status | baseline convert_layouts | optimized | reduction | lowers to LLVM | total_ns |
-    |---|---|---|---|---|---|---|
+    | index | num_warps | status | baseline | optimized | reduction | lowers to LLVM | total_ns | gpu_ns |
+    |---|---|---|---|---|---|---|---|---|
     #{Enum.map_join(report.records, "\n", &record_row/1)}
 
-    ### Winner
+    ### Winner (structural proxy)
 
     #{winner_text(report.winner)}
+
+    ### Winner (measured GPU latency)
+
+    #{latency_winner_text(report)}
+
+    ### Structural proxy vs latency
+
+    #{correlation_text(report.structural_vs_latency)}
 
     ### Per-config probes
 
@@ -100,11 +124,17 @@ defmodule Beaver.Shadow.TuneReport do
   defp record_row(record) do
     proxy = record.structural_proxy
 
-    "| #{record.config.index} | #{record.status} | #{proxy_field(proxy, :baseline)} | " <>
+    "| #{record.config.index} | #{record.config.num_warps} | #{record.status} | " <>
+      "#{proxy_field(proxy, :baseline)} | " <>
       "#{proxy_field(proxy, :optimized)} | #{reduction(proxy)} | " <>
       "#{proxy_field(proxy, :lowered_to_llvm)} | " <>
-      "#{(record.timings && record.timings.total_ns) || "-"} |"
+      "#{(record.timings && record.timings.total_ns) || "-"} | " <>
+      "#{gpu_ns(record.timings)} |"
   end
+
+  defp gpu_ns(nil), do: "-"
+  defp gpu_ns(%{gpu_ns: ns}) when is_number(ns), do: Integer.to_string(ns)
+  defp gpu_ns(_timings), do: "-"
 
   defp proxy_field(nil, _field), do: "-"
   defp proxy_field(proxy, field), do: Map.get(proxy, field) || "-"
@@ -121,6 +151,28 @@ defmodule Beaver.Shadow.TuneReport do
 
     "config #{winner.config.index} (num_warps #{winner.config.num_warps}) with " <>
       "#{proxy.optimized} convert_layouts after optimization."
+  end
+
+  defp latency_winner_text(%__MODULE__{latency_winner: nil}),
+    do: "no measured latency (GPU unavailable or all configs failed)"
+
+  defp latency_winner_text(%__MODULE__{latency_winner: winner}) do
+    gpu_ns = winner.timings && Map.get(winner.timings, :gpu_ns)
+
+    if is_number(gpu_ns) do
+      "config #{winner.config.index} (num_warps #{winner.config.num_warps}) at #{gpu_ns}ns."
+    else
+      "config #{winner.config.index} (num_warps #{winner.config.num_warps}), latency unknown."
+    end
+  end
+
+  defp correlation_text(nil) do
+    "Spearman(structural optimized count, GPU latency): not computable " <>
+      "(no GPU measurements or no variance in the structural proxy)."
+  end
+
+  defp correlation_text(rho) when is_number(rho) do
+    "Spearman(structural optimized count, GPU latency): #{Float.round(rho, 3)}"
   end
 
   defp probe_row(%{config: config, result: result}) do

--- a/lib/beaver/shadow/tuning.ex
+++ b/lib/beaver/shadow/tuning.ex
@@ -25,6 +25,7 @@ defmodule Beaver.Shadow.Tuning do
   alias Beaver.MLIR
   alias Beaver.Shadow.Corpus
   alias Beaver.Shadow.OptimizationTrial
+  alias Beaver.Shadow.Tuning.GPU
 
   @format 1
 
@@ -155,6 +156,8 @@ defmodule Beaver.Shadow.Tuning do
   def run(fixture_name, configs, opts \\ []) when is_atom(fixture_name) do
     fixture = Corpus.fixture(fixture_name)
     target = Keyword.get(opts, :target, "cuda:80")
+    gpu? = Keyword.get(opts, :gpu, false)
+    launch = Keyword.get(opts, :launch, Map.get(fixture, :launch))
     config_space_digest = configs_digest(configs)
     kernel_digest = kernel_digest(fixture)
 
@@ -166,7 +169,16 @@ defmodule Beaver.Shadow.Tuning do
         Beaver.Triton.register(context)
 
         Enum.map(configs, fn config ->
-          evaluate(fixture, config, context, target, config_space_digest, kernel_digest)
+          evaluate(
+            fixture,
+            config,
+            context,
+            target,
+            config_space_digest,
+            kernel_digest,
+            gpu?,
+            launch
+          )
         end)
       after
         MLIR.Context.destroy(context)
@@ -227,6 +239,43 @@ defmodule Beaver.Shadow.Tuning do
       {not proxy.lowered_to_llvm, proxy.optimized}
     end)
     |> List.first()
+  end
+
+  @doc """
+  Picks the winner by measured GPU latency (lowest median first).
+  """
+  @spec pick_winner_by_latency([Record.t()]) :: Record.t() | nil
+  def pick_winner_by_latency(records) do
+    records
+    |> Enum.filter(&(&1.status == :evaluated and is_number(&1.timings && &1.timings.gpu_ns)))
+    |> Enum.sort_by(& &1.timings.gpu_ns)
+    |> List.first()
+  end
+
+  @doc """
+  Spearman rank correlation between a structural fact and GPU latency.
+
+  `proxy_fun` extracts the structural value and `latency_fun` the latency from
+  each record; only records with both are used. Returns `nil` when fewer than
+  two points are available.
+  """
+  @spec correlation([Record.t()], (Record.t() -> number() | nil), (Record.t() -> number() | nil)) ::
+          float() | nil
+  def correlation(records, proxy_fun, latency_fun) do
+    pairs =
+      records
+      |> Enum.map(fn record ->
+        {proxy_fun.(record), latency_fun.(record)}
+      end)
+      |> Enum.filter(fn {proxy, latency} -> is_number(proxy) and is_number(latency) end)
+
+    if length(pairs) < 2 do
+      nil
+    else
+      {proxy_ranks, _} = rank(pairs |> Enum.map(&elem(&1, 0)))
+      {latency_ranks, _} = rank(pairs |> Enum.map(&elem(&1, 1)))
+      pearson(proxy_ranks, latency_ranks)
+    end
   end
 
   @doc """
@@ -330,11 +379,21 @@ defmodule Beaver.Shadow.Tuning do
     }
   end
 
-  defp evaluate(fixture, config, context, target, config_space_digest, kernel_digest) do
+  defp evaluate(
+         fixture,
+         config,
+         context,
+         target,
+         config_space_digest,
+         kernel_digest,
+         gpu?,
+         launch
+       ) do
     started = System.monotonic_time()
+    source_text = File.read!(Corpus.fixture_path(fixture.name))
 
     try do
-      module = MLIR.Module.create!(File.read!(Corpus.fixture_path(fixture.name)), ctx: context)
+      module = MLIR.Module.create!(source_text, ctx: context)
 
       result =
         OptimizationTrial.run(module,
@@ -342,6 +401,14 @@ defmodule Beaver.Shadow.Tuning do
           num_warps: config.num_warps,
           gpu: false
         )
+
+      gpu_latency =
+        if gpu? and launch do
+          case GPU.evaluate(source_text, context, target, config.num_warps, launch) do
+            {:ok, ns} -> ns
+            {:error, reason} -> reason
+          end
+        end
 
       proxy = %{
         baseline: result.baseline,
@@ -358,13 +425,17 @@ defmodule Beaver.Shadow.Tuning do
         config_space_digest: config_space_digest,
         config: config,
         status: if(result.lowered_to_llvm, do: :evaluated, else: :failed),
+        # GPU latency is an observation, never part of identity/1.
+        timings: %{
+          total_ns: System.monotonic_time() - started,
+          gpu_ns: gpu_latency
+        },
         failure:
           if(result.lowered_to_llvm,
             do: nil,
             else: %{kind: :lowering_failed, reason: "no llvm.func produced"}
           ),
-        structural_proxy: proxy,
-        timings: %{total_ns: System.monotonic_time() - started}
+        structural_proxy: proxy
       }
     rescue
       exception ->
@@ -381,6 +452,36 @@ defmodule Beaver.Shadow.Tuning do
           timings: %{total_ns: System.monotonic_time() - started}
         }
     end
+  end
+
+  defp rank(values) do
+    sorted = values |> Enum.sort() |> Enum.with_index()
+
+    rank_map =
+      sorted |> Enum.group_by(&elem(&1, 0)) |> Map.new(fn {v, idxs} -> {v, avg_rank(idxs)} end)
+
+    {Enum.map(values, &Map.fetch!(rank_map, &1)), sorted}
+  end
+
+  defp avg_rank(idxs) do
+    Enum.map(idxs, &(elem(&1, 1) + 1)) |> Enum.sum() |> Kernel./(length(idxs))
+  end
+
+  defp pearson(xs, ys) do
+    n = length(xs)
+    x_mean = Enum.sum(xs) / n
+    y_mean = Enum.sum(ys) / n
+
+    {sxy, sxx, syy} =
+      xs
+      |> Enum.zip(ys)
+      |> Enum.reduce({0.0, 0.0, 0.0}, fn {x, y}, {sxy, sxx, syy} ->
+        dx = x - x_mean
+        dy = y - y_mean
+        {sxy + dx * dy, sxx + dx * dx, syy + dy * dy}
+      end)
+
+    if sxx == 0.0 or syy == 0.0, do: nil, else: sxy / :math.sqrt(sxx * syy)
   end
 
   defp kernel_digest(fixture) do

--- a/lib/beaver/shadow/tuning/gpu.ex
+++ b/lib/beaver/shadow/tuning/gpu.ex
@@ -1,0 +1,157 @@
+defmodule Beaver.Shadow.Tuning.GPU do
+  @moduledoc """
+  Real-kernel latency evaluation for tuning configs.
+
+  Compiles a TTIR source with the config's `num_warps`, translates to PTX,
+  loads it through `Beaver.MLIR.CUDA`, allocates the buffers described by
+  `launch.buffer_sizes`, and reports the median launch latency across
+  `samples`. Buffer placeholder atoms in `launch.args_template` (e.g.
+  `{:ptr, :a}`) are resolved to the allocated device pointers.
+  """
+
+  alias Beaver.MLIR
+
+  @type launch() :: %{
+          kernel_name: String.t(),
+          grid: {pos_integer(), pos_integer(), pos_integer()},
+          block: {pos_integer(), pos_integer(), pos_integer()},
+          shared_mem: non_neg_integer(),
+          samples: pos_integer(),
+          buffer_sizes: %{atom() => pos_integer()},
+          args_template: [{:ptr | :i64, atom() | integer()}]
+        }
+
+  @doc """
+  Evaluates one config: lowers `source_text` with `num_warps`, launches on the
+  GPU and returns `{:ok, median_ns}` or `{:error, reason}`.
+  """
+  @spec evaluate(String.t(), MLIR.Context.t(), String.t(), pos_integer(), launch()) ::
+          {:ok, non_neg_integer()} | {:error, term()}
+  def evaluate(source_text, context, target, num_warps, launch) do
+    module = MLIR.Module.create!(source_text, ctx: context)
+
+    try do
+      llvm =
+        Beaver.Triton.compile_to_llvm(module,
+          target: target,
+          num_warps: num_warps
+        )
+
+      ptx = llvm_to_ptx(MLIR.to_string(llvm))
+      {:ok, launch_latency_ns(ptx, launch, num_warps)}
+    rescue
+      exception -> {:error, Exception.message(exception)}
+    after
+      MLIR.Module.destroy(module)
+    end
+  end
+
+  defp launch_latency_ns(ptx, launch, num_warps) do
+    %{
+      kernel_name: kernel_name,
+      grid: grid,
+      shared_mem: shared_mem,
+      samples: samples,
+      buffer_sizes: buffer_sizes,
+      args_template: args_template
+    } = launch
+
+    # The block must match the kernel's launch configuration: one warp per 32
+    # threads, so num_warps warps map to 32 * num_warps threads.
+    block = {32 * num_warps, 1, 1}
+
+    escaped =
+      ptx
+      |> String.replace("\\", "\\\\")
+      |> String.replace("\"", "\\\"")
+      |> String.replace("\n", "\\0A")
+
+    module_text = """
+    module {
+      gpu.binary @kernel [#gpu.object<#nvvm.target<chip = "sm_80">, assembly = "#{escaped}">]
+    }
+    """
+
+    context = MLIR.Context.create()
+
+    try do
+      module = MLIR.Module.create!(module_text, ctx: context)
+      {:ok, mod} = MLIR.CUDA.load_gpu_binary(module)
+      {:ok, f} = MLIR.CUDA.module_get_function(mod, kernel_name)
+
+      {:ok, buffers} = alloc_buffers(buffer_sizes)
+
+      try do
+        resolved_args = resolve_args(args_template, buffers)
+
+        :ok = MLIR.CUDA.launch_kernel(f, grid, block, resolved_args, shared_mem: shared_mem)
+        :ok = MLIR.CUDA.synchronize()
+
+        durations =
+          for _ <- 1..samples do
+            started = System.monotonic_time()
+            :ok = MLIR.CUDA.launch_kernel(f, grid, block, resolved_args, shared_mem: shared_mem)
+            :ok = MLIR.CUDA.synchronize()
+            System.monotonic_time() - started
+          end
+          |> Enum.sort()
+
+        Enum.at(durations, div(length(durations), 2))
+      after
+        Enum.each(buffers, fn {_name, ptr} -> MLIR.CUDA.mem_free(ptr) end)
+      end
+    after
+      MLIR.Context.destroy(context)
+    end
+  end
+
+  defp llvm_to_ptx(llvm_text) do
+    llvm_path =
+      Path.join(System.tmp_dir!(), "shadow_tune_#{System.unique_integer([:positive])}.ll")
+
+    ptx_path =
+      Path.join(System.tmp_dir!(), "shadow_tune_#{System.unique_integer([:positive])}.ptx")
+
+    File.write!(llvm_path, llvm_text)
+
+    llvm_bin =
+      System.get_env("LLVM_CONFIG_PATH")
+      |> Path.dirname()
+
+    {_, 0} =
+      System.cmd(
+        Path.join(llvm_bin, "mlir-translate"),
+        ["--mlir-to-llvmir", llvm_path, "-o", llvm_path <> ".ll"],
+        stderr_to_stdout: true
+      )
+
+    {_, 0} =
+      System.cmd(
+        Path.join(llvm_bin, "llc"),
+        ["-march=nvptx64", "-mcpu=sm_80", llvm_path <> ".ll", "-o", ptx_path],
+        stderr_to_stdout: true
+      )
+
+    ptx = File.read!(ptx_path)
+    File.rm!(llvm_path)
+    File.rm!(llvm_path <> ".ll")
+    File.rm!(ptx_path)
+    ptx
+  end
+
+  defp alloc_buffers(buffer_sizes) do
+    Enum.reduce_while(buffer_sizes, {:ok, %{}}, fn {name, size}, {:ok, acc} ->
+      case MLIR.CUDA.mem_alloc(size) do
+        {:ok, ptr} -> {:cont, {:ok, Map.put(acc, name, ptr)}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp resolve_args(args_template, buffers) do
+    Enum.map(args_template, fn
+      {:ptr, name} when is_atom(name) -> {:ptr, Map.fetch!(buffers, name)}
+      other -> other
+    end)
+  end
+end

--- a/test/fixtures/triton/ttir_matmul_1024.mlir
+++ b/test/fixtures/triton/ttir_matmul_1024.mlir
@@ -1,0 +1,61 @@
+module {
+  tt.func public @matmul_kernel(%arg0: !tt.ptr<f32> , %arg1: !tt.ptr<f32> , %arg2: !tt.ptr<f32> , %arg3: i32 , %arg4: i32 , %arg5: i32 , %arg6: i32 , %arg7: i32 , %arg8: i32 , %arg9: i32 , %arg10: i32 , %arg11: i32 ) attributes {noinline = false} {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32> 
+    %c0_i32 = arith.constant 0 : i32 
+    %c64_i32 = arith.constant 64 : i32 
+    %0 = tt.get_program_id x : i32 
+    %1 = tt.get_program_id y : i32 
+    %2 = arith.muli %0, %c64_i32 : i32 
+    %3 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32> 
+    %4 = tt.splat %2 : i32 -> tensor<64xi32> 
+    %5 = arith.addi %4, %3 : tensor<64xi32> 
+    %6 = arith.muli %1, %c64_i32 : i32 
+    %7 = tt.splat %6 : i32 -> tensor<64xi32> 
+    %8 = arith.addi %7, %3 : tensor<64xi32> 
+    %9 = tt.expand_dims %5 {axis = 1 : i32} : tensor<64xi32> -> tensor<64x1xi32> 
+    %10 = tt.splat %arg6 : i32 -> tensor<64x1xi32> 
+    %11 = arith.muli %9, %10 : tensor<64x1xi32> 
+    %12 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<64x1x!tt.ptr<f32>> 
+    %13 = tt.addptr %12, %11 : tensor<64x1x!tt.ptr<f32>>, tensor<64x1xi32> 
+    %14 = tt.expand_dims %3 {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32> 
+    %15 = tt.splat %arg7 : i32 -> tensor<1x64xi32> 
+    %16 = arith.muli %14, %15 : tensor<1x64xi32> 
+    %17 = tt.broadcast %13 : tensor<64x1x!tt.ptr<f32>> -> tensor<64x64x!tt.ptr<f32>> 
+    %18 = tt.broadcast %16 : tensor<1x64xi32> -> tensor<64x64xi32> 
+    %19 = tt.addptr %17, %18 : tensor<64x64x!tt.ptr<f32>>, tensor<64x64xi32> 
+    %20 = tt.expand_dims %3 {axis = 1 : i32} : tensor<64xi32> -> tensor<64x1xi32> 
+    %21 = tt.splat %arg8 : i32 -> tensor<64x1xi32> 
+    %22 = arith.muli %20, %21 : tensor<64x1xi32> 
+    %23 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<64x1x!tt.ptr<f32>> 
+    %24 = tt.addptr %23, %22 : tensor<64x1x!tt.ptr<f32>>, tensor<64x1xi32> 
+    %25 = tt.expand_dims %8 {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32> 
+    %26 = tt.splat %arg9 : i32 -> tensor<1x64xi32> 
+    %27 = arith.muli %25, %26 : tensor<1x64xi32> 
+    %28 = tt.broadcast %24 : tensor<64x1x!tt.ptr<f32>> -> tensor<64x64x!tt.ptr<f32>> 
+    %29 = tt.broadcast %27 : tensor<1x64xi32> -> tensor<64x64xi32> 
+    %30 = tt.addptr %28, %29 : tensor<64x64x!tt.ptr<f32>>, tensor<64x64xi32> 
+    %31:3 = scf.for %arg12 = %c0_i32 to %arg5 step %c64_i32 iter_args(%arg13 = %cst, %arg14 = %19, %arg15 = %30) -> (tensor<64x64xf32>, tensor<64x64x!tt.ptr<f32>>, tensor<64x64x!tt.ptr<f32>>)  : i32 {
+      %41 = tt.load %arg14 : tensor<64x64x!tt.ptr<f32>> 
+      %42 = tt.load %arg15 : tensor<64x64x!tt.ptr<f32>> 
+      %43 = tt.dot %41, %42, %arg13, inputPrecision = tf32 : tensor<64x64xf32> * tensor<64x64xf32> -> tensor<64x64xf32> 
+      %44 = arith.muli %arg7, %c64_i32 : i32 
+      %45 = tt.splat %44 : i32 -> tensor<64x64xi32> 
+      %46 = tt.addptr %arg14, %45 : tensor<64x64x!tt.ptr<f32>>, tensor<64x64xi32> 
+      %47 = arith.muli %arg8, %c64_i32 : i32 
+      %48 = tt.splat %47 : i32 -> tensor<64x64xi32> 
+      %49 = tt.addptr %arg15, %48 : tensor<64x64x!tt.ptr<f32>>, tensor<64x64xi32> 
+      scf.yield %43, %46, %49 : tensor<64x64xf32>, tensor<64x64x!tt.ptr<f32>>, tensor<64x64x!tt.ptr<f32>> 
+    } 
+    %32 = tt.splat %arg10 : i32 -> tensor<64x1xi32> 
+    %33 = arith.muli %9, %32 : tensor<64x1xi32> 
+    %34 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<64x1x!tt.ptr<f32>> 
+    %35 = tt.addptr %34, %33 : tensor<64x1x!tt.ptr<f32>>, tensor<64x1xi32> 
+    %36 = tt.splat %arg11 : i32 -> tensor<1x64xi32> 
+    %37 = arith.muli %25, %36 : tensor<1x64xi32> 
+    %38 = tt.broadcast %35 : tensor<64x1x!tt.ptr<f32>> -> tensor<64x64x!tt.ptr<f32>> 
+    %39 = tt.broadcast %37 : tensor<1x64xi32> -> tensor<64x64xi32> 
+    %40 = tt.addptr %38, %39 : tensor<64x64x!tt.ptr<f32>>, tensor<64x64xi32> 
+    tt.store %40, %31#0 : tensor<64x64x!tt.ptr<f32>> 
+    tt.return 
+  } 
+} 

--- a/test/shadow_report_test.exs
+++ b/test/shadow_report_test.exs
@@ -55,7 +55,7 @@ defmodule Beaver.Shadow.ReportTest do
     report = Report.generate()
 
     assert is_binary(report.llvm_revision) and report.llvm_revision != ""
-    assert length(report.fixtures) == 3
+    assert length(report.fixtures) == 4
 
     matmul = Enum.find(report.fixtures, &(&1.name == :matmul))
     assert matmul.baseline == 24

--- a/test/shadow_tune_report_test.exs
+++ b/test/shadow_tune_report_test.exs
@@ -62,6 +62,8 @@ defmodule Beaver.Shadow.TuneReportTest do
         config_space_digest: Tuning.configs_digest(run.records |> Enum.map(& &1.config)),
         records: run.records,
         winner: run.winner,
+        latency_winner: List.last(run.records),
+        structural_vs_latency: -0.5,
         probes: [
           %{
             config: %Config{index: 0, num_warps: 2},
@@ -84,8 +86,10 @@ defmodule Beaver.Shadow.TuneReportTest do
       assert rendered =~ "llvm revision: LLVM version 24.0.0git"
       assert rendered =~ "triton prebuilt dir: `/tmp/prebuilt`"
       assert rendered =~ "| 0 | 2 | - | - |"
-      assert rendered =~ "| 2 | evaluated | 24 | 4 | -20 | true | 1000000 |"
-      assert rendered =~ "### Winner" and rendered =~ "num_warps 8"
+      assert rendered =~ "| 2 | 8 | evaluated | 24 | 4 | -20 | true | 1000000 | - |"
+      assert rendered =~ "### Winner (structural proxy)" and rendered =~ "num_warps 8"
+      assert rendered =~ "### Winner (measured GPU latency)"
+      assert rendered =~ "Spearman(structural optimized count, GPU latency): -0.5"
       assert rendered =~ "| 0 | 2 | ok |"
       assert rendered =~ "| 1 | 4 | crash (exit 139) at `tritongpu-accelerate-matmul` |"
     end
@@ -110,6 +114,32 @@ defmodule Beaver.Shadow.TuneReportTest do
 
     rendered = TuneReport.render(report)
     assert rendered =~ "## Shadow Wavefront: Triton tuning measurement"
-    assert rendered =~ "| 0 | evaluated | 24 | 5 | -19 |"
+    assert rendered =~ "| 0 | 2 | evaluated | 24 | 5 | -19 |"
+  end
+
+  @tag :cuda
+  @tag skip: !@triton_enabled or System.get_env("BEAVER_CUDA_TEST") == nil
+  test "GPU generate/0 reports latency winner and correlation" do
+    configs = [
+      %Config{index: 0, num_warps: 2},
+      %Config{index: 1, num_warps: 4},
+      %Config{index: 2, num_warps: 8}
+    ]
+
+    report = TuneReport.generate(:matmul_1024, configs, gpu: true)
+
+    assert report.latency_winner != nil
+
+    latencies =
+      report.records
+      |> Enum.filter(&is_number(&1.timings && &1.timings.gpu_ns))
+      |> Enum.map(& &1.timings.gpu_ns)
+
+    assert report.latency_winner.timings.gpu_ns == Enum.min(latencies)
+    assert Enum.max(latencies) / Enum.min(latencies) > 1.1
+
+    rendered = TuneReport.render(report)
+    assert rendered =~ "### Winner (measured GPU latency)"
+    assert rendered =~ "Spearman(structural optimized count, GPU latency)"
   end
 end

--- a/test/shadow_tuning_test.exs
+++ b/test/shadow_tuning_test.exs
@@ -170,6 +170,104 @@ defmodule Beaver.Shadow.TuningTest do
     end
   end
 
+  describe "correlation/3" do
+    test "returns ~1.0 for perfectly monotonic negative structural/latency data" do
+      records = [
+        sample_record(%{
+          config: %Config{index: 0, num_warps: 2},
+          structural_proxy: %{baseline: 24, optimized: 8, reduction: 16, lowered_to_llvm: true},
+          timings: %{total_ns: 1, gpu_ns: 100}
+        }),
+        sample_record(%{
+          config: %Config{index: 1, num_warps: 4},
+          structural_proxy: %{baseline: 24, optimized: 5, reduction: 19, lowered_to_llvm: true},
+          timings: %{total_ns: 1, gpu_ns: 200}
+        }),
+        sample_record(%{
+          config: %Config{index: 2, num_warps: 8},
+          structural_proxy: %{baseline: 24, optimized: 3, reduction: 21, lowered_to_llvm: true},
+          timings: %{total_ns: 1, gpu_ns: 300}
+        })
+      ]
+
+      rho =
+        Tuning.correlation(
+          records,
+          fn record ->
+            record.structural_proxy && record.structural_proxy.optimized
+          end,
+          fn record ->
+            record.timings && record.timings.gpu_ns
+          end
+        )
+
+      assert_in_delta rho, -1.0, 0.001
+    end
+
+    test "returns nil with fewer than two paired points" do
+      records = [sample_record()]
+
+      assert Tuning.correlation(records, fn _ -> 1 end, fn _ -> 2 end) == nil
+    end
+
+    test "ignores records missing latency or proxy" do
+      records = [
+        sample_record(%{
+          config: %Config{index: 0, num_warps: 2},
+          timings: %{total_ns: 1, gpu_ns: 100}
+        }),
+        sample_record(%{
+          config: %Config{index: 1, num_warps: 4},
+          structural_proxy: nil,
+          timings: %{total_ns: 1, gpu_ns: 200}
+        }),
+        sample_record(%{
+          config: %Config{index: 2, num_warps: 8},
+          timings: %{total_ns: 1, gpu_ns: nil}
+        }),
+        sample_record(%{
+          config: %Config{index: 3, num_warps: 16},
+          timings: %{total_ns: 1, gpu_ns: 50}
+        })
+      ]
+
+      rho =
+        Tuning.correlation(
+          records,
+          fn record ->
+            record.structural_proxy && record.structural_proxy.optimized
+          end,
+          fn record ->
+            record.timings && record.timings.gpu_ns
+          end
+        )
+
+      # only index 0 and 3 have both; their optimized values are 5 and 5
+      assert rho == nil
+    end
+  end
+
+  describe "pick_winner_by_latency/1" do
+    test "picks the lowest measured latency" do
+      records = [
+        sample_record(%{
+          config: %Config{index: 0, num_warps: 2},
+          timings: %{total_ns: 1, gpu_ns: 300}
+        }),
+        sample_record(%{
+          config: %Config{index: 1, num_warps: 4},
+          timings: %{total_ns: 1, gpu_ns: 100}
+        }),
+        sample_record(%{
+          config: %Config{index: 2, num_warps: 8},
+          timings: %{total_ns: 1, gpu_ns: "cuLaunchKernel failed"}
+        })
+      ]
+
+      assert Tuning.pick_winner_by_latency(records).config.num_warps == 4
+    end
+  end
+
   @tag :triton
   @tag skip: !@triton_enabled
   test "CPU-only config enumeration produces records and a structural winner" do
@@ -209,5 +307,46 @@ defmodule Beaver.Shadow.TuningTest do
       assert decision.structural_proxy.baseline == 24
       assert decision.reason =~ "convert_layouts" or decision.reason =~ "pruned"
     end
+  end
+
+  @tag :triton
+  @tag skip: !@triton_enabled
+  test "1024x1024 matmul reproduces its corpus counts" do
+    fixture = Beaver.Shadow.Corpus.fixture(:matmul_1024)
+    run = Tuning.run(:matmul_1024, sample_configs())
+
+    assert fixture.baseline == 17
+    assert fixture.optimized == 3
+
+    for record <- run.records do
+      assert record.structural_proxy.baseline == 17
+      assert record.structural_proxy.optimized == 3
+      assert record.status == :evaluated
+    end
+  end
+
+  @tag :cuda
+  @tag skip: !@triton_enabled or System.get_env("BEAVER_CUDA_TEST") == nil
+  test "real GPU config space shows nontrivial latency spread and a latency winner" do
+    configs = [
+      %Config{index: 0, num_warps: 2},
+      %Config{index: 1, num_warps: 4},
+      %Config{index: 2, num_warps: 8}
+    ]
+
+    run = Tuning.run(:matmul_1024, configs, gpu: true)
+
+    latencies =
+      run.records
+      |> Enum.filter(&is_number(&1.timings && &1.timings.gpu_ns))
+      |> Enum.map(& &1.timings.gpu_ns)
+
+    assert length(latencies) == 3
+
+    winner = Tuning.pick_winner_by_latency(run.records)
+    assert winner.timings.gpu_ns == Enum.min(latencies)
+
+    # Nontrivial: the config choice moves real latency by more than noise.
+    assert Enum.max(latencies) / Enum.min(latencies) > 1.1
   end
 end


### PR DESCRIPTION
Forgejo #21 slice 6: calibrate the structural proxy against real GPU latency and expose the winner gap.

- Corpus gains `:matmul_1024` (1024x1024 TTIR, 17->3 convert_layouts);
- `Beaver.Shadow.Tuning.GPU`: compiles each config with its num_warps, derives the matching block, launches on the GPU, reports median latency; buffer placeholders resolve to device pointers;
- `Tuning.run/3` accepts `gpu: true`; records carry gpu_ns as an observation; `pick_winner_by_latency/1` and Spearman `correlation/3` are pure functions;
- tune_report renders the latency table, both winners, and the structural-vs-latency correlation.

Measured on RTX 5070 (local, @cuda): num_warps 8 runs the 1024x1024 matmul in 0.97ms vs 13.3ms for default num_warps 4 (~13.7x). All configs have identical convert_layout counts (3), so the structural proxy cannot rank them — that is the calibration result, and the latency winner is the actionable one.