### PR TITLE
ex: add enumerable_reduce_c op for closure-shaped reduce with capture

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -105,6 +105,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.map_length", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.enumerable_count", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.enumerable_reduce", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.enumerable_reduce_c", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.list_head", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.list_tail", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.list_get", &convert_term_read/3, version: "1.0")
@@ -154,6 +155,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     map_length: "ex.term.map_length",
     enumerable_count: "ex.term.enumerable_count",
     enumerable_reduce: "ex.term.enumerable_reduce",
+    enumerable_reduce_c: "ex.term.enumerable_reduce_c",
     list_head: "ex.term.list_head",
     list_tail: "ex.term.list_tail",
     list_get: "ex.term.list_get",
@@ -739,6 +741,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.map_length"), do: @term_intrinsics.map_length
   defp read_intrinsic("ex.enumerable_count"), do: @term_intrinsics.enumerable_count
   defp read_intrinsic("ex.enumerable_reduce"), do: @term_intrinsics.enumerable_reduce
+  defp read_intrinsic("ex.enumerable_reduce_c"), do: @term_intrinsics.enumerable_reduce_c
   defp read_intrinsic("ex.list_head"), do: @term_intrinsics.list_head
   defp read_intrinsic("ex.list_tail"), do: @term_intrinsics.list_tail
   defp read_intrinsic("ex.list_get"), do: @term_intrinsics.list_get
@@ -953,6 +956,10 @@ defmodule Beaver.MLIR.Conversion.Ex do
 
   defp intrinsic_function_type("ex.term.enumerable_reduce", _ctx) do
     MLIR.Type.function(List.duplicate(MLIR.Type.i64(), 3), [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.enumerable_reduce_c", _ctx) do
+    MLIR.Type.function(List.duplicate(MLIR.Type.i64(), 4), [MLIR.Type.i64()])
   end
 
   defp intrinsic_function_type("ex.term.fun_env", _ctx) do

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -223,6 +223,14 @@ defmodule Beaver.MLIR.Dialect.Ex do
         ),
         results: [result: all_of([base("!builtin.integer"), any()])]
 
+  defop enumerable_reduce_c(
+          enumerable = base(dyn()),
+          acc = all_of([base("!builtin.integer"), any()]),
+          continuation = all_of([base("!builtin.integer"), any()]),
+          capture = all_of([base("!builtin.integer"), any()])
+        ),
+        results: [result: all_of([base("!builtin.integer"), any()])]
+
   defop list_head(list = base(dyn())),
     results: [result: base(dyn())]
 


### PR DESCRIPTION
M3 protocol consolidation step 3 (tsai/beaver#27, batata issue #30): `ex.enumerable_reduce_c(enumerable, acc, continuation, capture)` lowers through the term-read path to the Zig runtime's closure-shaped `ex.term.enumerable_reduce_c` (continuation 13 = sum with captured scalar).\n\nPart of batata's closure continuation work.