### PR TITLE
ex: add yield_mark op for preemptive yield accounting

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -88,6 +88,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.to_int", &convert_to_int/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.reduction_tick", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.clock_init", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.yield_mark", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.try", &convert_try/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.throw", &convert_throw/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.catch_value", &convert_catch_value/3, version: "1.0")
@@ -158,6 +159,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     to_int: "ex.term.to_int",
     reduction_tick: "ex.term.clock_tick",
     clock_init: "ex.term.clock_init",
+    yield_mark: "ex.term.yield_mark",
     jmp_buf_size: "ex.term.jmp_buf_size",
     setjmp_addr: "ex.term.setjmp_addr",
     try_push: "ex.term.try_push",
@@ -839,6 +841,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.term_eq"), do: @term_intrinsics.term_eq
   defp read_intrinsic("ex.reduction_tick"), do: @term_intrinsics.reduction_tick
   defp read_intrinsic("ex.clock_init"), do: @term_intrinsics.clock_init
+  defp read_intrinsic("ex.yield_mark"), do: @term_intrinsics.yield_mark
   defp read_intrinsic("ex.binary_length"), do: @term_intrinsics.binary_length
   defp read_intrinsic("ex.binary_get"), do: @term_intrinsics.binary_get
   defp read_intrinsic("ex.binary_slice"), do: @term_intrinsics.binary_slice
@@ -1015,6 +1018,10 @@ defmodule Beaver.MLIR.Conversion.Ex do
   end
 
   defp intrinsic_function_type("ex.term.receive", _ctx) do
+    MLIR.Type.function([], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.yield_mark", _ctx) do
     MLIR.Type.function([], [MLIR.Type.i64()])
   end
 

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -152,6 +152,9 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop clock_init(budget = all_of([base("!builtin.integer"), any()])),
     results: [result: all_of([base("!builtin.integer"), any()])]
 
+  defop yield_mark(),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
   # Non-local exit (`throw`) and its catch. The body region runs normally; a
   # throw longjmps back and the catch region matches the thrown value.
   defop try(),


### PR DESCRIPTION
tsai/beaver#35 slice 3: preemptive yield/resume.\n\n- `ex.yield_mark()` lowers to `ex.term.yield_mark` (record a yield at a slice boundary; zero-arg intrinsic).\n\nPart of batata's reduction-count compilation.