### PR TITLE
ex: add stream_take/stream_drop ops for list slicing

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -123,6 +123,8 @@ defmodule Beaver.MLIR.Conversion.Ex do
     )
     |> Plan.add_conversion_pattern("ex.enumerable_map_fun", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.stream_filter", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.stream_take", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.stream_drop", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.func_addr", &convert_func_addr/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.list_head", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.list_tail", &convert_term_read/3, version: "1.0")
@@ -183,6 +185,8 @@ defmodule Beaver.MLIR.Conversion.Ex do
     enumerable_reduce_fun: "ex.term.enumerable_reduce_fun",
     enumerable_map_fun: "ex.term.enumerable_map_fun",
     stream_filter: "ex.term.stream_filter",
+    stream_take: "ex.term.stream_take",
+    stream_drop: "ex.term.stream_drop",
     list_head: "ex.term.list_head",
     list_tail: "ex.term.list_tail",
     list_get: "ex.term.list_get",
@@ -815,6 +819,8 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.enumerable_reduce_fun"), do: @term_intrinsics.enumerable_reduce_fun
   defp read_intrinsic("ex.enumerable_map_fun"), do: @term_intrinsics.enumerable_map_fun
   defp read_intrinsic("ex.stream_filter"), do: @term_intrinsics.stream_filter
+  defp read_intrinsic("ex.stream_take"), do: @term_intrinsics.stream_take
+  defp read_intrinsic("ex.stream_drop"), do: @term_intrinsics.stream_drop
 
   defp read_intrinsic("ex.list_head"), do: @term_intrinsics.list_head
   defp read_intrinsic("ex.list_tail"), do: @term_intrinsics.list_tail
@@ -1089,7 +1095,9 @@ defmodule Beaver.MLIR.Conversion.Ex do
               "ex.term.binary_utf8_get",
               "ex.term.binary_utf8_width",
               "ex.term.mapset_member",
-              "ex.term.mapset_put"
+              "ex.term.mapset_put",
+              "ex.term.stream_take",
+              "ex.term.stream_drop"
             ] do
     MLIR.Type.function([MLIR.Type.i64(), MLIR.Type.i64()], [MLIR.Type.i64()])
   end

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -288,6 +288,18 @@ defmodule Beaver.MLIR.Dialect.Ex do
         ),
         results: [result: base(dyn())]
 
+  defop stream_take(
+          list = base(dyn()),
+          n = all_of([base("!builtin.integer"), any()])
+        ),
+        results: [result: base(dyn())]
+
+  defop stream_drop(
+          list = base(dyn()),
+          n = all_of([base("!builtin.integer"), any()])
+        ),
+        results: [result: base(dyn())]
+
   defop func_addr(),
     attributes: [sym_name: base("#builtin.string")],
     results: [result: any()]


### PR DESCRIPTION
Slice extension (tsai/beaver#31): Stream.take/drop.\n\n- `ex.stream_take(list, n)` / `ex.stream_drop(list, n)` lower to `ex.term.stream_take` / `ex.term.stream_drop` (n clamped to [0, len]).\n\nPart of batata's Stream native-ization.