### PR TITLE
Add semantic SCF region builders

### DIFF
--- a/lib/beaver/mlir/dialect/scf.ex
+++ b/lib/beaver/mlir/dialect/scf.ex
@@ -1,0 +1,130 @@
+defmodule Beaver.MLIR.Dialect.SCF do
+  @moduledoc """
+  Operations and semantic builders for the MLIR `scf` dialect.
+
+  The generated operation functions remain available. `if_/2` and `for_/5`
+  add a small Elixir-shaped layer that owns the mechanical region, block
+  argument, result, and `scf.yield` construction.
+  """
+
+  use Beaver.MLIR.Dialect,
+    dialect: "scf",
+    ops: Beaver.MLIR.Dialect.Registry.ops("scf")
+
+  @doc """
+  Build an `scf.if` with implicit regions and yields.
+
+  The value of each branch is yielded. Use `result_types: []` (the default)
+  for a statement-like if and end each branch with an expression returning
+  `nil` or `[]`.
+
+      require Beaver.MLIR.Dialect.SCF
+
+      SCF.if_(condition, result_types: [Type.i32()]) do
+        lhs
+      else
+        rhs
+      end
+
+  An else branch is required when the operation has results.
+  """
+  defmacro if_(condition, branches) do
+    build_if(condition, [], branches)
+  end
+
+  defmacro if_(condition, opts, branches) do
+    build_if(condition, opts, branches)
+  end
+
+  defp build_if(condition, opts, branches) do
+    then_body = Keyword.fetch!(branches, :do)
+    else_body = Keyword.get(branches, :else)
+    result_types = Keyword.get(opts, :result_types, [])
+
+    if else_body == nil and result_types != [] do
+      raise ArgumentError, "SCF.if_ requires an else branch when result_types is not empty"
+    end
+
+    regions =
+      [branch_region(then_body)] ++
+        if else_body == nil, do: [], else: [branch_region(else_body)]
+
+    quote do
+      Beaver.mlir do
+        Beaver.MLIR.Dialect.SCF.if unquote(condition) do
+          (unquote_splicing(regions))
+        end >>> unquote(result_types)
+      end
+    end
+  end
+
+  @doc """
+  Build an `scf.for` with implicit block arguments and yield.
+
+  The body is a two-argument function receiving the induction variable and a
+  list of loop-carried values. Its return value is passed to `scf.yield`.
+
+      require Beaver.MLIR.Dialect.SCF
+
+      SCF.for_(lower, upper, step, iter_args: [initial]) do
+        fn iv, [acc] -> Arith.addi(acc, iv) >>> Type.index() end
+      end
+
+  Result types default to the types of `iter_args`. Pass `result_types:` to
+  override them explicitly.
+  """
+  defmacro for_(lower, upper, step, opts, do: body) do
+    iter_args = Keyword.get(opts, :iter_args, [])
+
+    unless is_list(iter_args) do
+      raise ArgumentError, "SCF.for_/5 expects :iter_args to be a list"
+    end
+
+    iv = Macro.var(:scf_iv, nil)
+
+    carried =
+      for index <- 0..(length(iter_args) - 1)//1 do
+        Macro.var(:"scf_iter_#{index}", nil)
+      end
+
+    block_args =
+      [quote(do: unquote(iv) >>> Beaver.MLIR.Type.index())] ++
+        Enum.zip_with(carried, iter_args, fn variable, initial ->
+          quote do
+            unquote(variable) >>> Beaver.MLIR.Value.type(unquote(initial))
+          end
+        end)
+
+    block_call = {:_scf_for_body, [], block_args}
+    operands = [lower, upper, step] ++ iter_args
+
+    result_types =
+      Keyword.get_lazy(opts, :result_types, fn ->
+        Enum.map(iter_args, fn initial ->
+          quote(do: Beaver.MLIR.Value.type(unquote(initial)))
+        end)
+      end)
+
+    quote do
+      Beaver.mlir do
+        Beaver.MLIR.Dialect.SCF.for unquote(operands) do
+          region do
+            block unquote(block_call) do
+              Beaver.MLIR.Dialect.SCF.yield(unquote(body).(unquote(iv), unquote(carried))) >>> []
+            end
+          end
+        end >>> unquote(result_types)
+      end
+    end
+  end
+
+  defp branch_region(body) do
+    quote do
+      region do
+        block do
+          Beaver.MLIR.Dialect.SCF.yield(unquote(body)) >>> []
+        end
+      end
+    end
+  end
+end

