### PR TITLE
Add structured One-Shot Bufferization pipelines

### DIFF
--- a/lib/beaver/mlir/dialect/bufferization.ex
+++ b/lib/beaver/mlir/dialect/bufferization.ex
@@ -1,0 +1,151 @@
+defmodule Beaver.MLIR.Dialect.Bufferization do
+  @moduledoc """
+  Operations and structured One-Shot Bufferization pipelines.
+
+  The pipeline helpers validate and render pass options, preserve diagnostics
+  through `Beaver.Composer`, and optionally append MLIR's ownership-based
+  deallocation pipeline.
+  """
+
+  use Beaver.MLIR.Dialect,
+    dialect: "bufferization",
+    ops: Beaver.MLIR.Dialect.Registry.ops("bufferization")
+
+  @boolean_options ~w(
+    allow_return_allocs_from_loops
+    allow_unknown_ops
+    bufferize_function_boundaries
+    check_parallel_regions
+    copy_before_write
+    must_infer_memory_space
+    use_encoding_for_memory_space
+  )a
+
+  @scalar_options ~w(analysis_heuristic buffer_alignment)a
+  @list_options ~w(dialect_filter no_analysis_func_filter)a
+  @layout_options ~w(function_boundary_type_conversion unknown_type_conversion)a
+  @control_options ~w(boundary_layout deallocate private_function_dynamic_ownership run)a
+  @supported_options @boolean_options ++
+                       @scalar_options ++ @list_options ++ @layout_options ++ @control_options
+
+  @layout_values %{
+    identity: "identity-layout-map",
+    fully_dynamic: "fully-dynamic-layout-map",
+    infer: "infer-layout-map"
+  }
+
+  @doc "Return a validated One-Shot Bufferize pass pipeline fragment."
+  def one_shot_pipeline(opts \\ []) when is_list(opts) do
+    validate_options!(opts)
+    opts = expand_boundary_layout(opts)
+
+    rendered =
+      opts
+      |> Keyword.take(@boolean_options ++ @scalar_options ++ @list_options ++ @layout_options)
+      |> Enum.map_join(" ", &render_option/1)
+
+    if rendered == "", do: "one-shot-bufferize", else: "one-shot-bufferize{#{rendered}}"
+  end
+
+  @doc "Return the complete bufferization pipeline as a `Beaver.Composer`."
+  def pipeline(operation_or_module, opts \\ []) do
+    composer = Beaver.Composer.append(operation_or_module, one_shot_pipeline(opts))
+
+    if Keyword.get(opts, :deallocate, false) do
+      deallocation =
+        if Keyword.get(opts, :private_function_dynamic_ownership, false) do
+          "buffer-deallocation-pipeline{private-function-dynamic-ownership=true}"
+        else
+          "buffer-deallocation-pipeline"
+        end
+
+      Beaver.Composer.append(composer, deallocation)
+    else
+      composer
+    end
+  end
+
+  @doc "Run One-Shot Bufferization and return diagnostics without raising."
+  def one_shot(operation_or_module, opts \\ []) do
+    operation_or_module
+    |> pipeline(opts)
+    |> Beaver.Composer.run(Keyword.get(opts, :run, []))
+  end
+
+  @doc "Run One-Shot Bufferization, raising with formatted MLIR diagnostics on failure."
+  def one_shot!(operation_or_module, opts \\ []) do
+    operation_or_module
+    |> pipeline(opts)
+    |> Beaver.Composer.run!(Keyword.get(opts, :run, []))
+  end
+
+  defp validate_options!(opts) do
+    unless Keyword.keyword?(opts) do
+      raise ArgumentError, "bufferization options must be a keyword list"
+    end
+
+    case Keyword.keys(opts) -- @supported_options do
+      [] ->
+        :ok
+
+      [unsupported | _] ->
+        raise ArgumentError, "unsupported bufferization option: #{inspect(unsupported)}"
+    end
+
+    Enum.each(
+      Keyword.take(opts, @boolean_options ++ [:deallocate, :private_function_dynamic_ownership]),
+      fn
+        {_name, value} when is_boolean(value) -> :ok
+        {name, value} -> raise ArgumentError, "#{name} must be a boolean, got: #{inspect(value)}"
+      end
+    )
+  end
+
+  defp expand_boundary_layout(opts) do
+    case Keyword.pop(opts, :boundary_layout) do
+      {nil, opts} ->
+        opts
+
+      {:identity, opts} ->
+        opts
+        |> Keyword.put_new(:unknown_type_conversion, :identity)
+        |> Keyword.put_new(:function_boundary_type_conversion, :identity)
+
+      {:fully_dynamic, opts} ->
+        opts
+        |> Keyword.put_new(:unknown_type_conversion, :fully_dynamic)
+        |> Keyword.put_new(:function_boundary_type_conversion, :fully_dynamic)
+
+      {:infer, opts} ->
+        Keyword.put_new(opts, :function_boundary_type_conversion, :infer)
+
+      {value, _opts} ->
+        raise ArgumentError, "unsupported boundary layout: #{inspect(value)}"
+    end
+  end
+
+  defp render_option({name, value}) when name in @boolean_options,
+    do: "#{pass_name(name)}=#{value}"
+
+  defp render_option({name, values}) when name in @list_options and is_list(values),
+    do: "#{pass_name(name)}=#{Enum.map_join(values, ",", &to_string/1)}"
+
+  defp render_option({name, value}) when name in @layout_options do
+    case @layout_values do
+      %{^value => spelling} -> "#{pass_name(name)}=#{spelling}"
+      _ -> raise ArgumentError, "unsupported #{name}: #{inspect(value)}"
+    end
+  end
+
+  defp render_option({:analysis_heuristic, value})
+       when value in [:bottom_up, :top_down, :bottom_up_from_terminators],
+       do: "analysis-heuristic=#{value |> to_string() |> String.replace("_", "-")}"
+
+  defp render_option({:buffer_alignment, value}) when is_integer(value) and value > 0,
+    do: "buffer-alignment=#{value}"
+
+  defp render_option({name, value}),
+    do: raise(ArgumentError, "invalid bufferization option #{name}: #{inspect(value)}")
+
+  defp pass_name(name), do: name |> to_string() |> String.replace("_", "-")
+end

