### PR TITLE
ex: add term read and equality ops to the dialect

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -86,6 +86,12 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.is_list", &convert_term_predicate/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.is_tuple", &convert_term_predicate/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.is_map", &convert_term_predicate/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.tuple_get", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.tuple_length", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.list_head", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.list_tail", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.list_length", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.term_eq", &convert_term_read/3, version: "1.0")
   end
 
   # Declaration-first manifest of the Zig term runtime ABI: batata's
@@ -100,7 +106,13 @@ defmodule Beaver.MLIR.Conversion.Ex do
     is_binary: "ex.term.is_binary",
     is_list: "ex.term.is_list",
     is_tuple: "ex.term.is_tuple",
-    is_map: "ex.term.is_map"
+    is_map: "ex.term.is_map",
+    tuple_get: "ex.term.tuple_get",
+    tuple_length: "ex.term.tuple_length",
+    list_head: "ex.term.list_head",
+    list_tail: "ex.term.list_tail",
+    list_length: "ex.term.list_length",
+    term_eq: "ex.term.eq"
   }
 
   @term_types ~w(!ex.dyn !ex.bound !ex.unbound)
@@ -356,6 +368,20 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp predicate_intrinsic("ex.is_tuple"), do: @term_intrinsics.is_tuple
   defp predicate_intrinsic("ex.is_map"), do: @term_intrinsics.is_map
 
+  defp convert_term_read(operation, operands, rewriter) do
+    base = insertion_point(operation, rewriter)
+    symbol = read_intrinsic(MLIR.Operation.name(operation))
+    result = emit_runtime_call(operation, rewriter, base, symbol, operands)
+    replace_with(rewriter, operation, result)
+  end
+
+  defp read_intrinsic("ex.tuple_get"), do: @term_intrinsics.tuple_get
+  defp read_intrinsic("ex.tuple_length"), do: @term_intrinsics.tuple_length
+  defp read_intrinsic("ex.list_head"), do: @term_intrinsics.list_head
+  defp read_intrinsic("ex.list_tail"), do: @term_intrinsics.list_tail
+  defp read_intrinsic("ex.list_length"), do: @term_intrinsics.list_length
+  defp read_intrinsic("ex.term_eq"), do: @term_intrinsics.term_eq
+
   defp insertion_point(operation, rewriter) do
     base = MLIR.ConversionPatternRewriter.as_base(rewriter)
     MLIR.RewriterBase.set_insertion_point_before(base, operation)
@@ -507,6 +533,11 @@ defmodule Beaver.MLIR.Conversion.Ex do
   end
 
   defp intrinsic_function_type("ex.term.list_cons") do
+    MLIR.Type.function([MLIR.Type.i64(), MLIR.Type.i64()], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type(symbol)
+       when symbol in ["ex.term.tuple_get", "ex.term.eq"] do
     MLIR.Type.function([MLIR.Type.i64(), MLIR.Type.i64()], [MLIR.Type.i64()])
   end
 

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -122,6 +122,24 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop is_map(value = any()),
     results: [result: all_of([base("!builtin.integer"), any()])]
 
+  defop tuple_get(tuple = base(dyn()), index = all_of([base("!builtin.integer"), any()])),
+    results: [result: base(dyn())]
+
+  defop tuple_length(tuple = base(dyn())),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
+  defop list_head(list = base(dyn())),
+    results: [result: base(dyn())]
+
+  defop list_tail(list = base(dyn())),
+    results: [result: base(dyn())]
+
+  defop list_length(list = base(dyn())),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
+  defop term_eq(left = base(dyn()), right = base(dyn())),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
   defop yield(values = variadic(any())), traits: [:terminator]
 
   defop func(),

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -514,6 +514,43 @@ defmodule ExConversionTest do
     assert rendered =~ "ex.term.is_list"
   end
 
+  test "converts term read ops to Zig runtime ABI calls", %{ctx: ctx} do
+    module =
+      term_module!(
+        ~S"""
+        module {
+          "ex.func"() ({
+          ^bb0:
+            %0 = "ex.lit"() {value = 1 : i64} : () -> i64
+            %1 = "ex.lit"() {value = 2 : i64} : () -> i64
+            %2 = "ex.box"(%0) : (i64) -> !ex.dyn
+            %3 = "ex.box"(%1) : (i64) -> !ex.dyn
+            %4 = "ex.tuple"(%2, %3) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
+            %5 = "ex.list"(%2, %3) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
+            %6 = "ex.tuple_length"(%4) : (!ex.dyn) -> i64
+            %7 = "ex.tuple_get"(%4, %0) : (!ex.dyn, i64) -> !ex.dyn
+            %8 = "ex.list_length"(%5) : (!ex.dyn) -> i64
+            %9 = "ex.list_head"(%5) : (!ex.dyn) -> !ex.dyn
+            %10 = "ex.list_tail"(%5) : (!ex.dyn) -> !ex.dyn
+            %11 = "ex.term_eq"(%7, %2) : (!ex.dyn, !ex.dyn) -> i64
+            "ex.return"(%11) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+          }) {sym_name = "main"} : () -> ()
+        }
+        """,
+        ctx
+      )
+
+    assert {:ok, _module, []} = Plan.run(Ex.plan(), module)
+
+    rendered = MLIR.to_string(module, generic: true)
+    assert rendered =~ "ex.term.tuple_length"
+    assert rendered =~ "ex.term.tuple_get"
+    assert rendered =~ "ex.term.list_length"
+    assert rendered =~ "ex.term.list_head"
+    assert rendered =~ "ex.term.list_tail"
+    assert rendered =~ "ex.term.eq"
+  end
+
   test "passes nested term operands through without re-tagging", %{ctx: ctx} do
     module =
       term_module!(


### PR DESCRIPTION
[tsai/beaver#23](http://localhost:3000/tsai/beaver/issues/23) step 2, dialect/conversion side — the batata-side match lowering (PR-C) consumes these.

## What

New ex dialect ops converting to the declaration-first Zig term runtime intrinsics:

- `ex.tuple_get(tuple, index) -> !ex.dyn` / `ex.tuple_length(tuple) -> i64`
- `ex.list_head(list) -> !ex.dyn` / `ex.list_tail(list) -> !ex.dyn` / `ex.list_length(list) -> i64`
- `ex.term_eq(left, right) -> i64` — word equality (immediate-safe, e.g. integer literal elements in patterns); deep container equality is a follow-up

Intrinsic declarations are emitted with the existing machinery; `tuple_get`/`eq` get two-argument function types.

## Tests

Conversion test: a module reading tuple/list lengths, elements, head/tail and comparing an element with a literal lowers to the matching `ex.term.*` calls.