### PR TITLE
ex: add enumerable_reduce op lowering to ex.term.enumerable_reduce

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -104,6 +104,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.tuple_length", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.map_length", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.enumerable_count", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.enumerable_reduce", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.list_head", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.list_tail", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.list_get", &convert_term_read/3, version: "1.0")
@@ -152,6 +153,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     tuple_length: "ex.term.tuple_length",
     map_length: "ex.term.map_length",
     enumerable_count: "ex.term.enumerable_count",
+    enumerable_reduce: "ex.term.enumerable_reduce",
     list_head: "ex.term.list_head",
     list_tail: "ex.term.list_tail",
     list_get: "ex.term.list_get",
@@ -736,6 +738,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.tuple_length"), do: @term_intrinsics.tuple_length
   defp read_intrinsic("ex.map_length"), do: @term_intrinsics.map_length
   defp read_intrinsic("ex.enumerable_count"), do: @term_intrinsics.enumerable_count
+  defp read_intrinsic("ex.enumerable_reduce"), do: @term_intrinsics.enumerable_reduce
   defp read_intrinsic("ex.list_head"), do: @term_intrinsics.list_head
   defp read_intrinsic("ex.list_tail"), do: @term_intrinsics.list_tail
   defp read_intrinsic("ex.list_get"), do: @term_intrinsics.list_get
@@ -946,6 +949,10 @@ defmodule Beaver.MLIR.Conversion.Ex do
 
   defp intrinsic_function_type("ex.term.make_fun", _ctx) do
     MLIR.Type.function(List.duplicate(MLIR.Type.i64(), 6), [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.enumerable_reduce", _ctx) do
+    MLIR.Type.function(List.duplicate(MLIR.Type.i64(), 3), [MLIR.Type.i64()])
   end
 
   defp intrinsic_function_type("ex.term.fun_env", _ctx) do

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -216,6 +216,13 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop enumerable_count(word = base(dyn())),
     results: [result: all_of([base("!builtin.integer"), any()])]
 
+  defop enumerable_reduce(
+          enumerable = base(dyn()),
+          acc = all_of([base("!builtin.integer"), any()]),
+          continuation = all_of([base("!builtin.integer"), any()])
+        ),
+        results: [result: all_of([base("!builtin.integer"), any()])]
+
   defop list_head(list = base(dyn())),
     results: [result: base(dyn())]
 


### PR DESCRIPTION
M3 protocol consolidation step 2 (tsai/beaver#27): `ex.enumerable_reduce(enumerable, acc, continuation)` lowers through the term-read path to the Zig runtime's tag-dispatched `ex.term.enumerable_reduce` (list/tuple/binary; continuation 1 = sum, 2 = return acc).\n\nPart of batata M3.