### PR TITLE
ex: add file_read/file_read_lines ops for runtime file IO

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -98,6 +98,8 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.mapset_from_list", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.mapset_member", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.mapset_put", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.file_read", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.file_read_lines", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.binary", &convert_term_binary/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.is_integer", &convert_term_predicate/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.is_atom", &convert_term_predicate/3, version: "1.0")
@@ -166,6 +168,8 @@ defmodule Beaver.MLIR.Conversion.Ex do
     mapset_from_list: "ex.term.mapset_from_list",
     mapset_member: "ex.term.mapset_member",
     mapset_put: "ex.term.mapset_put",
+    file_read: "ex.term.file_read",
+    file_read_lines: "ex.term.file_read_lines",
     binary_from_list: "ex.term.binary_from_list",
     is_integer: "ex.term.is_integer",
     is_atom: "ex.term.is_atom",
@@ -804,6 +808,8 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.mapset_from_list"), do: @term_intrinsics.mapset_from_list
   defp read_intrinsic("ex.mapset_member"), do: @term_intrinsics.mapset_member
   defp read_intrinsic("ex.mapset_put"), do: @term_intrinsics.mapset_put
+  defp read_intrinsic("ex.file_read"), do: @term_intrinsics.file_read
+  defp read_intrinsic("ex.file_read_lines"), do: @term_intrinsics.file_read_lines
   defp read_intrinsic("ex.enumerable_count"), do: @term_intrinsics.enumerable_count
   defp read_intrinsic("ex.enumerable_to_list"), do: @term_intrinsics.enumerable_to_list
 

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -204,6 +204,12 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop mapset_put(set = base(dyn()), member = base(dyn())),
     results: [result: base(dyn())]
 
+  defop file_read(path = base(dyn())),
+    results: [result: base(dyn())]
+
+  defop file_read_lines(path = base(dyn())),
+    results: [result: base(dyn())]
+
   defop binary(segments = variadic(base(dyn()))),
     results: [result: base(dyn())]
 


### PR DESCRIPTION
Slice extension (tsai/beaver#31): File stream.\n\n- `ex.file_read(path)` / `ex.file_read_lines(path)` lower to `ex.term.file_read` / `ex.term.file_read_lines` (libc stdio; lines split on newline, trailing newline yields a final empty line like BEAM File.stream!).\n\nPart of batata's File IO native-ization.