### PR TITLE
Refactor dynamic trait registration

### DIFF
--- a/lib/beaver/mlir/context.ex
+++ b/lib/beaver/mlir/context.ex
@@ -152,7 +152,7 @@ defmodule Beaver.MLIR.Context do
   Check if the op name is terminator
   """
   def terminator?(%__MODULE__{} = ctx, op) do
-    beaverIsOpNameTerminator(MLIR.StringRef.create(op), ctx) |> Beaver.Native.to_term()
+    MLIR.Trait.has?(ctx, op, :terminator)
   end
 
   def implements_interface?(ctx, op, interface_id) do

--- a/lib/beaver/mlir/operation.ex
+++ b/lib/beaver/mlir/operation.ex
@@ -244,7 +244,7 @@ defmodule Beaver.MLIR.Operation do
   Check if the operation is a terminator.
   """
   def terminator?(%__MODULE__{} = op) do
-    MLIR.Context.terminator?(MLIR.context(op), name(op))
+    MLIR.Trait.has?(op, :terminator)
   end
 
   def implements_interface?(%__MODULE__{} = op, interface_id) do

--- a/lib/beaver/mlir/trait.ex
+++ b/lib/beaver/mlir/trait.ex
@@ -1,0 +1,128 @@
+defmodule Beaver.MLIR.Trait do
+  @moduledoc """
+  Attaches and queries traits on dynamically defined MLIR operations.
+
+  Trait registration belongs to an `MLIR.Context`. Attaching an already
+  present trait is a no-op, so a dynamic dialect's runtime extensions may be
+  installed more than once in the same context.
+
+  The target operation must already be registered by an extensible dialect.
+  """
+
+  alias Beaver.MLIR
+
+  @traits %{
+    terminator: {
+      :mlirDynamicOpTraitIsTerminatorCreate,
+      :mlirDynamicOpTraitIsTerminatorGetTypeID
+    },
+    isolated_from_above: {
+      :mlirDynamicOpTraitIsIsolatedFromAboveCreate,
+      :mlirDynamicOpTraitIsIsolatedFromAboveGetTypeID
+    },
+    no_terminator: {
+      :mlirDynamicOpTraitNoTerminatorCreate,
+      :mlirDynamicOpTraitNoTerminatorGetTypeID
+    }
+  }
+
+  @type builtin :: :terminator | :isolated_from_above | :no_terminator
+
+  @doc "Returns the built-in dynamic traits supported by MLIR."
+  @spec builtins() :: [builtin()]
+  def builtins, do: Map.keys(@traits)
+
+  @doc false
+  def normalize!(nil), do: []
+
+  def normalize!(traits) when is_list(traits) do
+    traits = Enum.uniq(traits)
+    unsupported = traits -- builtins()
+
+    if unsupported != [] do
+      raise ArgumentError, "unsupported Slang traits: #{inspect(unsupported)}"
+    end
+
+    if :terminator in traits and :no_terminator in traits do
+      raise ArgumentError,
+            "conflicting Slang traits: :terminator and :no_terminator cannot be combined"
+    end
+
+    traits
+  end
+
+  def normalize!(traits) do
+    raise ArgumentError, "expected a list of Slang traits, got: #{inspect(traits)}"
+  end
+
+  @doc "Attaches a built-in trait to a registered dynamic operation."
+  @spec attach(MLIR.Context.t(), String.t(), builtin()) :: :ok
+  def attach(%MLIR.Context{} = context, operation_name, trait)
+      when is_binary(operation_name) do
+    if has?(context, operation_name, trait) do
+      :ok
+    else
+      {create, _type_id} = definition!(trait)
+      dynamic_trait = apply(MLIR.CAPI, create, [])
+      operation_name_ref = MLIR.StringRef.create(operation_name)
+
+      attached? =
+        MLIR.CAPI.mlirDynamicOpTraitAttach(dynamic_trait, operation_name_ref, context)
+        |> Beaver.Native.to_term()
+
+      # mlirDynamicOpTraitAttach consumes the trait on both success and
+      # failure. A false result can be an idempotent concurrent attachment, so
+      # inspect the registered operation again without destroying the pointer.
+      if attached? or has?(context, operation_name_ref, trait) do
+        :ok
+      else
+        raise ArgumentError,
+              "failed to attach #{inspect(trait)} to dynamic operation #{operation_name}"
+      end
+    end
+  end
+
+  @doc "Attaches all declared traits for operations in a dynamic dialect."
+  @spec attach_all(MLIR.Context.t(), String.t(), [{String.t(), [builtin()]}]) :: :ok
+  def attach_all(%MLIR.Context{} = context, dialect, declarations)
+      when is_binary(dialect) and is_list(declarations) do
+    for {operation, traits} <- declarations,
+        trait <- traits do
+      attach(context, "#{dialect}.#{operation}", trait)
+    end
+
+    :ok
+  end
+
+  @doc "Checks whether a registered operation name has a built-in trait."
+  @spec has?(MLIR.Context.t(), String.t() | MLIR.StringRef.t(), builtin()) :: boolean()
+  def has?(%MLIR.Context{} = context, operation_name, trait) do
+    operation_name =
+      case operation_name do
+        %MLIR.StringRef{} -> operation_name
+        name when is_binary(name) -> MLIR.StringRef.create(name)
+      end
+
+    MLIR.CAPI.mlirOperationNameHasTrait(operation_name, type_id(trait), context)
+    |> Beaver.Native.to_term()
+  end
+
+  @doc "Checks whether an operation has a built-in trait."
+  @spec has?(MLIR.Operation.t(), builtin()) :: boolean()
+  def has?(%MLIR.Operation{} = operation, trait) do
+    has?(MLIR.context(operation), MLIR.Operation.name(operation), trait)
+  end
+
+  @doc false
+  def type_id(trait) do
+    {_create, type_id} = definition!(trait)
+    apply(MLIR.CAPI, type_id, [])
+  end
+
+  defp definition!(trait) do
+    case @traits do
+      %{^trait => definition} -> definition
+      _ -> raise ArgumentError, "unsupported MLIR trait: #{inspect(trait)}"
+    end
+  end
+end