--- a/test/scf_test.exs
+++ b/test/scf_test.exs
@@ -1,0 +1,84 @@
+defmodule SCFTest do
+  use Beaver.Case, async: true
+  use Beaver
+
+  alias Beaver.MLIR
+  alias Beaver.MLIR.{Attribute, Type}
+  alias Beaver.MLIR.Dialect.{Arith, Func, SCF}
+
+  require Func
+  require SCF
+
+  @moduletag :smoke
+
+  test "builds if regions and yields branch results", %{ctx: ctx} do
+    module =
+      mlir ctx: ctx do
+        module do
+          Func.func choose(function_type: Type.function([Type.i1()], [Type.i32()])) do
+            region do
+              block _entry(condition >>> Type.i1()) do
+                value =
+                  SCF.if_ condition, result_types: [Type.i32()] do
+                    Arith.constant(value: Attribute.integer(Type.i32(), 1)) >>> Type.i32()
+                  else
+                    Arith.constant(value: Attribute.integer(Type.i32(), 2)) >>> Type.i32()
+                  end
+
+                Func.return(value) >>> []
+              end
+            end
+          end
+        end
+      end
+
+    MLIR.verify!(module)
+    assert to_string(module) =~ "scf.if"
+    assert to_string(module) =~ "else"
+  end
+
+  test "builds for with loop-carried values", %{ctx: ctx} do
+    module =
+      mlir ctx: ctx do
+        module do
+          Func.func sum(function_type: Type.function([], [Type.index()])) do
+            region do
+              block do
+                lower = Arith.constant(value: Attribute.index(0)) >>> Type.index()
+                upper = Arith.constant(value: Attribute.index(4)) >>> Type.index()
+                step = Arith.constant(value: Attribute.index(1)) >>> Type.index()
+                initial = Arith.constant(value: Attribute.index(0)) >>> Type.index()
+
+                sum =
+                  SCF.for_ lower, upper, step, iter_args: [initial] do
+                    fn iv, [acc] -> Arith.addi(acc, iv) >>> Type.index() end
+                  end
+
+                Func.return(sum) >>> []
+              end
+            end
+          end
+        end
+      end
+
+    MLIR.verify!(module)
+    assert to_string(module) =~ "scf.for"
+    assert to_string(module) =~ "iter_args"
+  end
+
+  test "rejects a result-bearing if without else" do
+    assert_raise ArgumentError, ~r/requires an else branch/, fn ->
+      Code.compile_string("""
+      defmodule InvalidResultBearingSCFIf do
+        require Beaver.MLIR.Dialect.SCF
+
+        def build do
+          Beaver.MLIR.Dialect.SCF.if_ true, result_types: [:result] do
+            :value
+          end
+        end
+      end
+      """)
+    end
+  end
+end


### PR DESCRIPTION
## What changed

- add `SCF.if_` with implicit then/else regions and `scf.yield`
- add `SCF.for_` with induction/block arguments, loop-carried values, inferred result types, and implicit yield
- preserve generated raw SCF operation functions as the escape hatch
- add async verifier-backed tests for result-bearing if and loop-carried for

## Why

Beaver already generates raw operation wrappers. Issue [Forgejo #39](http://localhost:3000/tsai/beaver/issues/39) calls for a semantic layer that removes mechanical region and block plumbing without hiding MLIR semantics. This is PR 1 of that stack.

## Impact

Compiler authors can express common structured control flow in Elixir while still receiving ordinary MLIR values and operations.

## Validation

- `mix test test/scf_test.exs test/region_test.exs` (6 passed)
- `git diff --check`

## Stack

1. **SCF region DSL** (this PR)
2. DLTI target/layout API
3. LLVM ABI helpers
4. Bufferization pipeline
5. Linalg/Tensor/Vector structured-compute API