### PR TITLE
ex: add enumerable_count/list_get ops and unbox passthrough

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -78,6 +78,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.func", &convert_func/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.box", &convert_box/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.to_word", &convert_to_word/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.unbox", &convert_to_word/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.self", &convert_self/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.send", &convert_send/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.receive", &convert_receive/3, version: "1.0")
@@ -101,8 +102,10 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.tuple_get", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.tuple_length", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.map_length", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.enumerable_count", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.list_head", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.list_tail", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.list_get", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.list_length", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.term_eq", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.binary_length", &convert_term_read/3, version: "1.0")
@@ -142,8 +145,10 @@ defmodule Beaver.MLIR.Conversion.Ex do
     tuple_get: "ex.term.tuple_get",
     tuple_length: "ex.term.tuple_length",
     map_length: "ex.term.map_length",
+    enumerable_count: "ex.term.enumerable_count",
     list_head: "ex.term.list_head",
     list_tail: "ex.term.list_tail",
+    list_get: "ex.term.list_get",
     list_length: "ex.term.list_length",
     term_eq: "ex.term.eq",
     binary_length: "ex.term.binary_length",
@@ -710,8 +715,10 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.tuple_get"), do: @term_intrinsics.tuple_get
   defp read_intrinsic("ex.tuple_length"), do: @term_intrinsics.tuple_length
   defp read_intrinsic("ex.map_length"), do: @term_intrinsics.map_length
+  defp read_intrinsic("ex.enumerable_count"), do: @term_intrinsics.enumerable_count
   defp read_intrinsic("ex.list_head"), do: @term_intrinsics.list_head
   defp read_intrinsic("ex.list_tail"), do: @term_intrinsics.list_tail
+  defp read_intrinsic("ex.list_get"), do: @term_intrinsics.list_get
   defp read_intrinsic("ex.list_length"), do: @term_intrinsics.list_length
   defp read_intrinsic("ex.term_eq"), do: @term_intrinsics.term_eq
   defp read_intrinsic("ex.binary_length"), do: @term_intrinsics.binary_length
@@ -923,6 +930,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp intrinsic_function_type(symbol, _ctx)
        when symbol in [
               "ex.term.tuple_get",
+              "ex.term.list_get",
               "ex.term.eq",
               "ex.term.binary_get",
               "ex.term.binary_slice",

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -110,6 +110,12 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop to_word(value = any()),
     results: [result: base(dyn())]
 
+  # Drops the term type annotation without untagging: the conversion is a
+  # pure passthrough, so a term word can cross control-flow regions (whose
+  # types must be legal after conversion) as a scalar i64.
+  defop unbox(word = base(dyn())),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
   # Actor mailbox access: the current execution context is a single actor.
   defop self(),
     results: [result: base(dyn())]
@@ -204,10 +210,16 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop map_length(map = base(dyn())),
     results: [result: all_of([base("!builtin.integer"), any()])]
 
+  defop enumerable_count(word = base(dyn())),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
   defop list_head(list = base(dyn())),
     results: [result: base(dyn())]
 
   defop list_tail(list = base(dyn())),
+    results: [result: base(dyn())]
+
+  defop list_get(list = base(dyn()), index = all_of([base("!builtin.integer"), any()])),
     results: [result: base(dyn())]
 
   defop list_length(list = base(dyn())),


### PR DESCRIPTION
M3 Enum slice (tsai/beaver#27) term-read additions:

- `ex.enumerable_count` — lowers to `ex.term.enumerable_count` (tag-dispatched element count for list/tuple/map/binary);
- `ex.list_get` — lowers to `ex.term.list_get` (element by index), completing the list read family;
- `ex.unbox` — pure-passthrough term-type drop so a word can cross `scf.while` regions (whose types must be legal after conversion) as i64; fixes target-materialization failures when `!ex.dyn` values are carried through control flow.
- `ex.term.list_get` intrinsic declaration (2-arg signature).

Part of batata M3.