--- a/lib/beaver/slang.ex
+++ b/lib/beaver/slang.ex
@@ -2,7 +2,6 @@ defmodule Beaver.Slang do
   use Beaver
   alias Beaver.MLIR.Dialect.IRDL
   @variadic_tags [:variadic, :optional, :single]
-  @dynamic_traits [:terminator, :isolated_from_above, :no_terminator]
   @callback __slang_dialect__(ctx :: Beaver.MLIR.Context.t()) :: Beaver.MLIR.Module.t()
   @callback __slang_traits__() :: [{String.t(), [atom()]}]
   @callback __slang_interfaces__() :: [{String.t(), keyword()}]
@@ -486,21 +485,6 @@ defmodule Beaver.Slang do
           "operation attributes must be a keyword list, got: #{Macro.to_string(attributes)}"
   end
 
-  defp normalize_traits!(nil), do: []
-
-  defp normalize_traits!(traits) when is_list(traits) do
-    traits = Enum.uniq(traits)
-
-    case traits -- @dynamic_traits do
-      [] -> traits
-      unsupported -> raise ArgumentError, "unsupported Slang traits: #{inspect(unsupported)}"
-    end
-  end
-
-  defp normalize_traits!(traits) do
-    raise ArgumentError, "expected a list of Slang traits, got: #{inspect(traits)}"
-  end
-
   defp normalize_region_descriptor(:any) do
     %{args: nil, size: nil}
   end
@@ -650,7 +634,7 @@ defmodule Beaver.Slang do
         region_names: region_names
       )
 
-    traits = normalize_traits!(opts[:traits])
+    traits = Beaver.MLIR.Trait.normalize!(opts[:traits])
     interfaces = normalize_interfaces!(opts[:interfaces])
 
     quote do
