### PR TITLE
Add callback-backed dynamic traits

### DIFF
--- a/guides/slang.md
+++ b/guides/slang.md
@@ -113,6 +113,48 @@ the requested built-in dynamic traits:
 - `:isolated_from_above`
 - `:no_terminator`
 
+Custom dynamic traits attach Elixir verification callbacks under a stable
+identity. The same identity shares one MLIR TypeID across every operation in a
+context:
+
+```elixir
+defmodule MyDialect.ValidOperands do
+end
+
+def verify_operands(operation) do
+  operand_count =
+    Beaver.MLIR.CAPI.mlirOperationGetNumOperands(operation)
+    |> Beaver.Native.to_term()
+
+  if operand_count > 0,
+    do: :ok,
+    else: {:error, :missing_operand}
+end
+
+defop checked(value = optional(any())),
+  traits: [
+    {MyDialect.ValidOperands,
+     verify: &__MODULE__.verify_operands/1}
+  ]
+```
+
+Use `:verify` for ordinary invariants and `:verify_regions` for invariants that
+need access to nested regions. A verifier accepts one borrowed operation and
+returns `:ok`, `true`, `{:ok, value}`, `:error`, `false`, or
+`{:error, reason}`. Failures, exceptions, unavailable callback owners, and
+timeouts become MLIR diagnostics and verification failures.
+
+Each operation attachment has a dedicated callback process. Custom trait
+TypeIDs and callback ownership belong to the MLIR context and are released by
+`Beaver.MLIR.Context.destroy/1`. Context multithreading must remain enabled so
+parse and verification work can run outside BEAM scheduler threads. Direct
+`Beaver.MLIR.Trait.attach_custom/5` calls accept a `:timeout` option, which
+defaults to 30 seconds.
+
+The operation passed to a verifier is borrowed and valid only until the
+callback returns. Do not send it to another process, store it, or use it after
+the callback.
+
 Keeping attachment out of schema construction makes the IRDL module safe to
 inspect, serialize, and test without mutating dialect registration. It also
 makes failures attributable to either schema verification or interface

--- a/lib/beaver/application.ex
+++ b/lib/beaver/application.ex
@@ -8,6 +8,7 @@ defmodule Beaver.Application do
       MLIR.CompilationCache.Memory.child_spec(name: MLIR.CompilationCache.Memory.default_name()),
       MLIR.Pass.global_registrar_child_specs(),
       MLIR.RewritePattern.global_registrar_child_specs(),
+      MLIR.Trait.global_registrar_child_specs(),
       MLIR.ExternalInterface.global_registrar_child_specs(),
       MLIR.ActionTracing.global_registrar_child_specs(),
       MLIR.Rewrite.thread_pool_child_spec()

--- a/lib/beaver/mlir.ex
+++ b/lib/beaver/mlir.ex
@@ -276,7 +276,11 @@ defmodule Beaver.MLIR do
       ctx = MLIR.context(op)
 
       {is_success, diagnostics} =
-        mlirOperationVerifyWithDiagnostics(ctx, MLIR.Operation.from_module(op))
+        Beaver.MLIR.CAPI.beaver_raw_operation_verify_async(
+          ctx.ref,
+          MLIR.Operation.from_module(op).ref
+        )
+        |> Beaver.MLIR.CAPI.await_async()
 
       if Beaver.Native.to_term(is_success) do
         {:ok, op}

--- a/lib/beaver/mlir/capi.ex
+++ b/lib/beaver/mlir/capi.ex
@@ -33,4 +33,14 @@ defmodule Beaver.MLIR.CAPI do
   end
 
   defdelegate load_nif(), to: __MODULE__.Raw
+
+  @doc false
+  def await_async(:async) do
+    receive do
+      {result, diagnostics} when is_list(diagnostics) ->
+        Beaver.Native.check!({result, diagnostics})
+    end
+  end
+
+  def await_async(result), do: Beaver.Native.check!(result)
 end

--- a/lib/beaver/mlir/capi_handwritten.ex
+++ b/lib/beaver/mlir/capi_handwritten.ex
@@ -26,6 +26,8 @@ defmodule Beaver.MLIR.CAPI.Handwritten do
     beaver_raw_triton_register_dialects: 1,
     beaver_raw_triton_register_passes: 0,
     beaver_raw_external_interface_release: 1,
+    beaver_raw_module_create_parse_async: 3,
+    beaver_raw_operation_verify_async: 2,
     beaver_raw_transform_state_payload_ops: 2,
     beaver_raw_transform_state_payload_values: 2,
     beaver_raw_transform_state_params: 2,

--- a/lib/beaver/mlir/context.ex
+++ b/lib/beaver/mlir/context.ex
@@ -92,6 +92,7 @@ defmodule Beaver.MLIR.Context do
       MLIR.ActionTracing.release_context(ctx)
       mlirContextDestroy(ctx)
     after
+      MLIR.Trait.release_context(ctx)
       MLIR.ExternalInterface.release_context(ctx)
 
       if ctx.thread_pool_owner do

--- a/lib/beaver/mlir/module.ex
+++ b/lib/beaver/mlir/module.ex
@@ -14,7 +14,12 @@ defmodule Beaver.MLIR.Module do
       opts,
       fn ctx ->
         {module, diagnostics} =
-          CAPI.mlirModuleCreateParseWithDiagnostics(ctx, ctx, MLIR.StringRef.create(str))
+          CAPI.beaver_raw_module_create_parse_async(
+            ctx.ref,
+            ctx.ref,
+            MLIR.StringRef.create(str).ref
+          )
+          |> CAPI.await_async()
 
         if MLIR.null?(module) do
           {:error, diagnostics}

