### PR TITLE
wasm: package MLIR modules into wasm binaries with imports/exports manifest

### DIFF
--- a/lib/beaver/wasm.ex
+++ b/lib/beaver/wasm.ex
@@ -1,0 +1,130 @@
+defmodule Beaver.Wasm do
+  @moduledoc """
+  WebAssembly packaging for MLIR modules — the WASM analogue of the
+  `gpu.binary` packaging.
+
+  `package_binary!/2` lowers a module to LLVM IR (via the `ex` conversion
+  plan and the standard arith/scf/cf-to-llvm passes), translates it with
+  `mlir-translate --mlir-to-llvmir`, compiles it to a wasm binary with the
+  Zig wasm32 target, and returns a `Beaver.Wasm.Binary` carrying the bytes
+  plus the imports/exports manifest parsed from the binary.
+
+  This is the host-boundary step of the batata WASM preparation (Forgejo
+  #37): the manifest names the WASI/import surface that a runtime must
+  provide, and the binary is ready for a `:wasm` Shadow Wavefront evaluator.
+  """
+
+  import Beaver.MLIR.Conversion
+  import Beaver.MLIR.Transform
+
+  alias Beaver.MLIR
+  alias Beaver.MLIR.Conversion.{Ex, Plan}
+
+  @doc """
+  Packages an MLIR module into a `Beaver.Wasm.Binary`.
+
+  Options:
+
+    * `:target` — wasm target triple (default `"wasm32-wasi"`)
+    * `:entry` — symbol to export (default `"main"`)
+    * `:opt` — Zig optimization flag (default `"-O2"`)
+    * `:nostdlib` — compile without libc/WASI imports (default `true`)
+  """
+  @spec package_binary!(MLIR.Module.t(), keyword()) :: Beaver.Wasm.Binary.t()
+  def package_binary!(%MLIR.Module{} = module, opts \\ []) do
+    target = Keyword.get(opts, :target, "wasm32-wasi")
+    entry = Keyword.get(opts, :entry, "main")
+    opt = Keyword.get(opts, :opt, "-O2")
+    nostdlib = Keyword.get(opts, :nostdlib, true)
+
+    llvm_ir = to_llvm_ir!(module)
+    bytes = compile!(llvm_ir, target, entry, opt, nostdlib)
+
+    %{Beaver.Wasm.Binary.parse(bytes) | target: target}
+  end
+
+  defp to_llvm_ir!(module) do
+    llvm =
+      module
+      |> then(&if(has_ex_ops?(&1), do: Plan.run!(Ex.plan(), &1), else: &1))
+      |> canonicalize()
+      |> convert_scf_to_cf()
+      |> convert_to_llvm()
+      |> reconcile_unrealized_casts()
+      |> Beaver.Composer.run!()
+
+    mlir_path = tmp_path(".mlir")
+    ll_path = tmp_path(".ll")
+
+    File.write!(mlir_path, MLIR.to_string(llvm))
+
+    run_tool!(mlir_translate(), ["--mlir-to-llvmir", mlir_path, "-o", ll_path])
+
+    ir = File.read!(ll_path)
+    cleanup([mlir_path, ll_path])
+    ir
+  end
+
+  defp has_ex_ops?(module) do
+    module
+    |> MLIR.Module.body()
+    |> Beaver.Walker.prewalk(false, fn
+      %MLIR.Operation{} = op, acc ->
+        {op, acc or String.starts_with?(MLIR.Operation.name(op), "ex.")}
+
+      other, acc ->
+        {other, acc}
+    end)
+    |> elem(1)
+  end
+
+  defp compile!(llvm_ir, target, entry, opt, nostdlib) do
+    ll_path = tmp_path(".ll")
+    wasm_path = tmp_path(".wasm")
+
+    File.write!(ll_path, llvm_ir)
+
+    args =
+      ["cc", "-target", target, opt] ++
+        if(nostdlib, do: ["-nostdlib"], else: []) ++
+        ["-Wl,--no-entry", "-Wl,--export=#{entry}", "-o", wasm_path, ll_path]
+
+    run_tool!(zig(), args)
+
+    bytes = File.read!(wasm_path)
+    cleanup([ll_path, wasm_path])
+    bytes
+  end
+
+  defp zig do
+    System.find_executable("zig") || raise "zig not found on PATH"
+  end
+
+  defp mlir_translate do
+    case System.get_env("LLVM_CONFIG_PATH") do
+      nil -> System.find_executable("mlir-translate") || raise("mlir-translate not found")
+      config -> Path.join([Path.dirname(config), "mlir-translate"])
+    end
+  end
+
+  defp run_tool!(executable, args) do
+    {output, status} = System.cmd(executable, args, stderr_to_stdout: true)
+
+    unless status == 0 do
+      raise "#{executable} failed (#{status}): #{String.slice(output, -1000, 1000)}"
+    end
+
+    :ok
+  end
+
+  defp tmp_path(suffix) do
+    Path.join(
+      System.tmp_dir!(),
+      "beaver_wasm_#{System.unique_integer([:positive])}#{suffix}"
+    )
+  end
+
+  defp cleanup(paths) do
+    Enum.each(paths, &File.rm/1)
+  end
+end

