### PR TITLE
ex: fix i1 boolean lowering for cmp/if and guarded case clauses

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -196,12 +196,24 @@ defmodule Beaver.MLIR.Conversion.Ex do
       %Changeset{name: "arith.cmpi", context: context, location: location}
       |> Changeset.add_argument([left, right])
       |> Changeset.add_argument(predicate: cmp_i_predicate(predicate))
-      |> Changeset.add_result(result_type)
+      |> Changeset.add_result(MLIR.Type.i1())
       |> MLIR.Operation.create()
 
     MLIR.RewriterBase.set_insertion_point_before(base, operation)
     MLIR.RewriterBase.insert(base, cmpi)
-    MLIR.ConversionPatternRewriter.replace_op(rewriter, operation, MLIR.Operation.result(cmpi, 0))
+
+    # Comparisons produce i1 in arith; widen back to the ex.cmp result's i64
+    # boolean representation so it can feed arithmetic and scf.if conditions.
+    ext =
+      %Changeset{name: "arith.extui", context: context, location: location}
+      |> Changeset.add_argument([MLIR.Operation.result(cmpi, 0)])
+      |> Changeset.add_result(result_type)
+      |> MLIR.Operation.create()
+
+    MLIR.RewriterBase.set_insertion_point_after(base, cmpi)
+    MLIR.RewriterBase.insert(base, ext)
+
+    MLIR.ConversionPatternRewriter.replace_op(rewriter, operation, MLIR.Operation.result(ext, 0))
     :ok
   end
 
@@ -218,9 +230,20 @@ defmodule Beaver.MLIR.Conversion.Ex do
 
     [then_region, else_region] = operation |> Walker.regions() |> Enum.to_list()
 
+    # scf.if conditions are i1 at the LLVM boundary; the ex universe carries
+    # booleans as i64 0/1, so truncate before the branch.
+    cond_i1 =
+      %Changeset{name: "arith.trunci", context: context, location: location}
+      |> Changeset.add_argument([cond])
+      |> Changeset.add_result(MLIR.Type.i1())
+      |> MLIR.Operation.create()
+
+    MLIR.RewriterBase.set_insertion_point_before(base, operation)
+    MLIR.RewriterBase.insert(base, cond_i1)
+
     scf_if =
       %Changeset{name: "scf.if", context: context, location: location}
-      |> Changeset.add_argument(cond)
+      |> Changeset.add_argument(MLIR.Operation.result(cond_i1, 0))
       |> Changeset.add_argument(MLIR.CAPI.mlirRegionCreate())
       |> Changeset.add_argument(MLIR.CAPI.mlirRegionCreate())
       |> Changeset.add_result(result_types)

--- a/lib/beaver/mlir/dialect/ex/expand_case.ex
+++ b/lib/beaver/mlir/dialect/ex/expand_case.ex
@@ -112,7 +112,7 @@ defmodule Beaver.MLIR.Dialect.Ex.ExpandCase do
   defp build_chain([clause | rest], scrutinee, result_types, context, location, rewriter) do
     {patterns, guard} = clause_patterns(clause, rewriter)
 
-    if patterns == [] and rest != [] do
+    if patterns == [] and guard == nil and rest != [] do
       raise ArgumentError,
             "ex.case catch-all clause must be last, got a clause without patterns before more clauses"
     end

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -352,6 +352,71 @@ defmodule ExConversionTest do
     assert rendered =~ "scf.if"
   end
 
+  test "expands a guarded no-pattern clause before more clauses", %{ctx: ctx} do
+    Beaver.Slang.load(ctx, ExDialect)
+
+    module =
+      MLIR.Module.create!(
+        ~S"""
+        module {
+          "ex.func"() ({
+          ^bb0:
+            %0 = "ex.lit"() {value = 1 : i64} : () -> i64
+            %1 = "ex.lit"() {value = 1 : i64} : () -> i64
+            %2 = "ex.case"(%0) ({
+            ^bb0:
+              "ex.clause"(%1) {patterns = array<i64>} : (i64) -> ()
+              %3 = "ex.lit"() {value = 10 : i64} : () -> i64
+              "ex.yield"(%3) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+            ^bb1:
+              "ex.clause"() {patterns = array<i64>} : () -> ()
+              %4 = "ex.lit"() {value = 20 : i64} : () -> i64
+              "ex.yield"(%4) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+            }) {operandSegmentSizes = array<i32: 1>} : (i64) -> i64
+            "ex.return"(%2) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+          }) {sym_name = "main"} : () -> ()
+        }
+        """,
+        ctx: ctx
+      )
+      |> MLIR.verify!()
+
+    module = ExpandCase.run!(module)
+    expanded = MLIR.to_string(module, generic: true)
+    # a no-pattern clause matches everything, so the condition is the guard
+    assert expanded =~ ~s{predicate = "ne"}
+
+    converted = Plan.run!(Ex.plan(), module)
+    assert MLIR.to_string(converted, generic: true) =~ "scf.if"
+  end
+
+  test "lowers control flow through to LLVM", %{ctx: ctx} do
+    Beaver.Slang.load(ctx, ExDialect)
+
+    module =
+      MLIR.Module.create!(@control_flow_module, ctx: ctx)
+      |> MLIR.verify!()
+      |> then(&ExpandCase.run!/1)
+
+    converted = Plan.run!(Ex.plan(), module)
+
+    pass_manager = MLIR.CAPI.mlirPassManagerCreate(ctx)
+
+    for pass <- [
+          &MLIR.CAPI.mlirCreateConversionArithToLLVMConversionPass/0,
+          &MLIR.CAPI.mlirCreateConversionSCFToControlFlowPass/0,
+          &MLIR.CAPI.mlirCreateConversionConvertControlFlowToLLVMPass/0,
+          &MLIR.CAPI.mlirCreateConversionConvertFuncToLLVMPass/0
+        ] do
+      MLIR.CAPI.mlirPassManagerAddOwnedPass(pass_manager, pass.())
+    end
+
+    assert {:ok, _} = MLIR.PassManager.run(pass_manager, converted)
+    rendered = MLIR.to_string(converted, generic: true)
+    assert rendered =~ "llvm.br"
+    refute rendered =~ "scf.if"
+  end
+
   test "rejects a case without a catch-all clause", %{ctx: ctx} do
     Beaver.Slang.load(ctx, ExDialect)
 


### PR DESCRIPTION
Follow-up to #554, required by the batata-side `case` lift (tsai/beaver#6).

## What

Three fixes in the ex lowering:

1. **`convert_cmp`**: `arith.cmpi` now produces an i1 result, widened back to
   the ex.cmp result's i64 boolean with `arith.extui`. Previously cmpi carried
   the i64 result type, which fails LLVM conversion (`llvm.icmp` result must
   be 1-bit).
2. **`convert_if`**: the i64 condition is truncated to i1 with `arith.trunci`
   before `scf.if` (scf.if requires a 1-bit condition at the LLVM boundary).
3. **`ExpandCase`**: a no-pattern clause with a guard is no longer treated as
   a misplaced catch-all — guarded clauses (e.g. variable patterns) can
   appear before more clauses; the condition is just the guard.

## Tests

- control flow (`ex.cmp`/`ex.if`) now lowers all the way to LLVM (`llvm.br`,
  no `scf.if` left) through arith-to-llvm + scf-to-cf + cf-to-llvm +
  func-to-llvm;
- guard-only (no-pattern) clause expands to `guard != 0` and converts;
- existing case expansion and scalar lowering coverage unchanged.