--- a/lib/beaver/mlir/trait.ex
+++ b/lib/beaver/mlir/trait.ex
@@ -6,10 +6,66 @@ defmodule Beaver.MLIR.Trait do
   present trait is a no-op, so a dynamic dialect's runtime extensions may be
   installed more than once in the same context.
 
-  The target operation must already be registered by an extensible dialect.
+  Custom traits use a stable TypeID per identity and context. Their verifier
+  callbacks run in a dedicated BEAM process and receive a borrowed operation
+  that is valid only until the callback returns. The target operation must
+  already be registered by an extensible dialect.
   """
 
+  use GenServer
+
+  require Logger
+
   alias Beaver.MLIR
+  alias Kinda.CallbackRuntime
+
+  defmodule Attachment do
+    @moduledoc "A live callback-backed dynamic trait attachment."
+    @enforce_keys [:pid, :id, :identity, :operation_name, :type_id]
+    defstruct [:pid, :id, :identity, :operation_name, :type_id]
+
+    @type t :: %__MODULE__{
+            pid: pid(),
+            id: term(),
+            identity: atom(),
+            operation_name: String.t(),
+            type_id: Beaver.MLIR.TypeID.t()
+          }
+  end
+
+  defmodule DefinitionServer do
+    @moduledoc false
+    use GenServer
+
+    alias Beaver.MLIR
+
+    @impl true
+    def init({context_ref, context_registry}) do
+      {:ok, _} = Registry.register(context_registry, context_ref, :definition)
+      {:ok, %{allocator: MLIR.CAPI.mlirTypeIDAllocatorCreate(), type_ids: %{}}}
+    end
+
+    @impl true
+    def handle_call({:type_id, identity}, _from, state) do
+      {type_id, type_ids} =
+        Map.get_and_update(state.type_ids, identity, fn
+          nil ->
+            type_id = MLIR.CAPI.mlirTypeIDAllocatorAllocateTypeID(state.allocator)
+            {type_id, type_id}
+
+          type_id ->
+            {type_id, type_id}
+        end)
+
+      {:reply, type_id, %{state | type_ids: type_ids}}
+    end
+
+    @impl true
+    def terminate(_reason, state) do
+      MLIR.CAPI.mlirTypeIDAllocatorDestroy(state.allocator)
+      :ok
+    end
+  end
 
   @traits %{
     terminator: {
@@ -26,7 +82,39 @@ defmodule Beaver.MLIR.Trait do
     }
   }
 
+  @definition_registry __MODULE__.DefinitionRegistry
+  @context_registry __MODULE__.ContextRegistry
+  @custom_callback_keys [:verify, :verify_regions]
+
   @type builtin :: :terminator | :isolated_from_above | :no_terminator
+  @type identity :: module() | atom()
+  @type custom :: {identity(), keyword()}
+  @type declaration :: builtin() | custom()
+
+  @doc false
+  def global_registrar_child_specs do
+    [
+      {Registry, keys: :unique, name: @definition_registry},
+      {Registry, keys: :duplicate, name: @context_registry}
+    ]
+  end
+
+  @doc false
+  def release_context(%MLIR.Context{ref: context_ref}) do
+    if Process.whereis(@context_registry) do
+      entries = Registry.lookup(@context_registry, context_ref)
+
+      entries
+      |> Enum.filter(&(elem(&1, 1) == :attachment))
+      |> Enum.each(fn {pid, _kind} -> release_attachment(pid) end)
+
+      entries
+      |> Enum.filter(&(elem(&1, 1) == :definition))
+      |> Enum.each(fn {pid, _kind} -> stop_definition(pid) end)
+    end
+
+    :ok
+  end
 
   @doc "Returns the built-in dynamic traits supported by MLIR."
   @spec builtins() :: [builtin()]
@@ -37,7 +125,7 @@ defmodule Beaver.MLIR.Trait do
 
   def normalize!(traits) when is_list(traits) do
     traits = Enum.uniq(traits)
-    unsupported = traits -- builtins()
+    unsupported = Enum.reject(traits, &(builtin?(&1) or custom_declaration?(&1)))
 
     if unsupported != [] do
       raise ArgumentError, "unsupported Slang traits: #{inspect(unsupported)}"
@@ -55,10 +143,10 @@ defmodule Beaver.MLIR.Trait do
     raise ArgumentError, "expected a list of Slang traits, got: #{inspect(traits)}"
   end
 
-  @doc "Attaches a built-in trait to a registered dynamic operation."
-  @spec attach(MLIR.Context.t(), String.t(), builtin()) :: :ok
+  @doc "Attaches a trait to a registered dynamic operation."
+  @spec attach(MLIR.Context.t(), String.t(), declaration()) :: :ok | Attachment.t()
   def attach(%MLIR.Context{} = context, operation_name, trait)
-      when is_binary(operation_name) do
+      when is_binary(operation_name) and is_atom(trait) do
     if has?(context, operation_name, trait) do
       :ok
     else
@@ -82,8 +170,44 @@ defmodule Beaver.MLIR.Trait do
     end
   end
 
+  def attach(%MLIR.Context{} = context, operation_name, {identity, callbacks})
+      when is_binary(operation_name) do
+    attach_custom(context, operation_name, identity, callbacks)
+  end
+
+  @doc "Attaches a callback-backed custom trait to a dynamic operation."
+  @spec attach_custom(MLIR.Context.t(), String.t(), identity(), keyword(), keyword()) ::
+          :ok | Attachment.t()
+  def attach_custom(context, operation_name, identity, callbacks, opts \\ []) do
+    callbacks = normalize_callbacks!(callbacks)
+    timeout_ms = Keyword.get(opts, :timeout, 30_000)
+
+    unless is_integer(timeout_ms) and timeout_ms >= 0 do
+      raise ArgumentError, ":timeout must be a non-negative integer"
+    end
+
+    type_id = type_id(context, identity)
+
+    if has_type_id?(context, operation_name, type_id) do
+      :ok
+    else
+      init = {context, operation_name, identity, type_id, callbacks, timeout_ms}
+
+      case GenServer.start(__MODULE__, init) do
+        {:ok, pid} ->
+          GenServer.call(pid, :attachment)
+
+        {:error, {%_{} = exception, stacktrace}} ->
+          reraise exception, stacktrace
+
+        {:error, reason} ->
+          raise "failed to attach trait #{inspect(identity)}: #{inspect(reason)}"
+      end
+    end
+  end
+
   @doc "Attaches all declared traits for operations in a dynamic dialect."
-  @spec attach_all(MLIR.Context.t(), String.t(), [{String.t(), [builtin()]}]) :: :ok
+  @spec attach_all(MLIR.Context.t(), String.t(), [{String.t(), [declaration()]}]) :: :ok
   def attach_all(%MLIR.Context{} = context, dialect, declarations)
       when is_binary(dialect) and is_list(declarations) do
     for {operation, traits} <- declarations,
@@ -94,23 +218,28 @@ defmodule Beaver.MLIR.Trait do
     :ok
   end
 
-  @doc "Checks whether a registered operation name has a built-in trait."
-  @spec has?(MLIR.Context.t(), String.t() | MLIR.StringRef.t(), builtin()) :: boolean()
+  @doc "Checks whether a registered operation name has a trait."
+  @spec has?(MLIR.Context.t(), String.t() | MLIR.StringRef.t(), builtin() | identity()) ::
+          boolean()
   def has?(%MLIR.Context{} = context, operation_name, trait) do
-    operation_name =
-      case operation_name do
-        %MLIR.StringRef{} -> operation_name
-        name when is_binary(name) -> MLIR.StringRef.create(name)
-      end
-
-    MLIR.CAPI.mlirOperationNameHasTrait(operation_name, type_id(trait), context)
-    |> Beaver.Native.to_term()
+    has_type_id?(context, operation_name, type_id(context, trait))
   end
 
-  @doc "Checks whether an operation has a built-in trait."
-  @spec has?(MLIR.Operation.t(), builtin()) :: boolean()
+  @doc "Checks whether an operation has a trait."
+  @spec has?(MLIR.Operation.t(), builtin() | identity()) :: boolean()
   def has?(%MLIR.Operation{} = operation, trait) do
     has?(MLIR.context(operation), MLIR.Operation.name(operation), trait)
+  end
+
+  @doc "Returns the TypeID used by a trait in a context."
+  def type_id(%MLIR.Context{} = context, trait) do
+    if builtin?(trait) do
+      type_id(trait)
+    else
+      context
+      |> definition_server()
+      |> GenServer.call({:type_id, trait})
+    end
   end
 
   @doc false
@@ -118,6 +247,187 @@ defmodule Beaver.MLIR.Trait do
     {_create, type_id} = definition!(trait)
     apply(MLIR.CAPI, type_id, [])
   end
+
+  @impl true
+  def init({context, operation_name, identity, type_id, callbacks, timeout_ms}) do
+    {:ok, _} = Registry.register(@context_registry, context.ref, :attachment)
+
+    {id, native_owner} =
+      MLIR.CAPI.beaver_raw_dynamic_trait_attach(
+        context,
+        operation_name,
+        type_id,
+        callbacks[:verify],
+        callbacks[:verify_regions],
+        timeout_ms
+      )
+
+    {:ok,
+     %{
+       context: context,
+       operation_name: operation_name,
+       identity: identity,
+       type_id: type_id,
+       callbacks: callbacks,
+       id: id,
+       native_owner: native_owner
+     }}
+  end
+
+  @impl true
+  def handle_call(:attachment, _from, state) do
+    attachment = %Attachment{
+      pid: self(),
+      id: state.id,
+      identity: state.identity,
+      operation_name: state.operation_name,
+      type_id: state.type_id
+    }
+
+    {:reply, attachment, state}
+  end
+
+  def handle_call(:context_destroyed, _from, state) do
+    :ok = MLIR.CAPI.beaver_raw_external_interface_release(state.native_owner)
+    {:stop, :normal, :ok, state}
+  end
+
+  @impl true
+  def handle_info(:external_interface_released, state), do: {:stop, :normal, state}
+
+  def handle_info(message, state) do
+    case dispatch(message, state.identity) do
+      {:handled, _failure} ->
+        {:noreply, state}
+
+      :unhandled ->
+        Logger.warning("unexpected dynamic trait callback message: #{inspect(message)}")
+        {:noreply, state}
+    end
+  end
+
+  defp dispatch({callback_name, token, callback, _id, operation}, identity)
+       when callback_name in [:verify, :verify_regions] do
+    operation = Beaver.Native.check!(operation)
+
+    outcome =
+      CallbackRuntime.invoke(
+        token,
+        fn -> callback.(operation) |> normalize_verification_result() end,
+        &MLIR.CAPI.beaver_raw_callback_reply/2,
+        &diagnose(&1, operation, identity, callback_name)
+      )
+
+    {:handled, callback_failure(outcome)}
+  end
+
+  defp dispatch(_message, _identity), do: :unhandled
+
+  defp normalize_verification_result(result) when result in [:ok, true], do: {:ok, :ok}
+  defp normalize_verification_result({:ok, _value}), do: {:ok, :ok}
+  defp normalize_verification_result(result) when result in [:error, false], do: {:error, result}
+  defp normalize_verification_result({:error, _reason} = error), do: error
+
+  defp normalize_verification_result(other) do
+    raise ArgumentError,
+          "trait verifier must return :ok, true, {:ok, value}, :error, false, " <>
+            "or {:error, reason}, got: #{inspect(other)}"
+  end
+
+  defp diagnose({:exception, kind, reason, stacktrace}, operation, identity, callback_name) do
+    message =
+      "dynamic trait #{inspect(identity)} #{callback_name} callback raised:\n" <>
+        Exception.format(kind, reason, stacktrace)
+
+    MLIR.Operation.location(operation) |> MLIR.Diagnostic.emit(message)
+    Logger.error(message)
+  end
+
+  defp diagnose({:error, reason}, operation, identity, callback_name) do
+    message =
+      "dynamic trait #{inspect(identity)} #{callback_name} callback failed: #{inspect(reason)}"
+
+    MLIR.Operation.location(operation) |> MLIR.Diagnostic.emit(message)
+    Logger.error(message)
+  end
+
+  defp diagnose(_outcome, _operation, _identity, _callback_name), do: :ok
+
+  defp normalize_callbacks!(callbacks) when is_list(callbacks) do
+    unless Keyword.keyword?(callbacks) do
+      raise ArgumentError, "custom trait callbacks must be a keyword list"
+    end
+
+    callbacks = Keyword.validate!(callbacks, @custom_callback_keys)
+
+    if Enum.all?(@custom_callback_keys, &is_nil(callbacks[&1])) do
+      raise ArgumentError, "custom trait requires :verify or :verify_regions"
+    end
+
+    Enum.each(callbacks, fn {name, callback} ->
+      unless is_function(callback, 1) do
+        raise ArgumentError, "custom trait #{inspect(name)} callback must have arity 1"
+      end
+    end)
+
+    callbacks
+  end
+
+  defp normalize_callbacks!(callbacks) do
+    raise ArgumentError,
+          "custom trait callbacks must be a keyword list, got: #{inspect(callbacks)}"
+  end
+
+  defp has_type_id?(context, operation_name, type_id) do
+    operation_name =
+      case operation_name do
+        %MLIR.StringRef{} -> operation_name
+        name when is_binary(name) -> MLIR.StringRef.create(name)
+      end
+
+    MLIR.CAPI.mlirOperationNameHasTrait(operation_name, type_id, context)
+    |> Beaver.Native.to_term()
+  end
+
+  defp definition_server(%MLIR.Context{ref: context_ref}) do
+    name = {:via, Registry, {@definition_registry, context_ref}}
+
+    case GenServer.start(DefinitionServer, {context_ref, @context_registry}, name: name) do
+      {:ok, pid} -> pid
+      {:error, {:already_started, pid}} -> pid
+      {:error, reason} -> raise "failed to start trait definition registry: #{inspect(reason)}"
+    end
+  end
+
+  defp release_attachment(pid) do
+    GenServer.call(pid, :context_destroyed)
+  catch
+    :exit, {:noproc, _} -> :ok
+    :exit, {:normal, _} -> :ok
+  end
+
+  defp stop_definition(pid) do
+    GenServer.stop(pid, :normal)
+  catch
+    :exit, {:noproc, _} -> :ok
+  end
+
+  defp callback_failure({:error, reason}), do: {:error, reason}
+
+  defp callback_failure({:exception, _kind, _reason, _stacktrace} = exception),
+    do: exception
+
+  defp callback_failure(_outcome), do: nil
+
+  defp builtin?(trait), do: is_map_key(@traits, trait)
+
+  defp custom_declaration?({identity, callbacks}) when is_list(callbacks) do
+    identity != nil and Keyword.keyword?(callbacks) and
+      Keyword.keys(callbacks) -- @custom_callback_keys == [] and
+      Enum.any?(@custom_callback_keys, &Keyword.has_key?(callbacks, &1))
+  end
+
+  defp custom_declaration?(_trait), do: false
 
   defp definition!(trait) do
     case @traits do

--- a/lib/beaver/slang.ex
+++ b/lib/beaver/slang.ex
@@ -3,7 +3,7 @@ defmodule Beaver.Slang do
   alias Beaver.MLIR.Dialect.IRDL
   @variadic_tags [:variadic, :optional, :single]
   @callback __slang_dialect__(ctx :: Beaver.MLIR.Context.t()) :: Beaver.MLIR.Module.t()
-  @callback __slang_traits__() :: [{String.t(), [atom()]}]
+  @callback __slang_traits__() :: [{String.t(), [Beaver.MLIR.Trait.declaration()]}]
   @callback __slang_interfaces__() :: [{String.t(), keyword()}]
   @callback __slang_dialect_name__() :: String.t()
   @moduledoc """
