### PR TITLE
ex: add utf8 binary read ops to the dialect

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -95,6 +95,8 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.binary_length", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.binary_get", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.binary_slice", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.binary_utf8_get", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.binary_utf8_width", &convert_term_read/3, version: "1.0")
   end
 
   # Declaration-first manifest of the Zig term runtime ABI: batata's
@@ -118,7 +120,9 @@ defmodule Beaver.MLIR.Conversion.Ex do
     term_eq: "ex.term.eq",
     binary_length: "ex.term.binary_length",
     binary_get: "ex.term.binary_get",
-    binary_slice: "ex.term.binary_slice"
+    binary_slice: "ex.term.binary_slice",
+    binary_utf8_get: "ex.term.binary_utf8_get",
+    binary_utf8_width: "ex.term.binary_utf8_width"
   }
 
   @term_types ~w(!ex.dyn !ex.bound !ex.unbound)
@@ -390,6 +394,8 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.binary_length"), do: @term_intrinsics.binary_length
   defp read_intrinsic("ex.binary_get"), do: @term_intrinsics.binary_get
   defp read_intrinsic("ex.binary_slice"), do: @term_intrinsics.binary_slice
+  defp read_intrinsic("ex.binary_utf8_get"), do: @term_intrinsics.binary_utf8_get
+  defp read_intrinsic("ex.binary_utf8_width"), do: @term_intrinsics.binary_utf8_width
 
   defp insertion_point(operation, rewriter) do
     base = MLIR.ConversionPatternRewriter.as_base(rewriter)
@@ -550,7 +556,9 @@ defmodule Beaver.MLIR.Conversion.Ex do
               "ex.term.tuple_get",
               "ex.term.eq",
               "ex.term.binary_get",
-              "ex.term.binary_slice"
+              "ex.term.binary_slice",
+              "ex.term.binary_utf8_get",
+              "ex.term.binary_utf8_width"
             ] do
     MLIR.Type.function([MLIR.Type.i64(), MLIR.Type.i64()], [MLIR.Type.i64()])
   end

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -149,6 +149,15 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop binary_slice(binary = base(dyn()), start = all_of([base("!builtin.integer"), any()])),
     results: [result: base(dyn())]
 
+  defop binary_utf8_get(binary = base(dyn()), index = all_of([base("!builtin.integer"), any()])),
+    results: [result: base(dyn())]
+
+  defop binary_utf8_width(
+          binary = base(dyn()),
+          index = all_of([base("!builtin.integer"), any()])
+        ),
+        results: [result: all_of([base("!builtin.integer"), any()])]
+
   defop yield(values = variadic(any())), traits: [:terminator]
 
   defop func(),

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -581,6 +581,35 @@ defmodule ExConversionTest do
     assert rendered =~ "ex.term.binary_slice"
   end
 
+  test "converts utf8 binary read ops to Zig runtime ABI calls", %{ctx: ctx} do
+    module =
+      term_module!(
+        ~S"""
+        module {
+          "ex.func"() ({
+          ^bb0:
+            %0 = "ex.lit"() {value = 0 : i64} : () -> i64
+            %1 = "ex.lit"() {value = 195 : i64} : () -> i64
+            %2 = "ex.lit"() {value = 169 : i64} : () -> i64
+            %3 = "ex.box"(%1) : (i64) -> !ex.dyn
+            %4 = "ex.box"(%2) : (i64) -> !ex.dyn
+            %5 = "ex.binary"(%3, %4) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
+            %6 = "ex.binary_utf8_width"(%5, %0) : (!ex.dyn, i64) -> i64
+            %7 = "ex.binary_utf8_get"(%5, %0) : (!ex.dyn, i64) -> !ex.dyn
+            "ex.return"(%6) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+          }) {sym_name = "main"} : () -> ()
+        }
+        """,
+        ctx
+      )
+
+    assert {:ok, _module, []} = Plan.run(Ex.plan(), module)
+
+    rendered = MLIR.to_string(module, generic: true)
+    assert rendered =~ "ex.term.binary_utf8_width"
+    assert rendered =~ "ex.term.binary_utf8_get"
+  end
+
   test "passes nested term operands through without re-tagging", %{ctx: ctx} do
     module =
       term_module!(


### PR DESCRIPTION
[tsai/beaver#23](http://localhost:3000/tsai/beaver/issues/23) step 4 follow-up — the batata-side `::utf8` segment lowering consumes these.

## What

New ex dialect ops converting to the declaration-first Zig term runtime intrinsics:

- `ex.binary_utf8_get(binary, index) -> !ex.dyn` — codepoint as a tagged int term
- `ex.binary_utf8_width(binary, index) -> i64` — consumed bytes (0 for invalid/out-of-range), so the following segment offset is dynamic

## Tests

Conversion test: utf8 width/get calls lower to the matching `ex.term.*` symbols.