### PR TITLE
ex: add binary read ops to the dialect

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -92,6 +92,9 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.list_tail", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.list_length", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.term_eq", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.binary_length", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.binary_get", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.binary_slice", &convert_term_read/3, version: "1.0")
   end
 
   # Declaration-first manifest of the Zig term runtime ABI: batata's
@@ -112,7 +115,10 @@ defmodule Beaver.MLIR.Conversion.Ex do
     list_head: "ex.term.list_head",
     list_tail: "ex.term.list_tail",
     list_length: "ex.term.list_length",
-    term_eq: "ex.term.eq"
+    term_eq: "ex.term.eq",
+    binary_length: "ex.term.binary_length",
+    binary_get: "ex.term.binary_get",
+    binary_slice: "ex.term.binary_slice"
   }
 
   @term_types ~w(!ex.dyn !ex.bound !ex.unbound)
@@ -381,6 +387,9 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.list_tail"), do: @term_intrinsics.list_tail
   defp read_intrinsic("ex.list_length"), do: @term_intrinsics.list_length
   defp read_intrinsic("ex.term_eq"), do: @term_intrinsics.term_eq
+  defp read_intrinsic("ex.binary_length"), do: @term_intrinsics.binary_length
+  defp read_intrinsic("ex.binary_get"), do: @term_intrinsics.binary_get
+  defp read_intrinsic("ex.binary_slice"), do: @term_intrinsics.binary_slice
 
   defp insertion_point(operation, rewriter) do
     base = MLIR.ConversionPatternRewriter.as_base(rewriter)
@@ -537,7 +546,12 @@ defmodule Beaver.MLIR.Conversion.Ex do
   end
 
   defp intrinsic_function_type(symbol)
-       when symbol in ["ex.term.tuple_get", "ex.term.eq"] do
+       when symbol in [
+              "ex.term.tuple_get",
+              "ex.term.eq",
+              "ex.term.binary_get",
+              "ex.term.binary_slice"
+            ] do
     MLIR.Type.function([MLIR.Type.i64(), MLIR.Type.i64()], [MLIR.Type.i64()])
   end
 

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -140,6 +140,15 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop term_eq(left = base(dyn()), right = base(dyn())),
     results: [result: all_of([base("!builtin.integer"), any()])]
 
+  defop binary_length(binary = base(dyn())),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
+  defop binary_get(binary = base(dyn()), index = all_of([base("!builtin.integer"), any()])),
+    results: [result: base(dyn())]
+
+  defop binary_slice(binary = base(dyn()), start = all_of([base("!builtin.integer"), any()])),
+    results: [result: base(dyn())]
+
   defop yield(values = variadic(any())), traits: [:terminator]
 
   defop func(),

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -551,6 +551,36 @@ defmodule ExConversionTest do
     assert rendered =~ "ex.term.eq"
   end
 
+  test "converts binary read ops to Zig runtime ABI calls", %{ctx: ctx} do
+    module =
+      term_module!(
+        ~S"""
+        module {
+          "ex.func"() ({
+          ^bb0:
+            %0 = "ex.lit"() {value = 1 : i64} : () -> i64
+            %1 = "ex.lit"() {value = 2 : i64} : () -> i64
+            %2 = "ex.box"(%0) : (i64) -> !ex.dyn
+            %3 = "ex.box"(%1) : (i64) -> !ex.dyn
+            %4 = "ex.binary"(%2, %3) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
+            %5 = "ex.binary_length"(%4) : (!ex.dyn) -> i64
+            %6 = "ex.binary_get"(%4, %0) : (!ex.dyn, i64) -> !ex.dyn
+            %7 = "ex.binary_slice"(%4, %1) : (!ex.dyn, i64) -> !ex.dyn
+            "ex.return"(%5) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+          }) {sym_name = "main"} : () -> ()
+        }
+        """,
+        ctx
+      )
+
+    assert {:ok, _module, []} = Plan.run(Ex.plan(), module)
+
+    rendered = MLIR.to_string(module, generic: true)
+    assert rendered =~ "ex.term.binary_length"
+    assert rendered =~ "ex.term.binary_get"
+    assert rendered =~ "ex.term.binary_slice"
+  end
+
   test "passes nested term operands through without re-tagging", %{ctx: ctx} do
     module =
       term_module!(


### PR DESCRIPTION
[tsai/beaver#23](http://localhost:3000/tsai/beaver/issues/23) step 4, dialect/conversion side — the batata-side binary match lowering consumes these.

## What

New ex dialect ops converting to the declaration-first Zig term runtime intrinsics:

- `ex.binary_length(binary) -> i64`
- `ex.binary_get(binary, index) -> !ex.dyn` — byte as a tagged int word
- `ex.binary_slice(binary, start) -> !ex.dyn` — materialized rest segment (M2; deferring rest materialization past guards stays an optimization)

## Tests

Conversion test: a module reading binary length, a byte and a rest slice lowers to the matching `ex.term.*` calls.