### PR TITLE
ex: give ex.call per-argument optional operand slots

### DIFF
--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -66,9 +66,17 @@ defmodule Beaver.MLIR.Dialect.Ex do
         ),
         results: [result: all_of([base("!builtin.integer"), any()])]
 
-  defop call(args = variadic(any())),
-    results: [result: any()],
-    attributes: [callee: ^callee_value, arity: ^integer_value]
+  # Each argument is its own optional slot so heterogeneous argument types
+  # (e.g. a term plus a scalar accumulator) verify: IRDL variadic groups are
+  # homogeneous, which would reject mixed-typed calls.
+  defop call(
+          arg0 = optional(any()),
+          arg1 = optional(any()),
+          arg2 = optional(any()),
+          arg3 = optional(any())
+        ),
+        results: [result: any()],
+        attributes: [callee: ^callee_value, arity: ^integer_value]
 
   defop cmp(
           left = all_of([base("!builtin.integer"), any()]),

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -20,7 +20,7 @@ defmodule ExConversionTest do
       %0 = "ex.lit"() {value = 1 : i64} : () -> i64
       %1 = "ex.lit"() {value = 2 : i64} : () -> i64
       %2 = "ex.add"(%0, %1) : (i64, i64) -> i64
-      %3 = "ex.call"(%0, %1) {callee = "add", arity = 2 : i64, operandSegmentSizes = array<i32: 2>} : (i64, i64) -> !ex.dyn
+      %3 = "ex.call"(%0, %1) {callee = "add", arity = 2 : i64, operandSegmentSizes = array<i32: 1, 1, 0, 0>} : (i64, i64) -> !ex.dyn
       "ex.return"(%2) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
     }) {sym_name = "main"} : () -> ()
   }
@@ -206,7 +206,7 @@ defmodule ExConversionTest do
           "ex.func"() ({
           ^bb0:
             %0 = "ex.lit"() {value = 1 : i64} : () -> i64
-            %1 = "ex.call"(%0, %0) {callee = "add", arity = 2 : i64, operandSegmentSizes = array<i32: 2>} : (i64, i64) -> !ex.dyn
+            %1 = "ex.call"(%0, %0) {callee = "add", arity = 2 : i64, operandSegmentSizes = array<i32: 1, 1, 0, 0>} : (i64, i64) -> !ex.dyn
             "ex.return"(%1) {operandSegmentSizes = array<i32: 1>} : (!ex.dyn) -> ()
           }) {sym_name = "main"} : () -> ()
         }
@@ -323,7 +323,7 @@ defmodule ExConversionTest do
           "ex.func"() ({
           ^bb0:
             %0 = "ex.lit"() {value = 1 : i64} : () -> i64
-            %1 = "ex.call"(%0) {callee = "id", arity = 1 : i64, operandSegmentSizes = array<i32: 1>} : (i64) -> i64
+            %1 = "ex.call"(%0) {callee = "id", arity = 1 : i64, operandSegmentSizes = array<i32: 1, 0, 0, 0>} : (i64) -> i64
             "ex.return"(%1) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
           }) {sym_name = "main"} : () -> ()
         }
@@ -336,6 +336,27 @@ defmodule ExConversionTest do
     rendered = MLIR.to_string(module, generic: true)
     assert rendered =~ "func.call"
     refute rendered =~ "!ex.dyn"
+  end
+
+  test "allows heterogeneous-typed ex.call arguments", %{ctx: ctx} do
+    module =
+      term_module!(
+        ~S"""
+        module {
+          "ex.func"() ({
+          ^bb0:
+            %0 = "ex.lit"() {value = 1 : i64} : () -> i64
+            %1 = "ex.box"(%0) : (i64) -> !ex.dyn
+            %2 = "ex.call"(%1, %0) {callee = "f", arity = 2 : i64, operandSegmentSizes = array<i32: 1, 1, 0, 0>} : (!ex.dyn, i64) -> i64
+            "ex.return"(%2) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+          }) {sym_name = "main"} : () -> ()
+        }
+        """,
+        ctx
+      )
+
+    assert {:ok, _module, []} = Plan.run(Ex.plan(), module)
+    assert MLIR.to_string(module, generic: true) =~ "func.call"
   end
 
   test "converts ex.to_word as a pure passthrough", %{ctx: ctx} do

--- a/test/ex_dialect_test.exs
+++ b/test/ex_dialect_test.exs
@@ -15,7 +15,7 @@ defmodule ExDialectTest do
       %1 = "ex.var"() {name = "x"} : () -> !ex.unbound
       %2 = "ex.bind"(%1, %0) : (!ex.unbound, i64) -> !ex.bound
       %3 = "ex.add"(%0, %0) : (i64, i64) -> i64
-      %4 = "ex.call"(%0, %0) {callee = "add", arity = 2 : i64, operandSegmentSizes = array<i32: 2>} : (i64, i64) -> !ex.dyn
+      %4 = "ex.call"(%0, %0) {callee = "add", arity = 2 : i64, operandSegmentSizes = array<i32: 1, 1, 0, 0>} : (i64, i64) -> !ex.dyn
       "ex.return"(%3) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
     }) {sym_name = "main"} : () -> ()
   }


### PR DESCRIPTION
[tsai/beaver#23](http://localhost:3000/tsai/beaver/issues/23) — required for multi-argument multi-clause functions with mixed argument types (e.g. `reduce(binary, acc)` calls with `(!ex.dyn, i64)`).

## What

`ex.call`'s single `variadic(any())` operand group is homogeneous in IRDL (one constraint variable per group), which rejects mixed-typed calls. The arguments are now four optional slots (`arg0`..`arg3`), each its own constraint variable; calls encode the slots with a 4-element `operandSegmentSizes` attribute (`[1, 1, 0, 0]` for a two-argument call).

## Tests

Existing call fixtures updated to the 4-element segment sizes; new test: a heterogeneous `(!ex.dyn, i64)` call verifies and converts to `func.call`.