### PR TITLE
ex: add reduction_tick/clock_init ops for preemptive loop slicing

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -86,6 +86,8 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.receive", &convert_receive/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.mailbox_clear", &convert_mailbox_clear/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.to_int", &convert_to_int/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.reduction_tick", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.clock_init", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.try", &convert_try/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.throw", &convert_throw/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.catch_value", &convert_catch_value/3, version: "1.0")
@@ -154,6 +156,8 @@ defmodule Beaver.MLIR.Conversion.Ex do
     receive: "ex.term.receive",
     mailbox_clear: "ex.term.mailbox_clear",
     to_int: "ex.term.to_int",
+    reduction_tick: "ex.term.clock_tick",
+    clock_init: "ex.term.clock_init",
     jmp_buf_size: "ex.term.jmp_buf_size",
     setjmp_addr: "ex.term.setjmp_addr",
     try_push: "ex.term.try_push",
@@ -833,6 +837,8 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.list_get"), do: @term_intrinsics.list_get
   defp read_intrinsic("ex.list_length"), do: @term_intrinsics.list_length
   defp read_intrinsic("ex.term_eq"), do: @term_intrinsics.term_eq
+  defp read_intrinsic("ex.reduction_tick"), do: @term_intrinsics.reduction_tick
+  defp read_intrinsic("ex.clock_init"), do: @term_intrinsics.clock_init
   defp read_intrinsic("ex.binary_length"), do: @term_intrinsics.binary_length
   defp read_intrinsic("ex.binary_get"), do: @term_intrinsics.binary_get
   defp read_intrinsic("ex.binary_slice"), do: @term_intrinsics.binary_slice

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -146,6 +146,12 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop to_int(word = base(dyn())),
     results: [result: all_of([base("!builtin.integer"), any()])]
 
+  defop reduction_tick(cost = all_of([base("!builtin.integer"), any()])),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
+  defop clock_init(budget = all_of([base("!builtin.integer"), any()])),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
   # Non-local exit (`throw`) and its catch. The body region runs normally; a
   # throw longjmps back and the catch region matches the thrown value.
   defop try(),


### PR DESCRIPTION
tsai/beaver#35 slice 2: preemptive loop slicing.\n\n- `ex.reduction_tick(cost)` lowers to `ex.term.clock_tick` (charge reductions, 1 when budget exhausted);\n- `ex.clock_init(budget)` lowers to `ex.term.clock_init` (set budget, reset used).\n\nPart of batata's reduction-count compilation.