### PR TITLE
Pin Triton prebuilts to versioned metadata

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -67,6 +67,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         name: Check-out beaver
+      - name: Read Triton version
+        if: matrix.llvm == 'triton'
+        run: echo "TRITON_REF=$(jq -er '.triton_ref' triton.json)" >> "$GITHUB_ENV"
       # Kinda 0.11.0 on Hex predates the LLP64 integer conversion fix; the
       # Windows lane needs the paired checkout until a release containing
       # beaver-lodge/kinda#68 is published.
@@ -119,7 +122,8 @@ jobs:
         run: |
           cd scripts/install_llvm
           if [ "${{ matrix.llvm }}" == "triton" ]; then
-            mix beaver.install_prebuilt_llvm --triton --install-dir "$RUNNER_TEMP/llvm-prebuilt"
+            mix beaver.install_prebuilt_llvm --triton --triton-ref "$TRITON_REF" \
+              --install-dir "$RUNNER_TEMP/llvm-prebuilt"
           else
             mix beaver.install_prebuilt_llvm --install-dir "$RUNNER_TEMP/llvm-prebuilt"
           fi
@@ -128,10 +132,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          ref="$(gh release list --repo beaver-lodge/beaver --limit 50 \
-            --json tagName --jq '[.[].tagName | select(startswith("triton-prebuilt-"))][0]')"
-          asset="$(gh release view "$ref" --repo beaver-lodge/beaver --json assets \
-            --jq '.assets[].name | select(endswith("ubuntu-x86_64.tar.gz"))')"
+          ref="triton-prebuilt-${TRITON_REF}"
+          asset="triton-${TRITON_REF}-ubuntu-x86_64.tar.gz"
           gh release download "$ref" --repo beaver-lodge/beaver \
             --pattern "$asset" --dir "$RUNNER_TEMP"
           mkdir -p "$RUNNER_TEMP/triton-prebuilt"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,13 +97,17 @@ jobs:
       - name: Strip dev suffix
         run: sed -i.bak 's/-dev//g' mix.exs && rm -f mix.exs.bak
       - uses: seanmiddleditch/gha-setup-ninja@master
+      - name: Read Triton version
+        if: runner.os == 'Windows'
+        run: echo "TRITON_REF=$(jq -er '.triton_ref' triton.json)" >> "$GITHUB_ENV"
       - name: Install prebuilt LLVM
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           cd scripts/install_llvm
           if [[ "${{ runner.os }}" == "Windows" ]]; then
-            mix beaver.install_prebuilt_llvm --triton --install-dir "$RUNNER_TEMP/llvm-prebuilt"
+            mix beaver.install_prebuilt_llvm --triton --triton-ref "$TRITON_REF" \
+              --install-dir "$RUNNER_TEMP/llvm-prebuilt"
           else
             mix beaver.install_prebuilt_llvm --install-dir "$RUNNER_TEMP/llvm-prebuilt"
           fi

--- a/.github/workflows/triton-prebuilt.yml
+++ b/.github/workflows/triton-prebuilt.yml
@@ -10,9 +10,6 @@ concurrency:
   group: triton-prebuilt-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  TRITON_REF: "882eb72e1858bfd588fafa4677b86ce00e9da872"
-
 jobs:
   build:
     name: triton-prebuilt-${{ matrix.os }}-${{ matrix.arch }}
@@ -31,12 +28,19 @@ jobs:
       - uses: actions/checkout@v4
         name: Check out Beaver
 
+      - name: Read Triton version
+        id: triton-version
+        run: |
+          ref="$(jq -er '.triton_ref' triton.json)"
+          echo "TRITON_REF=$ref" >> "$GITHUB_ENV"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v4
         name: Check out Triton
         with:
           repository: triton-lang/triton
           path: third_party/triton
-          ref: ${{ env.TRITON_REF }}
+          ref: ${{ steps.triton-version.outputs.ref }}
 
       - uses: erlef/setup-beam@v1
         with:
