### PR TITLE
ex: add div/rem ops lowering to arith.divsi/remsi

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -69,6 +69,8 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.add", &convert_add/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.sub", &convert_sub/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.mul", &convert_mul/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.div", &convert_div/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.rem", &convert_rem/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.cmp", &convert_cmp/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.if", &convert_if/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.yield", &convert_yield/3, version: "1.0")
@@ -245,6 +247,14 @@ defmodule Beaver.MLIR.Conversion.Ex do
 
   defp convert_mul(operation, [left, right], rewriter) do
     convert_binary("arith.muli", operation, [left, right], rewriter)
+  end
+
+  defp convert_div(operation, [left, right], rewriter) do
+    convert_binary("arith.divsi", operation, [left, right], rewriter)
+  end
+
+  defp convert_rem(operation, [left, right], rewriter) do
+    convert_binary("arith.remsi", operation, [left, right], rewriter)
   end
 
   defp convert_binary(arith_op, operation, [left, right], rewriter) do

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -66,6 +66,18 @@ defmodule Beaver.MLIR.Dialect.Ex do
         ),
         results: [result: all_of([base("!builtin.integer"), any()])]
 
+  defop div(
+          left = all_of([base("!builtin.integer"), any()]),
+          right = all_of([base("!builtin.integer"), any()])
+        ),
+        results: [result: all_of([base("!builtin.integer"), any()])]
+
+  defop rem(
+          left = all_of([base("!builtin.integer"), any()]),
+          right = all_of([base("!builtin.integer"), any()])
+        ),
+        results: [result: all_of([base("!builtin.integer"), any()])]
+
   # Each argument is its own optional slot so heterogeneous argument types
   # (e.g. a term plus a scalar accumulator) verify: IRDL variadic groups are
   # homogeneous, which would reject mixed-typed calls. Eight slots cover the


### PR DESCRIPTION
M3 protocol consolidation (tsai/beaver#27, batata issue #30): `ex.div` / `ex.rem` lower to `arith.divsi` / `arith.remsi`, enabling `div/2` and `rem/2` inside compiled reducer/mapper bodies.\n\nPart of batata's arbitrary reducer body compilation.