### PR TITLE
wasmssa: bind the WebAssembly SSA dialect ops

### DIFF
--- a/lib/beaver/mlir/dialect/wasmssa.ex
+++ b/lib/beaver/mlir/dialect/wasmssa.ex
@@ -1,2 +1,42 @@
-require Beaver.MLIR.Dialect
-Beaver.MLIR.Dialect.define("wasmssa")
+defmodule Beaver.MLIR.Dialect.WasmSSA do
+  alias Beaver.MLIR.Dialect
+
+  @moduledoc """
+  This module defines functions for Ops in #{__MODULE__ |> Module.split() |> List.last()} dialect.
+
+  The WebAssembly SSA dialect is MLIR's native WASM IR (block/loop/if, locals,
+  imports, tables, memories). Op construction functions are generated from the
+  ops registered in the MLIR context; operand/attribute segment sizes and
+  documentation come from the ODS dump.
+  """
+
+  use Beaver.MLIR.Dialect,
+    dialect: "wasmssa",
+    ops: Dialect.Registry.ops("wasmssa")
+
+  @doc """
+  Syntax sugar for `WasmSSA.func` SSA expression, mirroring `Func.func`.
+  """
+  defmacro func(call, do: body) do
+    {func_name, args} = call |> Macro.decompose_call()
+
+    quote do
+      unquote(args)
+      |> List.wrap()
+      |> List.flatten()
+      |> Keyword.put_new(
+        Beaver.MLIR.SymbolTable.attribute_name(),
+        Beaver.MLIR.Attribute.string(unquote(func_name))
+      )
+      |> Keyword.put_new(:loc, Beaver.MLIR.Location.from_env(__ENV__))
+      |> then(
+        &Beaver.MLIR.Operation.create(%Beaver.SSA{
+          op: "wasmssa.func",
+          ip: Beaver.Env.block(),
+          ctx: Beaver.Env.context(),
+          arguments: [fn -> unquote(body) end | &1]
+        })
+      )
+    end
+  end
+end

--- a/test/wasmssa_dialect_test.exs
+++ b/test/wasmssa_dialect_test.exs
@@ -1,0 +1,60 @@
+defmodule WasmSSADialectTest do
+  use Beaver
+  use Beaver.Case, async: true
+
+  require Beaver.MLIR.Dialect.WasmSSA
+
+  alias Beaver.MLIR
+  alias Beaver.MLIR.Dialect.WasmSSA
+  alias MLIR.Type
+
+  test "wasmssa ops are bound from the registry" do
+    assert function_exported?(WasmSSA, :func, 0)
+    assert function_exported?(WasmSSA, :const, 0)
+    assert function_exported?(WasmSSA, :return, 0)
+    assert function_exported?(WasmSSA, :local_get, 0)
+    assert function_exported?(WasmSSA, :call, 0)
+    assert function_exported?(WasmSSA, :branch_if, 0)
+  end
+
+  test "parses wasmssa text", %{ctx: ctx} do
+    module =
+      MLIR.Module.create!(
+        """
+        wasmssa.func @f() -> i32 {
+          %0 = wasmssa.const 10 : i32
+          wasmssa.return %0 : i32
+        }
+        """,
+        ctx: ctx
+      )
+
+    text = MLIR.to_string(module)
+    assert text =~ "wasmssa.func @f() -> i32"
+    assert text =~ "wasmssa.const 10 : i32"
+  end
+
+  test "constructs wasmssa ops from the DSL", %{ctx: ctx} do
+    module =
+      mlir ctx: ctx do
+        module do
+          WasmSSA.func f(
+                         functionType: Type.function([], [Type.i32()]),
+                         sym_name: MLIR.Attribute.string("f")
+                       ) do
+            region do
+              block _() do
+                c = WasmSSA.const(value: MLIR.Attribute.integer(Type.i32(), 10)) >>> Type.i32()
+                WasmSSA.return(c) >>> []
+              end
+            end
+          end
+        end
+      end
+
+    MLIR.verify!(module)
+    text = MLIR.to_string(module)
+    assert text =~ "wasmssa.func @f() -> i32"
+    assert text =~ "wasmssa.const 10 : i32"
+  end
+end


### PR DESCRIPTION
## Summary

The `wasmssa` dialect was registered in Beaver but had no op bindings. This PR adds:

- `Beaver.MLIR.Dialect.WasmSSA`: full dialect binding with op construction functions generated from the ops registered in the MLIR context (78 ops on the pinned prebuilt);
- a `Func.func`-style macro for `wasmssa.func` so function bodies can be built from the Elixir DSL;
- `test/wasmssa_dialect_test.exs` covering exported op functions, parsing wasmssa text modules, and DSL construction + verification.

Example of what now works:

```elixir
mlir ctx: ctx do
  module do
    WasmSSA.func f(
      functionType: Type.function([], [Type.i32()]),
      sym_name: MLIR.Attribute.string("f")
    ) do
      region do
        block _() do
          c = WasmSSA.const(value: MLIR.Attribute.integer(Type.i32(), 10)) >>> Type.i32()
          WasmSSA.return(c) >>> []
        end
      end
    end
  end
end
```

produces `wasmssa.func @f() -> i32 { %0 = wasmssa.const 10 : i32; wasmssa.return %0 : i32 }`.

This is slice 1 of the batata WASM preparation (Forgejo #37): parsing and constructing WasmSSA makes MLIR's `import-wasm` path (wasm binary -> MLIR) usable from Elixir.

## Validation

- `mix compile --warnings-as-errors` ✓
- `mix test`: 365 passed (15 doctests, 350 tests), 5 skipped, 21 excluded ✓