@@ -53,7 +57,8 @@ jobs:
       - name: Install Triton-pinned LLVM prebuilt
         run: |
           cd scripts/install_llvm
-          mix beaver.install_prebuilt_llvm --triton --install-dir "$RUNNER_TEMP/llvm-prebuilt"
+          mix beaver.install_prebuilt_llvm --triton --triton-ref "$TRITON_REF" \
+            --install-dir "$RUNNER_TEMP/llvm-prebuilt"
 
       - name: Build Triton core libraries
         env:
@@ -67,23 +72,23 @@ jobs:
       - name: Package Triton prebuilt
         run: |
           cd "$RUNNER_TEMP/triton-out"
-          tar czf "$RUNNER_TEMP/triton-${{ env.TRITON_REF }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz" .
+          tar czf "$RUNNER_TEMP/triton-${TRITON_REF}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz" .
           ls -lh "$RUNNER_TEMP"/*.tar.gz
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: triton-${{ env.TRITON_REF }}-${{ matrix.os }}-${{ matrix.arch }}
+          name: triton-${{ steps.triton-version.outputs.ref }}-${{ matrix.os }}-${{ matrix.arch }}
           path: ${{ runner.temp }}/triton-*.tar.gz
 
       - name: Publish release asset
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          tag="triton-prebuilt-${{ env.TRITON_REF }}"
-          asset="$RUNNER_TEMP/triton-${{ env.TRITON_REF }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz"
+          tag="triton-prebuilt-${TRITON_REF}"
+          asset="$RUNNER_TEMP/triton-${TRITON_REF}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz"
           gh release create "${tag}" --repo beaver-lodge/beaver \
-            --title "Triton core prebuilt @ ${{ env.TRITON_REF }}" \
+            --title "Triton core prebuilt @ ${TRITON_REF}" \
             --notes "Core Triton dialects/passes/conversions built against the Triton-pinned LLVM." \
             || true
           gh release upload "${tag}" "${asset}" --repo beaver-lodge/beaver --clobber

--- a/scripts/install_llvm/lib/mix/tasks/beaver.install_prebuilt_llvm.ex
+++ b/scripts/install_llvm/lib/mix/tasks/beaver.install_prebuilt_llvm.ex
@@ -4,8 +4,10 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
 
   By default it downloads the matching `llvm/eudsl` nightly build for the
   current platform. `--triton` installs the exact LLVM archive Triton pins
-  (resolved from `triton-lang/triton`'s `llvm-info.json` at run time). Any URL
-  can be used instead, for example Triton's pinned LLVM archive:
+  (resolved from `triton-lang/triton`'s `llvm-info.json` at run time).
+  `--triton-ref` can pin that metadata lookup to the same Triton commit as a
+  separately built Triton library. Any URL can be used instead, for example
+  Triton's pinned LLVM archive:
 
       (cd scripts/install_llvm && mix beaver.install_prebuilt_llvm \\
         --asset-url https://oaitriton.blob.core.windows.net/public/llvm-builds/llvm-b010a18d-ubuntu-x64-1.tar.gz \\
@@ -37,6 +39,8 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
       (`cmake/llvm-build-info.json` + `cmake/llvm-info.json` from
       `triton-lang/triton`); the archive URL and sha256 are derived from those
       files, so the pin tracks Triton's LLVM bumps.
+    * `--triton-ref REF` / `LLVM_TRITON_REF` — Git ref used to resolve Triton
+      LLVM metadata; defaults to `main`.
     * `--sha256 DIGEST` / `LLVM_EUDSL_SHA256` — verify the downloaded archive.
     * `--github-token TOKEN` / `GITHUB_TOKEN` or `GH_TOKEN` — used for
       `latest` resolution.
@@ -71,6 +75,7 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
     github_token: :string,
     github_env: :string,
     triton: :boolean,
+    triton_ref: :string,
     resolve_only: :boolean
   ]
 
@@ -105,6 +110,7 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
     |> put_env(:github_env, "GITHUB_ENV")
     |> put_env(:github_token, "GITHUB_TOKEN")
     |> put_env(:github_token, "GH_TOKEN")
+    |> put_default(:triton_ref, "main", "LLVM_TRITON_REF")
     |> maybe_resolve_only()
     |> maybe_triton()
   end
@@ -210,8 +216,8 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
   defp resolve_triton_asset!(opts, os_name, arch) do
     ensure_http!()
     suffix = triton_suffix(os_name, arch)
-    build_info = triton_json!("cmake/llvm-build-info.json")
-    info = triton_json!("cmake/llvm-info.json")
+    build_info = triton_json!(opts[:triton_ref], "cmake/llvm-build-info.json")
+    info = triton_json!(opts[:triton_ref], "cmake/llvm-info.json")
 
     hash = info["llvm_hash"] || build_info["llvm_hash"]
     build_number = info["build_number"] || build_info["build_number"]
@@ -240,8 +246,13 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
     end
   end
 
-  defp triton_json!(path) do
-    github_get!("https://raw.githubusercontent.com/triton-lang/triton/main/#{path}", nil)
+  @doc false
+  def triton_metadata_url(ref, path) do
+    "https://raw.githubusercontent.com/triton-lang/triton/#{ref}/#{path}"
+  end
+
+  defp triton_json!(ref, path) do
+    github_get!(triton_metadata_url(ref, path), nil)
   end
 
   defp resolve_latest_asset!(opts, os_name, arch) do

--- a/scripts/install_llvm/test/install_prebuilt_llvm_test.exs
+++ b/scripts/install_llvm/test/install_prebuilt_llvm_test.exs
@@ -71,6 +71,14 @@ defmodule Beaver.InstallPrebuiltLlvmTest do
     end
   end
 
+  test "triton metadata URL uses the requested ref" do
+    assert InstallPrebuiltLlvm.triton_metadata_url(
+             "882eb72e1858bfd588fafa4677b86ce00e9da872",
+             "cmake/llvm-info.json"
+           ) ==
+             "https://raw.githubusercontent.com/triton-lang/triton/882eb72e1858bfd588fafa4677b86ce00e9da872/cmake/llvm-info.json"
+  end
+
   test "installs a tarball and points LLVM_CONFIG_PATH at it" do
     fixture =
       Path.join(System.tmp_dir!(), "beaver-llvm-install-#{System.unique_integer([:positive])}")

--- a/triton.json
+++ b/triton.json
@@ -1,0 +1,3 @@
+{
+  "triton_ref": "882eb72e1858bfd588fafa4677b86ce00e9da872"
+}


### PR DESCRIPTION
## Summary

- add a machine-readable `triton.json` as the single source of truth for the Triton commit
- download the exact matching Triton core release asset instead of scanning only the newest 50 releases
- resolve Triton LLVM metadata from the same pinned commit in CI, prebuilt builds, and Windows releases
- add installer coverage for commit-specific metadata URLs

## Root cause

The Ubuntu Triton lane searched only the newest 50 Beaver releases for a `triton-prebuilt-*` tag. Frequent timestamp releases pushed the valid Triton prebuilt to position 52, leaving the asset pattern empty and producing `no assets match the file pattern`. The installer also read LLVM metadata from Triton `main`, which could drift from the commit used to build the core archive.

## Validation

- installer tests: 8 passed
- changed Elixir files pass `mix format --check-formatted`
- all changed workflow YAML parses successfully
- `triton.json` resolves to an existing release tag and exact Ubuntu asset
- pinned `llvm-info.json` resolves to LLVM `b010a18d`, build 1

The full local `--resolve-only` request hit a WSL-specific Erlang `:httpc` timeout to `raw.githubusercontent.com`; the same pinned URL was verified successfully with `curl` and is the same access path already used successfully by GitHub Actions.