### PR TITLE
ods: extract traits, regions, builders, assembly format and folder from ODS

### DIFF
--- a/lib/beaver/ods/dump.ex
+++ b/lib/beaver/ods/dump.ex
@@ -8,6 +8,11 @@ defmodule Beaver.MLIR.ODS.Dump do
   - Generate documentation for operations including their attributes, operands, and results
   - Check if an operation supports result type inference
 
+  Each operation record also carries the enriched facts extracted from the
+  TableGen ODS records: `native_class_name`, `traits`, `regions` (name +
+  variadic), `builders` (declared builder parameter types), `assembly_format`,
+  and `has_folder`.
+
   Operations can be looked up using `lookup/1`, and documentation can be generated using `gen_doc/1`.
   """
   @cache_key {__MODULE__, :operations}

--- a/native/tools/ods-extract/dump-ods.cpp
+++ b/native/tools/ods-extract/dump-ods.cpp
@@ -3,8 +3,11 @@
 #include "mlir/Support/ToolUtilities.h"
 #include "mlir/TableGen/Argument.h"
 #include "mlir/TableGen/Attribute.h"
+#include "mlir/TableGen/Builder.h"
 #include "mlir/TableGen/Constraint.h"
 #include "mlir/TableGen/Operator.h"
+#include "mlir/TableGen/Region.h"
+#include "mlir/TableGen/Trait.h"
 #include "mlir/Tools/PDLL/ODS/Constraint.h"
 #include "mlir/Tools/PDLL/ODS/Context.h"
 #include "mlir/Tools/PDLL/ODS/Dialect.h"
@@ -55,6 +58,30 @@ SmallVector<T *> sortMapByName(const llvm::StringMap<std::unique_ptr<T>> &map) {
   return storage;
 }
 
+// Extra per-operation facts that the pdll ods::Context does not carry; they
+// are collected from the tblgen::Operator records in
+// processTdIncludeRecords and emitted alongside the context dump.
+struct OdsExtras {
+  struct BuilderInfo {
+    struct Parameter {
+      std::string name;
+      std::string cppType;
+      bool hasDefault;
+    };
+    std::vector<Parameter> parameters;
+    bool deprecated;
+  };
+
+  std::string nativeClassName;
+  std::vector<std::string> traits;
+  std::vector<std::pair<std::string, bool>> regions; // (name, variadic)
+  std::vector<BuilderInfo> builders;
+  std::string assemblyFormat;
+  bool hasFolder;
+};
+
+llvm::StringMap<OdsExtras> g_extras;
+
 void printODSContext(raw_ostream &os, const ods::Context &odsContext) {
   using namespace mlir::pdll::ods;
   auto formatConstraintName = [](const auto &constraint) {
@@ -98,12 +125,60 @@ void printODSContext(raw_ostream &os, const ods::Context &odsContext) {
           j.attribute("name", dialect.getName());
           j.attributeArray("operations", [&] {
             for (const Operation *op : sortMapByName(dialect.getOperations())) {
+              const OdsExtras *extras = nullptr;
+              if (auto it = g_extras.find(op->getName()); it != g_extras.end())
+                extras = &it->second;
+
               j.object([&] {
                 j.attribute("name", op->getName());
                 j.attribute("summary", op->getSummary());
                 j.attribute("description", op->getDescription());
                 j.attribute("result_type_inference",
                             op->hasResultTypeInferrence());
+                j.attribute("native_class_name",
+                            extras ? extras->nativeClassName : "");
+
+                if (extras && !extras->traits.empty()) {
+                  j.attributeArray("traits", [&] {
+                    for (const std::string &trait : extras->traits)
+                      j.value(trait);
+                  });
+                }
+
+                if (extras && !extras->regions.empty()) {
+                  j.attributeArray("regions", [&] {
+                    for (const auto &[name, variadic] : extras->regions) {
+                      j.object([&] {
+                        j.attribute("name", name);
+                        j.attribute("variadic", variadic);
+                      });
+                    }
+                  });
+                }
+
+                if (extras && !extras->builders.empty()) {
+                  j.attributeArray("builders", [&] {
+                    for (const auto &builder : extras->builders) {
+                      j.object([&] {
+                        j.attribute("deprecated", builder.deprecated);
+                        j.attributeArray("parameters", [&] {
+                          for (const auto &param : builder.parameters) {
+                            j.object([&] {
+                              j.attribute("name", param.name);
+                              j.attribute("cpp_type", param.cppType);
+                              j.attribute("has_default", param.hasDefault);
+                            });
+                          }
+                        });
+                      });
+                    }
+                  });
+                }
+
+                if (extras && !extras->assemblyFormat.empty())
+                  j.attribute("assembly_format", extras->assemblyFormat);
+
+                j.attribute("has_folder", extras ? extras->hasFolder : false);
 
                 // Attributes
                 ArrayRef<Attribute> attributes = op->getAttributes();
@@ -151,6 +226,7 @@ std::string processAndFormatDoc(const Twine &doc) {
   }
   return docStr;
 }
+
 void processTdIncludeRecords(const llvm::RecordKeeper &tdRecords,
                              ods::Context &odsContext) {
   // Return the length kind of the given value.
@@ -205,6 +281,46 @@ void processTdIncludeRecords(const llvm::RecordKeeper &tdRecords,
       odsOp->appendResult(result.name, getLengthKind(result),
                           addTypeConstraint(result));
     }
+
+    // Collect the extra facts that the pdll ODS context does not carry.
+    OdsExtras extras;
+    extras.nativeClassName = op.getQualCppClassName();
+    extras.hasFolder = op.hasFolder();
+
+    for (const tblgen::Trait &trait : op.getTraits()) {
+      if (const auto *native = llvm::dyn_cast<tblgen::NativeTrait>(&trait)) {
+        extras.traits.push_back(native->getFullyQualifiedTraitName());
+      } else {
+        // Predicate and internal traits carry anonymous record names; keep
+        // only the ones with a real TableGen name.
+        StringRef name = trait.getDef().getName();
+        if (!name.starts_with("anonymous_"))
+          extras.traits.push_back(name.str());
+      }
+    }
+
+    for (const tblgen::NamedRegion &region : op.getRegions())
+      extras.regions.emplace_back(region.name.str(), region.isVariadic());
+
+    for (const tblgen::Builder &builder : op.getBuilders()) {
+      OdsExtras::BuilderInfo builderInfo;
+      builderInfo.deprecated = builder.getDeprecatedMessage().has_value();
+
+      for (const auto &param : builder.getParameters()) {
+        OdsExtras::BuilderInfo::Parameter parameter;
+        parameter.name = param.getName().value_or("").str();
+        parameter.cppType = param.getCppType().str();
+        parameter.hasDefault = param.getDefaultValue().has_value();
+        builderInfo.parameters.push_back(std::move(parameter));
+      }
+
+      extras.builders.push_back(std::move(builderInfo));
+    }
+
+    if (op.hasAssemblyFormat())
+      extras.assemblyFormat = op.getAssemblyFormat().str();
+
+    g_extras[op.getOperationName()] = std::move(extras);
   }
 }
 

--- a/test/ods_test.exs
+++ b/test/ods_test.exs
@@ -18,6 +18,26 @@ defmodule ODSDumpTest do
     assert {:error, "failed to find ODS dump of \"???\""} = MLIR.ODS.Dump.lookup("???")
   end
 
+  test "enriched ODS facts (traits, regions, builders, class, folder)" do
+    assert {:ok, arith_addi} = MLIR.ODS.Dump.lookup("arith.addi")
+    assert arith_addi["native_class_name"] == "::mlir::arith::AddIOp"
+    assert arith_addi["has_folder"] == true
+    assert arith_addi["traits"] |> Enum.any?(&(&1 == "::mlir::OpTrait::IsCommutative"))
+    assert arith_addi["traits"] |> Enum.any?(&(&1 == "InferTypeOpInterface"))
+
+    assert {:ok, scf_for} = MLIR.ODS.Dump.lookup("scf.for")
+    assert scf_for["regions"] == [%{"name" => "region", "variadic" => false}]
+    assert is_list(scf_for["builders"])
+
+    first_builder_parameters =
+      scf_for["builders"] |> List.first() |> Map.fetch!("parameters")
+
+    assert Enum.any?(
+             first_builder_parameters,
+             &(&1["name"] == "lowerBound" and &1["cpp_type"] == "Value")
+           )
+  end
+
   test "loads the canonical JSON dump lazily" do
     dump_path = Application.app_dir(:beaver, "priv/generated/ods_dump.json")
     priv_dir = Application.app_dir(:beaver, "priv")


### PR DESCRIPTION
## Summary

Enriches the ODS extraction (`native/tools/ods-extract/dump-ods.cpp`) with facts the underlying `tblgen::Operator` records already carry but the pdll ODS context does not expose:

- **native_class_name** — C++ op class (`::mlir::arith::AddIOp`)
- **traits** — fully-qualified native trait names (`::mlir::OpTrait::IsCommutative`, `InferTypeOpInterface`, `NoMemoryEffect`, ...); anonymous predicate records are skipped
- **regions** — name + variadic per region
- **builders** — declared builder parameter names / C++ types / has-default
- **assembly_format** — custom assembly syntax when present
- **has_folder** — foldability

Coverage on the pinned prebuilt: all 2076 ops get `native_class_name`/\`has_folder\`; 1657 have traits, 156 regions, 455 builders, 1728 assembly formats.

`Beaver.MLIR.ODS.Dump` loads the enriched records unchanged (additive JSON); a new test pins `arith.addi` traits/class/folder and `scf.for` regions/builders.

## Why it matters

- `traits` turns the boolean `result_type_inference` into the full story: Pure ops (CSE eligibility), `SameOperandsAndResultType`, interface traits — no need to guess.
- `regions` gives the DSL region-bearing ops (and their variadic shape) instead of constructing regions blind.
- `builders` gives typed builder signatures for generating type-correct Elixir op construction.
- `assembly_format` feeds `gen_doc` syntax display and future custom parsers.

## Validation

- `zig build ods_extraction` regenerates `ods_dump.json` with the new fields (verified: `arith.addi`, `scf.for`).
- `mix test`: 362 passed (15 doctests, 347 tests), 5 skipped, 21 excluded.