### PR TITLE
ex: add string/base ops (utf8_length, encode16, decode16, int/string conversion)

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -114,6 +114,11 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.binary_slice", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.binary_utf8_get", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.binary_utf8_width", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.binary_utf8_length", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.binary_encode16", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.binary_decode16", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.int_to_string", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.string_to_int", &convert_term_read/3, version: "1.0")
   end
 
   # Declaration-first manifest of the Zig term runtime ABI: batata's
@@ -156,7 +161,12 @@ defmodule Beaver.MLIR.Conversion.Ex do
     binary_get: "ex.term.binary_get",
     binary_slice: "ex.term.binary_slice",
     binary_utf8_get: "ex.term.binary_utf8_get",
-    binary_utf8_width: "ex.term.binary_utf8_width"
+    binary_utf8_width: "ex.term.binary_utf8_width",
+    binary_utf8_length: "ex.term.binary_utf8_length",
+    binary_encode16: "ex.term.binary_encode16",
+    binary_decode16: "ex.term.binary_decode16",
+    int_to_string: "ex.term.int_to_string",
+    string_to_int: "ex.term.string_to_int"
   }
 
   @term_types ~w(!ex.dyn !ex.bound !ex.unbound)
@@ -736,6 +746,11 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.binary_slice"), do: @term_intrinsics.binary_slice
   defp read_intrinsic("ex.binary_utf8_get"), do: @term_intrinsics.binary_utf8_get
   defp read_intrinsic("ex.binary_utf8_width"), do: @term_intrinsics.binary_utf8_width
+  defp read_intrinsic("ex.binary_utf8_length"), do: @term_intrinsics.binary_utf8_length
+  defp read_intrinsic("ex.binary_encode16"), do: @term_intrinsics.binary_encode16
+  defp read_intrinsic("ex.binary_decode16"), do: @term_intrinsics.binary_decode16
+  defp read_intrinsic("ex.int_to_string"), do: @term_intrinsics.int_to_string
+  defp read_intrinsic("ex.string_to_int"), do: @term_intrinsics.string_to_int
 
   defp insertion_point(operation, rewriter) do
     base = MLIR.ConversionPatternRewriter.as_base(rewriter)

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -249,6 +249,21 @@ defmodule Beaver.MLIR.Dialect.Ex do
         ),
         results: [result: all_of([base("!builtin.integer"), any()])]
 
+  defop binary_utf8_length(binary = base(dyn())),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
+  defop binary_encode16(binary = base(dyn())),
+    results: [result: base(dyn())]
+
+  defop binary_decode16(binary = base(dyn())),
+    results: [result: base(dyn())]
+
+  defop int_to_string(word = base(dyn())),
+    results: [result: base(dyn())]
+
+  defop string_to_int(binary = base(dyn())),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
   defop yield(values = variadic(any())), traits: [:terminator]
 
   defop func(),


### PR DESCRIPTION
M3 String/Base slice (tsai/beaver#27) term ops:

- `ex.binary_utf8_length` → `ex.term.binary_utf8_length` (UTF-8 codepoint count);
- `ex.binary_encode16` / `ex.binary_decode16` → `ex.term.binary_encode16` / `ex.term.binary_decode16` (uppercase hex);
- `ex.int_to_string` / `ex.string_to_int` → `ex.term.int_to_string` / `ex.term.string_to_int` (decimal rendering/parsing, scalar i64 result for the parser).

All lower through the existing term-read path. Part of batata M3.