--- a/lib/beaver/wasm/binary.ex
+++ b/lib/beaver/wasm/binary.ex
@@ -52,7 +52,7 @@ defmodule Beaver.Wasm.Binary do
 
   defp parse_sections(<<id, rest::binary>>, imports, exports) do
     {section_size, payload} = take_uleb(rest)
-    <<section::binary-size(section_size), tail::binary>> = payload
+    <<section::binary-size(^section_size), tail::binary>> = payload
 
     case id do
       2 -> parse_sections(tail, parse_imports(section, []), exports)
@@ -111,7 +111,7 @@ defmodule Beaver.Wasm.Binary do
   # --- primitives ---
   defp take_name(binary) do
     {len, rest} = take_uleb(binary)
-    <<name::binary-size(len), tail::binary>> = rest
+    <<name::binary-size(^len), tail::binary>> = rest
     {name, tail}
   end
 

--- a/lib/beaver/wasm/binary.ex
+++ b/lib/beaver/wasm/binary.ex
@@ -1,0 +1,129 @@
+defmodule Beaver.Wasm.Binary do
+  @moduledoc """
+  A packaged WebAssembly binary with its imports/exports manifest.
+
+  This is the WASM analogue of the `gpu.binary` packaging: the compiled
+  binary bytes plus the host-boundary facts (`imports`/`exports`) that a
+  runtime or an experiment receipt needs, without re-reading the LLVM IR.
+
+  The manifest is parsed directly from the wasm binary's import/export
+  sections, so it reflects what the binary actually declares.
+  """
+
+  import Bitwise
+
+  alias Beaver.Wasm.Binary
+
+  @magic <<0x00, 0x61, 0x73, 0x6D>>
+
+  @type import :: %{module: String.t(), name: String.t(), kind: atom()}
+  @type export :: %{name: String.t(), kind: atom(), index: non_neg_integer()}
+
+  defstruct [:bytes, :target, :imports, :exports]
+
+  @type t :: %__MODULE__{
+          bytes: binary(),
+          target: String.t() | nil,
+          imports: [import()],
+          exports: [export()]
+        }
+
+  @doc """
+  Parses the wasm binary header and the import/export sections.
+
+  Unknown sections are skipped; a malformed binary raises.
+  """
+  @spec parse(binary()) :: t()
+  def parse(@magic <> <<version::little-32, rest::binary>>) when version != 0 do
+    {imports, exports} = parse_sections(rest, [], [])
+
+    %Binary{
+      bytes: @magic <> <<version::little-32, rest::binary>>,
+      imports: imports,
+      exports: exports
+    }
+  end
+
+  def parse(_other) do
+    raise ArgumentError, "not a WebAssembly binary (missing \\0asm magic)"
+  end
+
+  defp parse_sections(<<>>, imports, exports), do: {Enum.reverse(imports), Enum.reverse(exports)}
+
+  defp parse_sections(<<id, rest::binary>>, imports, exports) do
+    {section_size, payload} = take_uleb(rest)
+    <<section::binary-size(section_size), tail::binary>> = payload
+
+    case id do
+      2 -> parse_sections(tail, parse_imports(section, []), exports)
+      7 -> parse_sections(tail, imports, parse_exports(section, []))
+      _ -> parse_sections(tail, imports, exports)
+    end
+  end
+
+  # --- imports (section 2) ---
+  defp parse_imports(<<0, _::binary>>, acc), do: Enum.reverse(acc)
+
+  defp parse_imports(section, acc) do
+    {count, rest} = take_uleb(section)
+    parse_import_entries(rest, count, acc)
+  end
+
+  defp parse_import_entries(<<>>, 0, acc), do: Enum.reverse(acc)
+
+  defp parse_import_entries(binary, count, acc) when count > 0 do
+    {module, rest} = take_name(binary)
+    {name, rest} = take_name(rest)
+    <<kind, rest::binary>> = rest
+
+    entry = %{module: module, name: name, kind: import_kind(kind)}
+
+    # skip the kind-specific index (function/table/memory/global type index)
+    {_index, rest} = take_uleb(rest)
+    parse_import_entries(rest, count - 1, [entry | acc])
+  end
+
+  defp import_kind(0), do: :func
+  defp import_kind(1), do: :table
+  defp import_kind(2), do: :memory
+  defp import_kind(3), do: :global
+  defp import_kind(other), do: {:unknown, other}
+
+  # --- exports (section 7) ---
+  defp parse_exports(<<0, _::binary>>, acc), do: Enum.reverse(acc)
+
+  defp parse_exports(section, acc) do
+    {count, rest} = take_uleb(section)
+    parse_export_entries(rest, count, acc)
+  end
+
+  defp parse_export_entries(<<>>, 0, acc), do: Enum.reverse(acc)
+
+  defp parse_export_entries(binary, count, acc) when count > 0 do
+    {name, rest} = take_name(binary)
+    <<kind, rest::binary>> = rest
+    {index, rest} = take_uleb(rest)
+
+    entry = %{name: name, kind: import_kind(kind), index: index}
+    parse_export_entries(rest, count - 1, [entry | acc])
+  end
+
+  # --- primitives ---
+  defp take_name(binary) do
+    {len, rest} = take_uleb(binary)
+    <<name::binary-size(len), tail::binary>> = rest
+    {name, tail}
+  end
+
+  defp take_uleb(binary), do: decode_uleb(binary, 0, 0)
+
+  defp decode_uleb(<<byte, rest::binary>>, acc, shift) do
+    value = acc ||| (byte &&& 0x7F) <<< shift
+
+    if (byte &&& 0x80) == 0 do
+      {value, rest}
+    else
+      decode_uleb(rest, value, shift + 7)
+    end
+  end
+end