@@ -13,7 +13,8 @@ defmodule Beaver.Slang do
   Slang supports named type and attribute parameters, named operation operands,
   results, attributes and regions, reusable constraints, `any_of`, `all_of` and
   `base` constraints, and optional or variadic operands and results. Built-in
-  dynamic operation traits can be attached when the dialect is loaded.
+  built-in and callback-backed custom operation traits can be attached when
+  the dialect is loaded.
 
   Schema construction and runtime interface attachment are separate:
   `__slang_dialect__/1` builds the inspectable IRDL module, while `load/2`

--- a/native/include/mlir-c/Beaver/CAPIPolicy.h
+++ b/native/include/mlir-c/Beaver/CAPIPolicy.h
@@ -14,7 +14,6 @@ typedef enum {
 
   BeaverCapiPolicyDirtyCPUAndIO__mlirExecutionEngineInvokePacked,
 
-  BeaverCapiPolicyCallbackBridge__mlirDynamicOpTraitCreate,
   BeaverCapiPolicyCallbackBridge__mlirInferShapedTypeOpInterfaceInferReturnTypes,
   BeaverCapiPolicyCallbackBridge__mlirInferTypeOpInterfaceInferReturnTypes,
   BeaverCapiPolicyCallbackBridge__mlirTransformStateForEachParam,
@@ -36,6 +35,7 @@ typedef enum {
   BeaverCapiPolicyCallbackRuntime__mlirMemoryEffectsOpInterfaceAttachFallbackModel,
   BeaverCapiPolicyCallbackRuntime__mlirPatternDescriptorOpInterfaceAttachFallbackModel,
   BeaverCapiPolicyCallbackRuntime__mlirTransformOpInterfaceAttachFallbackModel,
+  BeaverCapiPolicyCallbackRuntime__mlirDynamicOpTraitCreate,
 } BeaverCapiPolicyMarker;
 
 #endif // MLIR_C_BEAVER_CAPI_POLICY_H

--- a/native/src/callback_bridge.zig
+++ b/native/src/callback_bridge.zig
@@ -6,16 +6,19 @@ const prelude = @import("prelude.zig");
 const c = prelude.c;
 const mlir_capi = @import("mlir_capi.zig");
 const string_ref = @import("string_ref.zig");
+const diagnostic = @import("diagnostic.zig");
 
 const SpeculatabilityDispatcher = kinda.callback_runtime.Dispatcher(.{"get_speculatability"});
 const MemoryEffectsDispatcher = kinda.callback_runtime.Dispatcher(.{"get_effects"});
 const TransformDispatcher = kinda.callback_runtime.Dispatcher(.{ "apply", "allows_repeated_handle_operands" });
 const PatternDescriptorDispatcher = kinda.callback_runtime.Dispatcher(.{ "populate_patterns", "populate_patterns_with_state" });
+const DynamicTraitDispatcher = kinda.callback_runtime.Dispatcher(.{ "verify", "verify_regions" });
 
 var speculatability_state_type: beam.resource_type = undefined;
 var memory_effects_state_type: beam.resource_type = undefined;
 var transform_state_type: beam.resource_type = undefined;
 var pattern_descriptor_state_type: beam.resource_type = undefined;
+var dynamic_trait_state_type: beam.resource_type = undefined;
 
 fn notifyReleased(recipient: beam.pid) void {
     const environment = e.enif_alloc_env() orelse return;
@@ -306,6 +309,61 @@ const PatternDescriptorState = struct {
     }
 };
 
+const DynamicTraitState = struct {
+    dispatcher: *DynamicTraitDispatcher,
+    model_released: std.atomic.Value(bool) = .init(false),
+
+    fn construct(_: ?*anyopaque) callconv(.c) void {}
+
+    fn destruct(user_data: ?*anyopaque) callconv(.c) void {
+        const self: *@This() = @ptrCast(@alignCast(user_data orelse return));
+        notifyReleased(self.dispatcher.handler);
+        releaseModel(@This(), self);
+    }
+
+    fn invokeVerifier(
+        self: *@This(),
+        comptime callback: []const u8,
+        operation: mlir_capi.Operation.T,
+    ) mlir_capi.LogicalResult.T {
+        if (!self.dispatcher.hasCallback(callback)) return c.mlirLogicalResultSuccess();
+        const environment = e.enif_alloc_env() orelse
+            return callbackFailure(operation);
+        const operation_term = makeHandle(mlir_capi.Operation, environment, operation) orelse
+            return callbackFailure(operation);
+        const response = self.dispatcher.invoke(callback, environment, .{operation_term}) catch
+            return callbackFailure(operation);
+        if (response.status != .replied) return callbackFailure(operation);
+        return if (response.success) c.mlirLogicalResultSuccess() else c.mlirLogicalResultFailure();
+    }
+
+    fn callbackFailure(operation: mlir_capi.Operation.T) mlir_capi.LogicalResult.T {
+        c.mlirEmitError(
+            c.mlirOperationGetLocation(operation),
+            "dynamic trait callback timed out or its owner is unavailable",
+        );
+        return c.mlirLogicalResultFailure();
+    }
+
+    fn verify(
+        operation: mlir_capi.Operation.T,
+        user_data: ?*anyopaque,
+    ) callconv(.c) mlir_capi.LogicalResult.T {
+        const self: *@This() = @ptrCast(@alignCast(user_data orelse
+            return c.mlirLogicalResultFailure()));
+        return self.invokeVerifier("verify", operation);
+    }
+
+    fn verifyRegions(
+        operation: mlir_capi.Operation.T,
+        user_data: ?*anyopaque,
+    ) callconv(.c) mlir_capi.LogicalResult.T {
+        const self: *@This() = @ptrCast(@alignCast(user_data orelse
+            return c.mlirLogicalResultFailure()));
+        return self.invokeVerifier("verify_regions", operation);
+    }
+};
+
 fn destroyState(comptime State: type) fn (beam.env, ?*anyopaque) callconv(.c) void {
     return struct {
         fn destroy(_: beam.env, object: ?*anyopaque) callconv(.c) void {
@@ -460,6 +518,110 @@ fn attachPatternDescriptorFallback(environment: beam.env, _: c_int, args: [*c]co
     );
 }
 
+fn attachDynamicTrait(environment: beam.env, _: c_int, args: [*c]const beam.term) !beam.term {
+    const context = try mlir_capi.Context.resource.fetch(environment, args[0]);
+    const operation_name = try string_ref.get_binary_as_string_ref(environment, args[1]);
+    const type_id = try mlir_capi.TypeID.resource.fetch(environment, args[2]);
+    const dispatcher = try DynamicTraitDispatcher.initWithOptions(try beam.self(environment), .{
+        .timeout_ms = try timeout(environment, args[5]),
+    });
+    var dispatcher_owned = true;
+    errdefer if (dispatcher_owned) dispatcher.deinit();
+    if (!beam.is_nil2(environment, args[3])) dispatcher.setCallback("verify", args[3]);
+    if (!beam.is_nil2(environment, args[4])) dispatcher.setCallback("verify_regions", args[4]);
+    const state = try allocateState(
+        DynamicTraitState,
+        DynamicTraitDispatcher,
+        dynamic_trait_state_type,
+        dispatcher,
+    );
+    errdefer if (dispatcher_owned) e.enif_release_resource(state);
+    dispatcher_owned = false;
+
+    // Add the BEAM-term reference before handing the allocation reference to
+    // MLIR. A failed insertion destroys the trait synchronously; the term then
+    // keeps the state alive until this NIF returns and its environment clears.
+    const result = attachmentTerm(
+        DynamicTraitState,
+        environment,
+        dispatcher.copyId(environment),
+        state,
+    );
+    const trait = c.mlirDynamicOpTraitCreate(
+        type_id,
+        .{
+            .construct = DynamicTraitState.construct,
+            .destruct = DynamicTraitState.destruct,
+            .verifyTrait = DynamicTraitState.verify,
+            .verifyRegionTrait = DynamicTraitState.verifyRegions,
+        },
+        state,
+    );
+
+    if (!c.mlirDynamicOpTraitAttach(trait, operation_name, context))
+        return error.DynamicTraitAlreadyAttached;
+    return result;
+}
+
+fn AsyncDiagnosticsNIF(comptime name: []const u8) type {
+    const bang = kinda.BangFunc(@import("prelude.zig").allKinds, c, name);
+
+    return struct {
+        const Worker = struct {
+            recipient: beam.pid,
+            environment: beam.env,
+            context: mlir_capi.Context.T,
+            args: [bang.arity]beam.term,
+
+            fn deinit(self: *@This()) void {
+                e.enif_free_env(self.environment);
+                std.heap.smp_allocator.destroy(self);
+            }
+
+            fn run(user_data: ?*anyopaque) callconv(.c) void {
+                const self: *@This() = @ptrCast(@alignCast(user_data orelse return));
+                const result = diagnostic.call_with_diagnostics(
+                    self.environment,
+                    self.context,
+                    bang.nif,
+                    .{ self.environment, bang.arity, &self.args },
+                ) catch {
+                    self.deinit();
+                    return;
+                };
+
+                _ = beam.send_advanced(null, self.recipient, self.environment, result);
+                self.deinit();
+            }
+        };
+
+        fn nif(environment: beam.env, n: c_int, args: [*c]const beam.term) !beam.term {
+            if (n != bang.arity + 1) return error.BadArity;
+            const context = try mlir_capi.Context.resource.fetch(environment, args[0]);
+            const worker = try std.heap.smp_allocator.create(Worker);
+            errdefer std.heap.smp_allocator.destroy(worker);
+            const owned_environment = e.enif_alloc_env() orelse
+                return error.FailedToAllocateDiagnosticEnvironment;
+            errdefer e.enif_free_env(owned_environment);
+
+            worker.* = .{
+                .recipient = try beam.self(environment),
+                .environment = owned_environment,
+                .context = context,
+                .args = undefined,
+            };
+            for (0..bang.arity) |index| {
+                worker.args[index] = e.enif_make_copy(owned_environment, args[index + 1]);
+            }
+
+            if (!c.beaverContextAddWork(context, Worker.run, worker)) {
+                return error.ContextMultithreadingDisabled;
+            }
+            return beam.make_atom(environment, "async");
+        }
+    };
+}
+
 fn releaseStateTerm(
     comptime State: type,
     environment: beam.env,
@@ -479,7 +641,8 @@ fn releaseExternalInterface(environment: beam.env, _: c_int, args: [*c]const bea
         releaseStateTerm(SpeculatabilityState, environment, speculatability_state_type, args[0]) or
         releaseStateTerm(MemoryEffectsState, environment, memory_effects_state_type, args[0]) or
         releaseStateTerm(TransformState, environment, transform_state_type, args[0]) or
-        releaseStateTerm(PatternDescriptorState, environment, pattern_descriptor_state_type, args[0]);
+        releaseStateTerm(PatternDescriptorState, environment, pattern_descriptor_state_type, args[0]) or
+        releaseStateTerm(DynamicTraitState, environment, dynamic_trait_state_type, args[0]);
     if (!released) return error.InvalidExternalInterfaceState;
     return beam.make_ok(environment);
 }
@@ -600,6 +763,11 @@ pub fn open(environment: beam.env) void {
         "Beaver.MLIR.PatternDescriptorOpInterface.FallbackState",
         destroyState(PatternDescriptorState),
     );
+    dynamic_trait_state_type = openResourceType(
+        environment,
+        "Beaver.MLIR.Trait.DynamicState",
+        destroyState(DynamicTraitState),
+    );
 }
 
 pub const nifs = .{
@@ -608,6 +776,9 @@ pub const nifs = .{
     prelude.beaverRawNIF(@This(), "memory_effects_attach_fallback_model", 4),
     prelude.beaverRawNIF(@This(), "transform_op_interface_attach_fallback_model", 5),
     prelude.beaverRawNIF(@This(), "pattern_descriptor_op_interface_attach_fallback_model", 5),
+    prelude.beaverRawNIF(@This(), "dynamic_trait_attach", 6),
+    prelude.beaverRawNIF(@This(), "module_create_parse_async", 3),
+    prelude.beaverRawNIF(@This(), "operation_verify_async", 2),
     prelude.beaverRawNIF(@This(), "transform_state_payload_ops", 2),
     prelude.beaverRawNIF(@This(), "transform_state_payload_values", 2),
     prelude.beaverRawNIF(@This(), "transform_state_params", 2),
@@ -620,6 +791,9 @@ pub const conditionally_speculatable_query_async = querySpeculatabilityAsync;
 pub const memory_effects_attach_fallback_model = attachMemoryEffectsFallback;
 pub const transform_op_interface_attach_fallback_model = attachTransformFallback;
 pub const pattern_descriptor_op_interface_attach_fallback_model = attachPatternDescriptorFallback;
+pub const dynamic_trait_attach = attachDynamicTrait;
+pub const module_create_parse_async = AsyncDiagnosticsNIF("mlirModuleCreateParse").nif;
+pub const operation_verify_async = AsyncDiagnosticsNIF("mlirOperationVerify").nif;
 pub const transform_state_payload_ops = transformStatePayloadOps;
 pub const transform_state_payload_values = transformStatePayloadValues;
 pub const transform_state_params = transformStateParams;

--- a/native/tools/capi/gen_manifest.exs
+++ b/native/tools/capi/gen_manifest.exs
@@ -10,6 +10,17 @@ defmodule Beaver.CAPI.ManifestGenerator do
   ]
 
   @runtime_declarations %{
+    "mlirDynamicOpTraitCreate" => %{
+      name: "beaver_raw_dynamic_trait_attach",
+      params: [
+        "context",
+        "operation_name",
+        "type_id",
+        "verify_callback",
+        "verify_regions_callback",
+        "timeout_ms"
+      ]
+    },
     "mlirTypeConverterAddConversion" => %{
       name: "beaver_raw_type_converter_add_conversion",
       params: ["registration", "callback", "timeout_ms"]

--- a/test/capi_manifest_test.exs
+++ b/test/capi_manifest_test.exs
@@ -126,7 +126,8 @@ defmodule Beaver.MLIR.CAPI.ManifestTest do
                "mlirConditionallySpeculatableOpInterfaceAttachFallbackModel",
                "mlirMemoryEffectsOpInterfaceAttachFallbackModel",
                "mlirPatternDescriptorOpInterfaceAttachFallbackModel",
-               "mlirTransformOpInterfaceAttachFallbackModel"
+               "mlirTransformOpInterfaceAttachFallbackModel",
+               "mlirDynamicOpTraitCreate"
              ])
 
     for entry <- pending_entries do

--- a/test/custom_trait_test.exs
+++ b/test/custom_trait_test.exs
@@ -1,0 +1,110 @@
+defmodule CustomTraitTest do
+  use Beaver.Case, async: true
+
+  alias Beaver.MLIR
+
+  @moduletag :smoke
+
+  test "Slang attaches custom traits with a shared identity", %{ctx: ctx} do
+    assert CustomTraitSlang
+           |> then(&Beaver.Slang.load(ctx, &1))
+           |> MLIR.LogicalResult.success?()
+
+    assert MLIR.Trait.has?(ctx, "custom_trait_test.valid", CustomTraitSlang.Validity)
+    assert MLIR.Trait.has?(ctx, "custom_trait_test.also_valid", CustomTraitSlang.Validity)
+
+    valid = module_with(ctx, "custom_trait_test.valid")
+    assert {:ok, ^valid} = MLIR.verify(valid)
+  end
+
+  test "ordinary verifier failures become MLIR diagnostics", %{ctx: ctx} do
+    Beaver.Slang.load(ctx, CustomTraitSlang)
+
+    assert {:error, diagnostics} = parse_with(ctx, "custom_trait_test.invalid")
+    rendered = MLIR.Diagnostic.format(diagnostics)
+    assert rendered =~ "CustomTraitSlang.Validity"
+    assert rendered =~ "invalid_operation"
+  end
+
+  test "region verifier exceptions become MLIR diagnostics", %{ctx: ctx} do
+    Beaver.Slang.load(ctx, CustomTraitSlang)
+
+    assert {:error, diagnostics} = parse_with(ctx, "custom_trait_test.invalid_regions")
+    rendered = MLIR.Diagnostic.format(diagnostics)
+    assert rendered =~ "CustomTraitSlang.RegionValidity"
+    assert rendered =~ "invalid regions"
+  end
+
+  test "custom TypeIDs and callback ownership are isolated by context" do
+    ctx1 = MLIR.Context.create()
+    ctx2 = MLIR.Context.create()
+
+    Beaver.Slang.load(ctx1, CustomTraitSlang)
+    Beaver.Slang.load(ctx2, CustomTraitSlang)
+
+    id1 = MLIR.Trait.type_id(ctx1, CustomTraitSlang.Validity)
+    id2 = MLIR.Trait.type_id(ctx2, CustomTraitSlang.Validity)
+
+    refute MLIR.CAPI.mlirTypeIDEqual(id1, id2) |> Beaver.Native.to_term()
+
+    attachment =
+      MLIR.Trait.attach_custom(
+        ctx1,
+        "custom_trait_test.valid",
+        __MODULE__.ManualTrait,
+        verify: fn _operation -> :ok end
+      )
+
+    monitor = Process.monitor(attachment.pid)
+    MLIR.Context.destroy(ctx1)
+    assert_receive {:DOWN, ^monitor, :process, _, reason} when reason in [:normal, :noproc], 1_000
+    MLIR.Context.destroy(ctx2)
+  end
+
+  test "callback timeout fails verification with a diagnostic", %{ctx: ctx} do
+    Beaver.Slang.load(ctx, CustomTraitSlang)
+
+    MLIR.Trait.attach_custom(
+      ctx,
+      "custom_trait_test.valid",
+      __MODULE__.SlowTrait,
+      [verify: fn _operation -> Process.sleep(100) end],
+      timeout: 10
+    )
+
+    assert {:error, diagnostics} = parse_with(ctx, "custom_trait_test.valid")
+
+    assert MLIR.Diagnostic.format(diagnostics) =~
+             "dynamic trait callback timed out or its owner is unavailable"
+  end
+
+  test "a stopped callback owner fails verification safely", %{ctx: ctx} do
+    Beaver.Slang.load(ctx, CustomTraitSlang)
+
+    attachment =
+      MLIR.Trait.attach_custom(
+        ctx,
+        "custom_trait_test.valid",
+        __MODULE__.StoppedTrait,
+        verify: fn _operation -> :ok end
+      )
+
+    monitor = Process.monitor(attachment.pid)
+    Process.exit(attachment.pid, :kill)
+    assert_receive {:DOWN, ^monitor, :process, _, :killed}, 1_000
+
+    assert {:error, diagnostics} = parse_with(ctx, "custom_trait_test.valid")
+
+    assert MLIR.Diagnostic.format(diagnostics) =~
+             "dynamic trait callback timed out or its owner is unavailable"
+  end
+
+  defp module_with(ctx, operation_name) do
+    MLIR.Module.create!(~s[module { "#{operation_name}"() : () -> () }], ctx: ctx)
+  end
+
+  defp parse_with(ctx, operation_name) do
+    MLIR.Module.create(~s[module { "#{operation_name}"() : () -> () }], ctx: ctx)
+    |> Beaver.Deferred.create(ctx)
+  end
+end

--- a/test/support/custom_trait_slang.ex
+++ b/test/support/custom_trait_slang.ex
@@ -1,0 +1,42 @@
+defmodule CustomTraitSlang.Validity do
+  @moduledoc false
+end
+
+defmodule CustomTraitSlang.RegionValidity do
+  @moduledoc false
+end
+
+defmodule CustomTraitSlang do
+  @moduledoc false
+  use Beaver.Slang, name: "custom_trait_test"
+
+  def verify(operation) do
+    if Beaver.MLIR.Operation.name(operation) == "custom_trait_test.invalid" do
+      {:error, :invalid_operation}
+    else
+      :ok
+    end
+  end
+
+  def verify_regions(operation) do
+    if Beaver.MLIR.Operation.name(operation) == "custom_trait_test.invalid_regions" do
+      raise "invalid regions"
+    else
+      :ok
+    end
+  end
+
+  defop valid(),
+    traits: [{CustomTraitSlang.Validity, verify: &__MODULE__.verify/1}]
+
+  defop also_valid(),
+    traits: [{CustomTraitSlang.Validity, verify: &__MODULE__.verify/1}]
+
+  defop invalid(),
+    traits: [{CustomTraitSlang.Validity, verify: &__MODULE__.verify/1}]
+
+  defop invalid_regions(),
+    traits: [
+      {CustomTraitSlang.RegionValidity, verify_regions: &__MODULE__.verify_regions/1}
+    ]
+end


### PR DESCRIPTION
## Summary

- add callback-backed custom dynamic traits with stable per-context TypeIDs
- run trait verifiers in dedicated BEAM processes with timeout, owner-exit, and diagnostic handling
- move parse and verification work onto MLIR context workers so callbacks never execute on BEAM scheduler threads
- expose custom traits through Slang and document callback lifetime and threading rules
- cover success, verification failure, region verification, timeout, owner exit, context isolation, and cleanup

## Stack

This PR is stacked on #585. Review and merge #585 first; this PR should then be rebased/retargeted to `main`.

## Validation

- `mix test test/custom_trait_test.exs test/trait_test.exs test/capi_manifest_test.exs` — 14 passed
- `LLVM_CONFIG_PATH=/home/jackal/oss/beaver/priv/llvm-prebuilt/bin/llvm-config mix test` — 369 passed, 5 skipped, 21 excluded
- `mix format --check-formatted`
- `zig fmt --check native/src/callback_bridge.zig`
- `git diff --check`

`mix credo --strict` still reports existing repository-wide findings; no findings were reported for the new core `lib/beaver/mlir/trait.ex` implementation.

Tracks Forgejo issue tsai/beaver#36.
