### PR TITLE
Add LLVM ABI types, symbols, and operation builders

### DIFF
--- a/lib/beaver/mlir/dialect/llvm.ex
+++ b/lib/beaver/mlir/dialect/llvm.ex
@@ -1,2 +1,208 @@
-require Beaver.MLIR.Dialect
-Beaver.MLIR.Dialect.define("llvm")
+defmodule Beaver.MLIR.Dialect.LLVM do
+  @moduledoc """
+  Operations and ABI-oriented builders for the MLIR LLVM dialect.
+
+  The raw generated operation functions remain available. These helpers cover
+  contextual LLVM types, enum attributes, symbols, and common function/global/
+  call shapes that otherwise require textual assembly details.
+  """
+
+  alias Beaver.MLIR
+
+  use Beaver.MLIR.Dialect,
+    dialect: "llvm",
+    ops: Beaver.MLIR.Dialect.Registry.ops("llvm")
+
+  @linkages ~w(external available_externally linkonce linkonce_odr weak weak_odr appending internal private extern_weak common)a
+
+  @calling_conventions %{
+    c: "ccc",
+    fast: "fastcc",
+    cold: "coldcc",
+    ghc: "cc_10",
+    hipe: "cc_11",
+    anyreg: "anyregcc",
+    preserve_most: "preserve_mostcc",
+    preserve_all: "preserve_allcc",
+    swift: "swiftcc",
+    tail: "tailcc",
+    ptx_kernel: "ptx_kernelcc",
+    ptx_device: "ptx_devicecc",
+    spir_func: "spir_funccc",
+    spir_kernel: "spir_kernelcc",
+    x86_64_sysv: "x86_64_sysvcc",
+    win64: "win64cc",
+    amdgpu_kernel: "amdgpu_kernelcc",
+    aarch64_vector: "aarch64_vectorcallcc",
+    aarch64_sve_vector: "aarch64_sve_vectorcallcc",
+    wasm_emscripten_invoke: "wasm_emscripten_invokecc"
+  }
+
+  @doc "Build an opaque LLVM pointer type for an address space."
+  def pointer, do: pointer(0, [])
+  def pointer(opts) when is_list(opts), do: pointer(0, opts)
+  def pointer(address_space) when is_integer(address_space), do: pointer(address_space, [])
+
+  def pointer(address_space, opts) when is_integer(address_space) and address_space >= 0 do
+    suffix = if address_space == 0, do: "", else: "<#{address_space}>"
+    MLIR.Type.get("!llvm.ptr#{suffix}", opts)
+  end
+
+  @doc "Build an LLVM array type."
+  def array(element_type, count, opts \\ []) when is_integer(count) and count >= 0 do
+    contextual_type(opts, fn ctx ->
+      element_type = render_type(element_type, ctx)
+      MLIR.Type.get("!llvm.array<#{count} x #{element_type}>", ctx: ctx)
+    end)
+  end
+
+  @doc "Build a literal LLVM struct type."
+  def struct(field_types, opts \\ []) when is_list(field_types) do
+    contextual_type(opts, fn ctx ->
+      fields = Enum.map_join(field_types, ", ", &render_type(&1, ctx))
+      packed = if Keyword.get(opts, :packed, false), do: "packed ", else: ""
+      MLIR.Type.get("!llvm.struct<#{packed}(#{fields})>", ctx: ctx)
+    end)
+  end
+
+  @doc """
+  Build an LLVM function type.
+
+  LLVM functions have zero or one result. Set `vararg: true` to append `...`
+  to the parameter list.
+  """
+  def function_type(params, results, opts \\ []) when is_list(params) and is_list(results) do
+    if length(results) > 1 do
+      raise ArgumentError, "LLVM function types support at most one result"
+    end
+
+    contextual_type(opts, fn ctx ->
+      params = Enum.map(params, &render_type(&1, ctx))
+      params = if Keyword.get(opts, :vararg, false), do: params ++ ["..."], else: params
+
+      result =
+        case results do
+          [] -> "void"
+          [type] -> render_type(type, ctx)
+        end
+
+      MLIR.Type.get("!llvm.func<#{result} (#{Enum.join(params, ", ")})>", ctx: ctx)
+    end)
+  end
+
+  @doc "Build a validated `#llvm.linkage` attribute."
+  def linkage(value, opts \\ []) when is_atom(value) do
+    unless value in @linkages do
+      raise ArgumentError, "unsupported LLVM linkage: #{inspect(value)}"
+    end
+
+    MLIR.Attribute.get("#llvm.linkage<#{value}>", opts)
+  end
+
+  @doc "Build a validated `#llvm.cconv` attribute for a common calling convention."
+  def calling_convention(value, opts \\ []) when is_atom(value) do
+    case @calling_conventions do
+      %{^value => spelling} -> MLIR.Attribute.get("#llvm.cconv<#{spelling}>", opts)
+      _ -> raise ArgumentError, "unsupported LLVM calling convention: #{inspect(value)}"
+    end
+  end
+
+  @doc """
+  Define an `llvm.func` using the same symbol macro shape as `Func.func`.
+  """
+  defmacro func(call, opts) do
+    quote do
+      require Beaver.MLIR.Dialect.Func
+
+      Beaver.MLIR.Dialect.Func.func_like(
+        unquote(call),
+        Beaver.MLIR.Dialect.LLVM.func(),
+        unquote(opts)
+      )
+    end
+  end
+
+  @doc """
+  Build an inline-initialized `llvm.mlir.global`.
+
+  Required options are `:sym_name` and `:type`. Optional options include
+  `:value`, `:constant`, `:linkage`, `:alignment`, and `:address_space`.
+  Linkage atoms are accepted directly.
+  """
+  def global(%Beaver.SSA{arguments: arguments, ctx: ctx} = ssa) do
+    opts = Keyword.new(arguments)
+    sym_name = Keyword.fetch!(opts, :sym_name)
+    type = opts |> Keyword.fetch!(:type) |> Beaver.Deferred.create(ctx)
+    address_space = Keyword.get(opts, :address_space, 0)
+
+    arguments = [
+      global_type: MLIR.Attribute.type(type),
+      sym_name: MLIR.Attribute.string(to_string(sym_name), ctx: ctx),
+      linkage: normalize_linkage(Keyword.get(opts, :linkage, :external), ctx),
+      addr_space: MLIR.Attribute.integer(MLIR.Type.i32(ctx: ctx), address_space)
+    ]
+
+    arguments =
+      arguments
+      |> maybe_attribute(:value, Keyword.get(opts, :value))
+      |> maybe_unit(:constant, Keyword.get(opts, :constant, false), ctx)
+      |> maybe_i64(:alignment, Keyword.get(opts, :alignment), ctx)
+      |> Kernel.++([fn -> [MLIR.CAPI.mlirRegionCreate()] end])
+
+    MLIR.Operation.eval_ssa(%Beaver.SSA{ssa | op: mlir_global(), arguments: arguments})
+  end
+
+  @doc """
+  Build a direct `llvm.call` from operands and a `callee:` symbol.
+
+      LLVM.call_(arg, callee: :identity) >>> Type.i32()
+  """
+  def call_(%Beaver.SSA{arguments: arguments, ctx: ctx} = ssa) do
+    {options, operands} = Enum.split_with(arguments, &match?({key, _} when is_atom(key), &1))
+    callee = options |> Keyword.fetch!(:callee) |> to_string()
+    options = Keyword.drop(options, [:callee])
+
+    arguments = [
+      {:callee_operands, operands},
+      {:op_bundle_operands, []},
+      {:callee, MLIR.Attribute.flat_symbol_ref(callee, ctx: ctx)},
+      {:operand_segment_sizes, :infer},
+      {:op_bundle_sizes, MLIR.Attribute.dense_array([], Beaver.Native.I32, ctx: ctx)}
+      | options
+    ]
+
+    MLIR.Operation.eval_ssa(%Beaver.SSA{
+      ssa
+      | op: call(),
+        arguments: arguments
+    })
+  end
+
+  defp contextual_type(opts, fun), do: Beaver.Deferred.from_opts(opts, fun)
+
+  defp render_type(type, ctx) do
+    type
+    |> Beaver.Deferred.create(ctx)
+    |> case do
+      %MLIR.Type{} = type -> to_string(type)
+      other -> raise ArgumentError, "expected an MLIR type, got: #{inspect(other)}"
+    end
+  end
+
+  defp normalize_linkage(%MLIR.Attribute{} = linkage, _ctx), do: linkage
+  defp normalize_linkage(linkage, ctx) when is_atom(linkage), do: linkage(linkage, ctx: ctx)
+
+  defp maybe_attribute(arguments, _name, nil), do: arguments
+  defp maybe_attribute(arguments, name, value), do: arguments ++ [{name, value}]
+
+  defp maybe_unit(arguments, _name, false, _ctx), do: arguments
+
+  defp maybe_unit(arguments, name, true, ctx),
+    do: arguments ++ [{name, MLIR.Attribute.unit(ctx: ctx)}]
+
+  defp maybe_i64(arguments, _name, nil, _ctx), do: arguments
+
+  defp maybe_i64(arguments, name, value, ctx) when is_integer(value) and value > 0 do
+    arguments ++ [{name, MLIR.Attribute.integer(MLIR.Type.i64(ctx: ctx), value)}]
+  end
+end