--- a/test/wasm_packaging_test.exs
+++ b/test/wasm_packaging_test.exs
@@ -1,0 +1,72 @@
+defmodule WasmPackagingTest do
+  use Beaver
+  use Beaver.Case, async: true
+
+  alias Beaver.MLIR
+  alias Beaver.Wasm
+  alias MLIR.Dialect.{Func, Arith}
+  alias MLIR.Type
+  require Func
+
+  defp add_module(ctx) do
+    mlir ctx: ctx do
+      module do
+        Func.func add(
+                    function_type: Type.function([Type.i32(), Type.i32()], [Type.i32()]),
+                    sym_name: MLIR.Attribute.string("add")
+                  ) do
+          region do
+            block _(a >>> Type.i32(), b >>> Type.i32()) do
+              r = Arith.addi(a, b) >>> Type.i32()
+              Func.return(r) >>> []
+            end
+          end
+        end
+      end
+    end
+  end
+
+  test "packages a module into a wasm binary with exports manifest", %{ctx: ctx} do
+    binary = add_module(ctx) |> Wasm.package_binary!(entry: "add")
+
+    assert binary.bytes |> binary_part(0, 4) == <<0x00, 0x61, 0x73, 0x6D>>
+    assert binary.target == "wasm32-wasi"
+    assert Enum.any?(binary.exports, &(&1.name == "add" and &1.kind == :func))
+    assert binary.imports == []
+  end
+
+  test "parses the imports manifest (WASI imports without -nostdlib)", %{ctx: ctx} do
+    binary = add_module(ctx) |> Wasm.package_binary!(entry: "add", nostdlib: false)
+
+    assert Enum.any?(
+             binary.imports,
+             &(&1.module == "wasi_snapshot_preview1" and &1.kind == :func)
+           )
+  end
+
+  test "runs the packaged binary in node", %{ctx: ctx} do
+    binary = add_module(ctx) |> Wasm.package_binary!(entry: "add")
+
+    wasm_path =
+      Path.join(System.tmp_dir!(), "beaver_wasm_#{System.unique_integer([:positive])}.wasm")
+
+    File.write!(wasm_path, binary.bytes)
+
+    on_exit(fn -> File.rm(wasm_path) end)
+
+    {output, 0} =
+      System.cmd(
+        "node",
+        [
+          "-e",
+          """
+          const fs = require('fs');
+          const buf = fs.readFileSync(process.argv[1]);
+          WebAssembly.instantiate(buf, {}).then(r => console.log(r.instance.exports.add(2, 3)));
+          """,
+          wasm_path
+        ], stderr_to_stdout: true)
+
+    assert String.trim(output) == "5"
+  end
+end