@@ -1037,30 +1021,6 @@ defmodule Beaver.Slang do
     )
   end
 
-  @trait_factories %{
-    terminator: :mlirDynamicOpTraitIsTerminatorCreate,
-    isolated_from_above: :mlirDynamicOpTraitIsIsolatedFromAboveCreate,
-    no_terminator: :mlirDynamicOpTraitNoTerminatorCreate
-  }
-
-  defp attach_dynamic_traits(ctx, dialect, traits) do
-    for {operation, operation_traits} <- traits,
-        trait <- operation_traits do
-      dynamic_trait = apply(MLIR.CAPI, Map.fetch!(@trait_factories, trait), [])
-      operation_name = MLIR.StringRef.create("#{dialect}.#{operation}")
-
-      unless MLIR.CAPI.mlirDynamicOpTraitAttach(dynamic_trait, operation_name, ctx)
-             |> Beaver.Native.to_term() do
-        MLIR.CAPI.mlirDynamicOpTraitDestroy(dynamic_trait)
-
-        raise ArgumentError,
-              "failed to attach #{inspect(trait)} to dynamic operation #{dialect}.#{operation}"
-      end
-    end
-
-    :ok
-  end
-
   @external_interfaces [
     :memory_effects,
     :conditionally_speculatable,
@@ -1091,23 +1051,50 @@ defmodule Beaver.Slang do
   This function loads the MLIR dialect into the MLIR context. It invokes the internal function of the provided module to create the dialect's IRDL module and performs additional MLIR transformations and verification.
   """
   def load(ctx, mod) when is_atom(mod) do
+    dialect_name = mod.__slang_dialect_name__()
+
     result =
-      apply(mod, :__slang_dialect__, [ctx])
-      |> Beaver.MLIR.Transform.canonicalize()
-      |> Beaver.Composer.run!()
-      |> MLIR.verify!()
-      |> Beaver.MLIR.CAPI.mlirLoadIRDLDialects()
+      if dynamic_dialect_loaded?(ctx, dialect_name) do
+        MLIR.CAPI.mlirLogicalResultSuccess()
+      else
+        apply(mod, :__slang_dialect__, [ctx])
+        |> Beaver.MLIR.Transform.canonicalize()
+        |> Beaver.Composer.run!()
+        |> MLIR.verify!()
+        |> Beaver.MLIR.CAPI.mlirLoadIRDLDialects()
+      end
 
     if MLIR.LogicalResult.success?(result) do
-      attach_dynamic_traits(ctx, mod.__slang_dialect_name__(), mod.__slang_traits__())
+      Beaver.MLIR.Trait.attach_all(
+        ctx,
+        dialect_name,
+        mod.__slang_traits__()
+      )
 
       Beaver.MLIR.ExternalInterface.attach_all(
         ctx,
-        mod.__slang_dialect_name__(),
+        dialect_name,
         mod.__slang_interfaces__()
       )
     end
 
     result
+  end
+
+  defp dynamic_dialect_loaded?(ctx, dialect_name) do
+    dialect =
+      MLIR.CAPI.mlirContextGetLoadedDialect(ctx, MLIR.StringRef.create(dialect_name))
+
+    if MLIR.CAPI.beaverIsNullDialect(dialect) |> Beaver.Native.to_term() do
+      false
+    else
+      unless MLIR.CAPI.mlirDialectIsAExtensibleDialect(dialect) |> Beaver.Native.to_term() do
+        raise ArgumentError,
+              "cannot load Slang dialect #{inspect(dialect_name)}: " <>
+                "a non-extensible dialect with that namespace is already loaded"
+      end
+
+      true
+    end
   end
 end

--- a/native/include/mlir-c/Beaver/Op.h
+++ b/native/include/mlir-c/Beaver/Op.h
@@ -19,9 +19,6 @@ extern "C" {
 
 #undef DEFINE_C_API_STRUCT
 
-MLIR_CAPI_EXPORTED bool beaverIsOpNameTerminator(MlirStringRef op_name,
-                                                 MlirContext context);
-
 MLIR_CAPI_EXPORTED void beaverContextGetOps(MlirContext context,
                                             MlirStringCallback insert,
                                             void *container);

--- a/native/lib/CAPI/Beaver.cpp
+++ b/native/lib/CAPI/Beaver.cpp
@@ -157,12 +157,6 @@ beaverPassManagerEnableTiming(MlirPassManager passManager) {
   unwrap(passManager)->enableTiming();
 }
 
-MLIR_CAPI_EXPORTED bool beaverIsOpNameTerminator(MlirStringRef op_name,
-                                                 MlirContext context) {
-  auto name = OperationName(unwrap(op_name), unwrap(context));
-  return name.isRegistered() && name.mightHaveTrait<OpTrait::IsTerminator>();
-}
-
 MLIR_CAPI_EXPORTED void beaverContextGetOps(MlirContext context,
                                             MlirStringCallback insert,
                                             void *container) {

--- a/test/trait_test.exs
+++ b/test/trait_test.exs
@@ -20,5 +20,41 @@ defmodule TraitTest do
 
     ops = MLIR.Module.body(m) |> Beaver.Walker.operations()
     assert MLIR.Operation.terminator?(ops[0])
+    assert MLIR.Trait.has?(ops[0], :terminator)
+  end
+
+  test "attaches and queries built-in dynamic traits idempotently", %{ctx: ctx} do
+    assert CompleteSlang
+           |> then(&Beaver.Slang.load(ctx, &1))
+           |> MLIR.LogicalResult.success?()
+
+    assert MLIR.Trait.has?(ctx, "complete_slang.yield", :terminator)
+    assert MLIR.Trait.has?(ctx, "complete_slang.scope", :isolated_from_above)
+    assert MLIR.Trait.has?(ctx, "complete_slang.scope", :no_terminator)
+
+    assert CompleteSlang
+           |> then(&Beaver.Slang.load(ctx, &1))
+           |> MLIR.LogicalResult.success?()
+
+    assert :ok =
+             MLIR.Trait.attach_all(
+               ctx,
+               CompleteSlang.__slang_dialect_name__(),
+               CompleteSlang.__slang_traits__()
+             )
+
+    assert :ok = MLIR.Trait.attach(ctx, "complete_slang.yield", :terminator)
+  end
+
+  test "validates built-in trait declarations" do
+    assert MLIR.Trait.normalize!([:terminator, :terminator]) == [:terminator]
+
+    assert_raise ArgumentError, ~r/conflicting Slang traits/, fn ->
+      MLIR.Trait.normalize!([:terminator, :no_terminator])
+    end
+
+    assert_raise ArgumentError, ~r/unsupported Slang traits/, fn ->
+      MLIR.Trait.normalize!([:unknown])
+    end
   end
 end


### PR DESCRIPTION
## Summary

- extract built-in dynamic operation trait handling into `Beaver.MLIR.Trait`
- make Slang dialect and trait registration idempotent within an MLIR context
- replace the terminator-specific Beaver C API with upstream TypeID-based trait queries
- reject conflicting trait declarations and fix ownership after `mlirDynamicOpTraitAttach`

## Why

LLVM consumes a dynamic trait passed to `mlirDynamicOpTraitAttach` on both success and failure. Beaver previously destroyed the same pointer again on a failed insertion, leaving a double-free path when a trait was attached twice.

Loading the same Slang dialect twice also attempted to register its operations again and triggered an LLVM assertion before trait attachment. This change detects an already loaded extensible dialect and only installs its runtime extensions again.

This is the first PR in the stacked implementation of Forgejo issue `tsai/beaver#36`. The follow-up PR adds callback-backed custom dynamic traits on top of the new abstraction.

## Validation

- `mix format --check-formatted`
- `git diff --check`
- `LLVM_CONFIG_PATH=/home/jackal/oss/beaver/priv/llvm-prebuilt/bin/llvm-config mix test`
  - 363 passed, 5 skipped, 21 excluded

