### PR TITLE
ex: allow scalar-typed ex.call results

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -76,6 +76,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.var", &convert_var/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.func", &convert_func/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.box", &convert_box/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.to_word", &convert_to_word/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.tuple", &convert_term_tuple/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.list", &convert_term_list/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.map", &convert_term_map/3, version: "1.0")
@@ -369,6 +370,10 @@ defmodule Beaver.MLIR.Conversion.Ex do
       end
 
     replace_with(rewriter, operation, word)
+  end
+
+  defp convert_to_word(operation, [operand], rewriter) do
+    replace_with(rewriter, operation, operand)
   end
 
   defp predicate_intrinsic("ex.is_integer"), do: @term_intrinsics.is_integer

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -67,7 +67,7 @@ defmodule Beaver.MLIR.Dialect.Ex do
         results: [result: all_of([base("!builtin.integer"), any()])]
 
   defop call(args = variadic(any())),
-    results: [result: base(dyn())],
+    results: [result: any()],
     attributes: [callee: ^callee_value, arity: ^integer_value]
 
   defop cmp(
@@ -90,6 +90,11 @@ defmodule Beaver.MLIR.Dialect.Ex do
     attributes: [patterns: any()]
 
   defop box(value = any()),
+    results: [result: base(dyn())]
+
+  # Lifts an already-tagged word (e.g. a function argument) into the term
+  # type without tagging: the conversion is a pure passthrough.
+  defop to_word(value = any()),
     results: [result: base(dyn())]
 
   defop tuple(elements = variadic(base(dyn()))),

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -315,6 +315,53 @@ defmodule ExConversionTest do
     assert rendered =~ "scf.yield"
   end
 
+  test "allows scalar-typed ex.call results", %{ctx: ctx} do
+    module =
+      term_module!(
+        ~S"""
+        module {
+          "ex.func"() ({
+          ^bb0:
+            %0 = "ex.lit"() {value = 1 : i64} : () -> i64
+            %1 = "ex.call"(%0) {callee = "id", arity = 1 : i64, operandSegmentSizes = array<i32: 1>} : (i64) -> i64
+            "ex.return"(%1) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+          }) {sym_name = "main"} : () -> ()
+        }
+        """,
+        ctx
+      )
+
+    assert {:ok, _module, []} = Plan.run(Ex.plan(), module)
+
+    rendered = MLIR.to_string(module, generic: true)
+    assert rendered =~ "func.call"
+    refute rendered =~ "!ex.dyn"
+  end
+
+  test "converts ex.to_word as a pure passthrough", %{ctx: ctx} do
+    module =
+      term_module!(
+        ~S"""
+        module {
+          "ex.func"() ({
+          ^bb0(%arg0: i64):
+            %0 = "ex.to_word"(%arg0) : (i64) -> !ex.dyn
+            %1 = "ex.is_binary"(%0) : (!ex.dyn) -> i64
+            "ex.return"(%1) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+          }) {sym_name = "main"} : () -> ()
+        }
+        """,
+        ctx
+      )
+
+    assert {:ok, _module, []} = Plan.run(Ex.plan(), module)
+
+    rendered = MLIR.to_string(module, generic: true)
+    assert rendered =~ "func.call"
+    assert rendered =~ "ex.term.is_binary"
+    refute rendered =~ "arith.shli"
+  end
+
   test "expands multiple integer patterns per clause into an OR condition", %{ctx: ctx} do
     Beaver.Slang.load(ctx, ExDialect)
 


### PR DESCRIPTION
[tsai/beaver#23](http://localhost:3000/tsai/beaver/issues/23) — prerequisite for typed calls to scalar-returning callees (recursive binary scanners).

## What

`ex.call`'s result constraint relaxes from `!ex.dyn` to `any()`, so a batata transform pass can retype calls whose callee returns i64 (e.g. `count(t)` in a recursive scanner) and have the result feed arithmetic.

## Tests

Conversion test: an `ex.call` with an i64 result verifies and lowers to `func.call` with no `!ex.dyn` left.