--- a/test/wasm_packaging_test.exs
+++ b/test/wasm_packaging_test.exs
@@ -65,7 +65,9 @@ defmodule WasmPackagingTest do
           WebAssembly.instantiate(buf, {}).then(r => console.log(r.instance.exports.add(2, 3)));
           """,
           wasm_path
-        ], stderr_to_stdout: true)
+        ],
+        stderr_to_stdout: true
+      )
 
     assert String.trim(output) == "5"
   end


### PR DESCRIPTION
## Summary

Slice 2 of the batata WASM preparation (Forgejo #37): `Beaver.Wasm` packages an MLIR module into a wasm binary with a parsed imports/exports manifest.

- `Beaver.Wasm.package_binary!/2`: lowers the module to LLVM IR (`ex` conversion plan when ex ops are present, then arith/scf/cf-to-llvm), translates the LLVM-dialect output with `mlir-translate --mlir-to-llvmir`, compiles to `wasm32-wasi` with `zig cc` (`-nostdlib` by default, overridable), and returns a `Beaver.Wasm.Binary`.
- `Beaver.Wasm.Binary`: bytes + `imports`/`exports` manifest parsed from the wasm import/export sections (LEB128 + section walk; unknown sections skipped).
- Tests: exports manifest for a pure function (no imports), WASI imports manifest with `nostdlib: false` (`wasi_snapshot_preview1`), and running the packaged `add(2, 3)` in node (`5`).

The manifest is the host-boundary step: it names the WASI/import surface a runtime must provide, and the binary is ready for a `:wasm` Shadow Wavefront evaluator.

## Notes

- The pipeline does not run `llvm-request-c-wrappers` (the C-interface wrappers create undefined `_mlir_ciface_*` symbols that fail wasm linking for external declarations).
- `mlir-translate --mlir-to-llvmir` works on the LLVM-dialect output (the prebuilt's tool lacks the LLVMTranslationDialectInterface registration for func/arith, but translates llvm.* fine).

## Validation

- `mix compile --warnings-as-errors` ✓
- `mix test`: 376 passed (15 doctests, 361 tests), 5 skipped, 21 excluded ✓