--- a/test/bufferization_test.exs
+++ b/test/bufferization_test.exs
@@ -1,0 +1,62 @@
+defmodule BufferizationTest do
+  use Beaver.Case, async: true
+
+  alias Beaver.MLIR
+  alias Beaver.MLIR.Dialect.Bufferization
+
+  @moduletag :smoke
+
+  @tensor_module """
+  module {
+    func.func @main() -> f32 {
+      %tensor = bufferization.alloc_tensor() : tensor<4xf32>
+      %c0 = arith.constant 0 : index
+      %value = tensor.extract %tensor[%c0] : tensor<4xf32>
+      func.return %value : f32
+    }
+  }
+  """
+
+  test "renders structured One-Shot Bufferize options" do
+    pipeline =
+      Bufferization.one_shot_pipeline(
+        bufferize_function_boundaries: true,
+        boundary_layout: :identity,
+        allow_unknown_ops: true,
+        analysis_heuristic: :bottom_up_from_terminators
+      )
+
+    assert pipeline =~ "bufferize-function-boundaries=true"
+    assert pipeline =~ "unknown-type-conversion=identity-layout-map"
+    assert pipeline =~ "function-boundary-type-conversion=identity-layout-map"
+    assert pipeline =~ "analysis-heuristic=bottom-up-from-terminators"
+  end
+
+  test "runs bufferization and preserves structured diagnostics", %{ctx: ctx} do
+    module = MLIR.Module.create!(@tensor_module, ctx: ctx)
+
+    assert {:ok, ^module, diagnostics} = Bufferization.one_shot(module)
+    assert is_list(diagnostics)
+    MLIR.verify!(module)
+    assert to_string(module) =~ "memref.alloc"
+    refute to_string(module) =~ "bufferization.alloc_tensor"
+  end
+
+  test "optionally appends ownership-based deallocation", %{ctx: ctx} do
+    module = MLIR.Module.create!(@tensor_module, ctx: ctx)
+
+    assert ^module = Bufferization.one_shot!(module, deallocate: true)
+    MLIR.verify!(module)
+    assert to_string(module) =~ "memref.dealloc"
+  end
+
+  test "rejects unknown and invalid options" do
+    assert_raise ArgumentError, ~r/unsupported bufferization option/, fn ->
+      Bufferization.one_shot_pipeline(unknown: true)
+    end
+
+    assert_raise ArgumentError, ~r/allow_unknown_ops must be a boolean/, fn ->
+      Bufferization.one_shot_pipeline(allow_unknown_ops: :yes)
+    end
+  end
+end


### PR DESCRIPTION
## What changed

- add a validated One-Shot Bufferize pipeline builder
- map semantic boundary-layout choices to current MLIR pass options
- support function-boundary, unknown-op, analysis, dialect-filter, memory-space, and alignment configuration
- expose diagnostic-preserving and raising execution forms
- optionally append MLIR's ownership-based buffer deallocation pipeline
- reject unknown keys and invalid option types before pass parsing

## Why

This is PR 4 for [Forgejo #39](http://localhost:3000/tsai/beaver/issues/39). Tensor-based programs need a stable, structured path into native memory semantics; raw pass strings make configuration fragile and diagnostics harder to manage.

## Impact

Authors can run current One-Shot Bufferization and deallocation from structured Elixir options while retaining the ordinary Composer escape hatch.

## Validation

- `mix test test/scf_test.exs test/dlti_test.exs test/llvm_dialect_test.exs test/bufferization_test.exs` (15 passed)
- actual tensor allocation/extract → memref allocation/load transformation
- ownership-based deallocation insertion
- parser and verifier enabled
- `git diff --check`

## Stack

1. #591 — SCF region DSL
2. #592 — DLTI target/layout API
3. #594 — LLVM ABI helpers
4. **Bufferization pipeline** (this PR)
5. Linalg/Tensor/Vector structured-compute API