### PR TITLE
ex: add list_cons op lowering to ex.term.list_cons

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -91,6 +91,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.apply", &convert_apply/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.tuple", &convert_term_tuple/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.list", &convert_term_list/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.list_cons", &convert_term_list_cons/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.map", &convert_term_map/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.binary", &convert_term_binary/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.is_integer", &convert_term_predicate/3, version: "1.0")
@@ -340,6 +341,15 @@ defmodule Beaver.MLIR.Conversion.Ex do
     base = insertion_point(operation, rewriter)
     list = build_list(operands, operation, rewriter, base)
     replace_with(rewriter, operation, list)
+  end
+
+  defp convert_term_list_cons(operation, [head, tail], rewriter) do
+    base = insertion_point(operation, rewriter)
+
+    result =
+      emit_runtime_call(operation, rewriter, base, @term_intrinsics.list_cons, [head, tail])
+
+    replace_with(rewriter, operation, result)
   end
 
   defp convert_term_tuple(operation, operands, rewriter) do

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -177,6 +177,9 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop list(elements = variadic(base(dyn()))),
     results: [result: base(dyn())]
 
+  defop list_cons(head = base(dyn()), tail = base(dyn())),
+    results: [result: base(dyn())]
+
   defop map(entries = variadic(base(dyn()))),
     results: [result: base(dyn())]
 


### PR DESCRIPTION
Adds `ex.list_cons(head, tail)`, lowering through the existing term-read path to the Zig runtime's `ex.term.list_cons`. This gives the compiler a single-element list constructor for loops that build lists incrementally (Enum.map const/capture-add mappers in batata M3, tsai/beaver#27), which `ex.list` (variadic) cannot express.\n\nPart of batata M3.