--- a/test/llvm_dialect_test.exs
+++ b/test/llvm_dialect_test.exs
@@ -1,0 +1,89 @@
+defmodule LLVMDialectTest do
+  use Beaver.Case, async: true
+  use Beaver
+
+  alias Beaver.MLIR
+  alias Beaver.MLIR.{Attribute, Type}
+  alias Beaver.MLIR.Dialect.LLVM
+
+  require LLVM
+
+  @moduletag :smoke
+
+  test "builds contextual LLVM ABI types", %{ctx: ctx} do
+    assert to_string(LLVM.pointer(ctx: ctx)) == "!llvm.ptr"
+    assert to_string(LLVM.pointer(3, ctx: ctx)) == "!llvm.ptr<3>"
+    assert to_string(LLVM.array(Type.i8(), 4, ctx: ctx)) == "!llvm.array<4 x i8>"
+
+    assert to_string(LLVM.struct([Type.i32(), Type.f64()], packed: true, ctx: ctx)) ==
+             "!llvm.struct<packed (i32, f64)>"
+
+    assert to_string(LLVM.function_type([Type.i32()], [Type.i32()], ctx: ctx)) ==
+             "!llvm.func<i32 (i32)>"
+
+    assert to_string(LLVM.function_type([Type.i32()], [], vararg: true, ctx: ctx)) ==
+             "!llvm.func<void (i32, ...)>"
+  end
+
+  test "builds validated ABI enum attributes", %{ctx: ctx} do
+    assert to_string(LLVM.linkage(:internal, ctx: ctx)) == "#llvm.linkage<internal>"
+    assert to_string(LLVM.calling_convention(:fast, ctx: ctx)) == "#llvm.cconv<fastcc>"
+
+    assert_raise ArgumentError, ~r/unsupported LLVM linkage/, fn ->
+      apply(LLVM, :linkage, [:local, [ctx: ctx]])
+    end
+  end
+
+  test "defines, calls, and verifies an LLVM function", %{ctx: ctx} do
+    module =
+      mlir ctx: ctx do
+        module do
+          LLVM.func identity(
+                      function_type: LLVM.function_type([Type.i32()], [Type.i32()]),
+                      linkage: LLVM.linkage(:internal),
+                      CConv: LLVM.calling_convention(:c)
+                    ) do
+            region do
+              block _entry(arg >>> Type.i32()) do
+                LLVM.return(arg) >>> []
+              end
+            end
+          end
+
+          LLVM.func caller(function_type: LLVM.function_type([], [Type.i32()])) do
+            region do
+              block do
+                value = LLVM.mlir_constant(value: Attribute.integer(Type.i32(), 7)) >>> Type.i32()
+                result = LLVM.call_(value, callee: :identity) >>> Type.i32()
+                LLVM.return(result) >>> []
+              end
+            end
+          end
+        end
+      end
+
+    MLIR.verify!(module)
+    assert to_string(module) =~ "llvm.func internal @identity"
+    assert to_string(module) =~ "llvm.call @identity"
+  end
+
+  test "builds an inline initialized global", %{ctx: ctx} do
+    module =
+      mlir ctx: ctx do
+        module do
+          LLVM.global(
+            sym_name: :answer,
+            type: Type.i32(),
+            value: Attribute.integer(Type.i32(), 42),
+            constant: true,
+            linkage: :internal,
+            alignment: 4
+          ) >>> []
+        end
+      end
+
+    MLIR.verify!(module)
+    assert to_string(module) =~ "llvm.mlir.global internal constant @answer"
+    assert to_string(module) =~ "alignment = 4"
+  end
+end


### PR DESCRIPTION
## What changed

- add LLVM pointer, array, literal struct, and function type builders
- add validated linkage and common calling-convention attributes
- add an `llvm.func` symbol macro compatible with Beaver's region DSL
- add direct-call construction with correct operand segments and op-bundle metadata
- add inline global construction with linkage, address space, constant, value, and alignment handling
- keep all generated raw LLVM operation functions available

## Why

This is PR 3 for [Forgejo #39](http://localhost:3000/tsai/beaver/issues/39). The useful LLVM wrapper boundary is ABI and symbol authoring; LLVM IR export itself remains in Forgejo #38.

## Impact

Authors can build verified LLVM ABI types and common module/function operations without hand-writing dialect assembly attributes or segment metadata.

## Validation

- `mix test test/scf_test.exs test/dlti_test.exs test/llvm_dialect_test.exs` (11 passed)
- parser-backed type and enum tests
- verifier-backed function, direct call, and global tests
- `git diff --check`

## Stack

1. #591 — SCF region DSL
2. #592 — DLTI target/layout API
3. **LLVM ABI helpers** (this PR)
4. Bufferization pipeline
5. Linalg/Tensor/Vector structured-compute API