### PR TITLE
ex: add stream_filter op for eager predicate filtering

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -122,6 +122,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
       version: "1.0"
     )
     |> Plan.add_conversion_pattern("ex.enumerable_map_fun", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.stream_filter", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.func_addr", &convert_func_addr/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.list_head", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.list_tail", &convert_term_read/3, version: "1.0")
@@ -181,6 +182,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     enumerable_reduce_range: "ex.term.enumerable_reduce_range",
     enumerable_reduce_fun: "ex.term.enumerable_reduce_fun",
     enumerable_map_fun: "ex.term.enumerable_map_fun",
+    stream_filter: "ex.term.stream_filter",
     list_head: "ex.term.list_head",
     list_tail: "ex.term.list_tail",
     list_get: "ex.term.list_get",
@@ -812,6 +814,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
 
   defp read_intrinsic("ex.enumerable_reduce_fun"), do: @term_intrinsics.enumerable_reduce_fun
   defp read_intrinsic("ex.enumerable_map_fun"), do: @term_intrinsics.enumerable_map_fun
+  defp read_intrinsic("ex.stream_filter"), do: @term_intrinsics.stream_filter
 
   defp read_intrinsic("ex.list_head"), do: @term_intrinsics.list_head
   defp read_intrinsic("ex.list_tail"), do: @term_intrinsics.list_tail
@@ -1049,6 +1052,16 @@ defmodule Beaver.MLIR.Conversion.Ex do
   end
 
   defp intrinsic_function_type("ex.term.enumerable_map_fun", _ctx) do
+    MLIR.Type.function(
+      [
+        MLIR.Type.i64(),
+        MLIR.Type.function([MLIR.Type.i64()], [MLIR.Type.i64()])
+      ],
+      [MLIR.Type.i64()]
+    )
+  end
+
+  defp intrinsic_function_type("ex.term.stream_filter", _ctx) do
     MLIR.Type.function(
       [
         MLIR.Type.i64(),

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -282,6 +282,12 @@ defmodule Beaver.MLIR.Dialect.Ex do
         ),
         results: [result: base(dyn())]
 
+  defop stream_filter(
+          list = base(dyn()),
+          predicate = any()
+        ),
+        results: [result: base(dyn())]
+
   defop func_addr(),
     attributes: [sym_name: base("#builtin.string")],
     results: [result: any()]


### PR DESCRIPTION
Slice extension (tsai/beaver#31): eager Stream.filter.\n\n- `ex.stream_filter(list, predicate)` lowers to `ex.term.stream_filter` (compiled predicate per item, ordered result).\n\nPart of batata's Stream native-ization.