### PR TITLE
Add structured Linalg, Tensor, and Vector builders

### DIFF
--- a/lib/beaver/mlir/dialect/linalg.ex
+++ b/lib/beaver/mlir/dialect/linalg.ex
@@ -1,2 +1,152 @@
-require Beaver.MLIR.Dialect
-Beaver.MLIR.Dialect.define("linalg")
+defmodule Beaver.MLIR.Dialect.Linalg do
+  @moduledoc """
+  Operations and structured-compute builders for the MLIR Linalg dialect.
+  """
+
+  alias Beaver.MLIR
+  alias Beaver.MLIR.Dialect.Bufferization
+
+  use Beaver.MLIR.Dialect,
+    dialect: "linalg",
+    ops: Beaver.MLIR.Dialect.Registry.ops("linalg")
+
+  @doc """
+  Build a `linalg.generic` with structured inputs, outputs, maps, iterators,
+  scalar block arguments, and an implicit `linalg.yield`.
+
+  The body receives two lists: scalar input values and scalar output values.
+  Its return value is yielded.
+
+      Linalg.generic(
+        inputs: [lhs, rhs],
+        outputs: [init],
+        indexing_maps: [identity, identity, identity],
+        iterators: [:parallel]
+      ) do
+        fn [lhs, rhs], [_out] -> Arith.addf(lhs, rhs) >>> Type.f32() end
+      end
+  """
+  defmacro generic(opts, do: body) do
+    inputs = Keyword.fetch!(opts, :inputs)
+    outputs = Keyword.fetch!(opts, :outputs)
+    maps = Keyword.fetch!(opts, :indexing_maps)
+    iterators = Keyword.fetch!(opts, :iterators)
+
+    unless is_list(inputs) and is_list(outputs) and is_list(maps) and is_list(iterators) do
+      raise ArgumentError,
+            "linalg.generic inputs, outputs, indexing_maps, and iterators must be lists"
+    end
+
+    input_vars = scalar_vars(:linalg_input, length(inputs))
+    output_vars = scalar_vars(:linalg_output, length(outputs))
+
+    block_args =
+      Enum.zip_with(input_vars ++ output_vars, inputs ++ outputs, fn variable, shaped ->
+        quote do
+          unquote(variable) >>> Beaver.MLIR.Dialect.Linalg.block_argument_type(unquote(shaped))
+        end
+      end)
+
+    block_call = {:_linalg_body, [], block_args}
+
+    quote do
+      Beaver.mlir do
+        Beaver.MLIR.Dialect.Linalg.generic inputs: unquote(inputs),
+                                           outputs: unquote(outputs),
+                                           indexing_maps:
+                                             Beaver.MLIR.Dialect.Linalg.indexing_maps(
+                                               unquote(maps)
+                                             ),
+                                           iterator_types:
+                                             Beaver.MLIR.Dialect.Linalg.iterator_types(
+                                               unquote(iterators)
+                                             ),
+                                           operand_segment_sizes: :infer do
+          region do
+            block unquote(block_call) do
+              Beaver.MLIR.Dialect.Linalg.yield(
+                unquote(body).(unquote(input_vars), unquote(output_vars))
+              ) >>> []
+            end
+          end
+        end >>> Beaver.MLIR.Dialect.Linalg.result_types(unquote(outputs))
+      end
+    end
+  end
+
+  @doc "Build the array attribute used by `linalg.generic` indexing maps."
+  def indexing_maps(maps) when is_list(maps) do
+    fn ctx ->
+      maps
+      |> Enum.map(fn map ->
+        map |> Beaver.Deferred.create(ctx) |> MLIR.Attribute.affine_map()
+      end)
+      |> MLIR.Attribute.array(ctx: ctx)
+    end
+  end
+
+  @doc "Build and validate Linalg iterator types."
+  def iterator_types(iterators) when is_list(iterators) do
+    allowed = [:parallel, :reduction, :window]
+
+    case iterators -- allowed do
+      [] ->
+        :ok
+
+      [invalid | _] ->
+        raise ArgumentError, "unsupported Linalg iterator type: #{inspect(invalid)}"
+    end
+
+    fn ctx ->
+      iterators
+      |> Enum.map(&MLIR.Attribute.get("#linalg.iterator_type<#{&1}>", ctx: ctx))
+      |> MLIR.Attribute.array(ctx: ctx)
+    end
+  end
+
+  @doc false
+  def block_argument_type(value) do
+    type = MLIR.Value.type(value)
+    if MLIR.Type.shaped?(type), do: MLIR.ShapedType.element_type(type), else: type
+  end
+
+  @doc false
+  def result_types(outputs) do
+    outputs
+    |> Enum.map(&MLIR.Value.type/1)
+    |> Enum.filter(&MLIR.Type.tensor?/1)
+  end
+
+  @doc "Build a Linalg → Bufferization → LLVM lowering composer."
+  def llvm_pipeline(operation_or_module, opts \\ []) do
+    bufferization_opts =
+      opts
+      |> Keyword.get(:bufferization, [])
+      |> Keyword.put_new(:bufferize_function_boundaries, true)
+      |> Keyword.put_new(:boundary_layout, :identity)
+
+    operation_or_module
+    |> Bufferization.pipeline(bufferization_opts)
+    |> Beaver.Composer.append("convert-linalg-to-loops")
+    |> Beaver.Composer.append("canonicalize")
+    |> Beaver.Composer.append("lower-affine")
+    |> Beaver.Composer.append("convert-scf-to-cf")
+    |> Beaver.Composer.append("convert-index-to-llvm")
+    |> Beaver.Composer.append("convert-arith-to-llvm")
+    |> Beaver.Composer.append("finalize-memref-to-llvm")
+    |> Beaver.Composer.append("convert-func-to-llvm")
+    |> Beaver.Composer.append("convert-cf-to-llvm")
+    |> Beaver.Composer.append("reconcile-unrealized-casts")
+  end
+
+  @doc "Run the Linalg → Bufferization → LLVM lowering pipeline."
+  def lower_to_llvm!(operation_or_module, opts \\ []) do
+    operation_or_module
+    |> llvm_pipeline(opts)
+    |> Beaver.Composer.run!(Keyword.get(opts, :run, []))
+  end
+
+  defp scalar_vars(prefix, count) do
+    for index <- 0..(count - 1)//1, do: Macro.var(:"#{prefix}_#{index}", nil)
+  end
+end

--- a/lib/beaver/mlir/dialect/tensor.ex
+++ b/lib/beaver/mlir/dialect/tensor.ex
@@ -4,6 +4,11 @@ defmodule Beaver.MLIR.Dialect.Tensor do
   """
   alias Beaver.MLIR.{Attribute, Type}
 
+  defmodule Slice do
+    @moduledoc "Static/dynamic offsets, sizes, and strides for tensor slices."
+    defstruct [:offsets, :sizes, :strides]
+  end
+
   use Beaver.MLIR.Dialect,
     dialect: "tensor",
     ops: Beaver.MLIR.Dialect.Registry.ops("tensor")
@@ -19,5 +24,70 @@ defmodule Beaver.MLIR.Dialect.Tensor do
 
   def reassociation_for_reshape(src, target) do
     Beaver.MLIR.CAPI.beaverGetReassociationIndicesForReshape(src, target)
+  end
+
+  @doc "Build a validated mixed static/dynamic tensor slice specification."
+  def slice(offsets, sizes, strides)
+      when is_list(offsets) and is_list(sizes) and is_list(strides) do
+    rank = length(offsets)
+
+    unless length(sizes) == rank and length(strides) == rank do
+      raise ArgumentError, "tensor slice offsets, sizes, and strides must have equal lengths"
+    end
+
+    %Slice{offsets: offsets, sizes: sizes, strides: strides}
+  end
+
+  @doc "Build `tensor.extract_slice` from a mixed static/dynamic slice spec."
+  def extract_slice_(%Beaver.SSA{arguments: [source, %Slice{} = slice], ctx: ctx} = ssa) do
+    arguments = slice_arguments(slice, ctx)
+
+    Beaver.MLIR.Operation.eval_ssa(%Beaver.SSA{
+      ssa
+      | op: extract_slice(),
+        arguments: [{:source, source} | arguments] ++ [operand_segment_sizes: :infer]
+    })
+  end
+
+  @doc "Build `tensor.insert_slice` from a mixed static/dynamic slice spec."
+  def insert_slice_(%Beaver.SSA{arguments: [source, dest, %Slice{} = slice], ctx: ctx} = ssa) do
+    arguments = slice_arguments(slice, ctx)
+
+    Beaver.MLIR.Operation.eval_ssa(%Beaver.SSA{
+      ssa
+      | op: insert_slice(),
+        arguments:
+          [{:source, source}, {:dest, dest} | arguments] ++ [operand_segment_sizes: :infer]
+    })
+  end
+
+  defp slice_arguments(%Slice{} = slice, ctx) do
+    {offsets, static_offsets} = split_slice_entries(slice.offsets, :offset)
+    {sizes, static_sizes} = split_slice_entries(slice.sizes, :size)
+    {strides, static_strides} = split_slice_entries(slice.strides, :stride)
+
+    [
+      {:offsets, offsets},
+      {:sizes, sizes},
+      {:strides, strides},
+      {:static_offsets, Attribute.dense_array(static_offsets, Beaver.Native.I64, ctx: ctx)},
+      {:static_sizes, Attribute.dense_array(static_sizes, Beaver.Native.I64, ctx: ctx)},
+      {:static_strides, Attribute.dense_array(static_strides, Beaver.Native.I64, ctx: ctx)}
+    ]
+  end
+
+  defp split_slice_entries(entries, kind) do
+    Enum.reduce(entries, {[], []}, fn
+      value, {dynamic, static} when is_integer(value) ->
+        {dynamic, static ++ [value]}
+
+      %Beaver.MLIR.Value{} = value, {dynamic, static} ->
+        sentinel = Beaver.MLIR.ShapedType.to_dynamic_magic_number(:dynamic, kind)
+        {dynamic ++ [value], static ++ [sentinel]}
+
+      value, _acc ->
+        raise ArgumentError,
+              "tensor slice entries must be integers or index values, got: #{inspect(value)}"
+    end)
   end
 end

--- a/lib/beaver/mlir/dialect/vector.ex
+++ b/lib/beaver/mlir/dialect/vector.ex
@@ -1,2 +1,49 @@
-require Beaver.MLIR.Dialect
-Beaver.MLIR.Dialect.define("vector")
+defmodule Beaver.MLIR.Dialect.Vector do
+  @moduledoc "Operations and transfer helpers for the MLIR Vector dialect."
+
+  alias Beaver.MLIR
+
+  use Beaver.MLIR.Dialect,
+    dialect: "vector",
+    ops: Beaver.MLIR.Dialect.Registry.ops("vector")
+
+  @doc "Build the boolean array attribute used by vector transfer bounds."
+  def in_bounds(bounds, opts \\ []) when is_list(bounds) do
+    unless Enum.all?(bounds, &is_boolean/1) do
+      raise ArgumentError, "vector in_bounds entries must be booleans"
+    end
+
+    Beaver.Deferred.from_opts(opts, fn ctx ->
+      bounds
+      |> Enum.map(&MLIR.Attribute.bool(&1, ctx: ctx))
+      |> MLIR.Attribute.array(ctx: ctx)
+    end)
+  end
+
+  @doc """
+  Build a `vector.transfer_read` with named indices and transfer attributes.
+
+      Vector.transfer_read_(source, padding,
+        indices: [i], permutation_map: map, in_bounds: [true]
+      ) >>> vector_type
+  """
+  def transfer_read_(%Beaver.SSA{arguments: [base, padding | options], ctx: ctx} = ssa) do
+    options = Keyword.new(options)
+    indices = Keyword.get(options, :indices, [])
+    map = options |> Keyword.fetch!(:permutation_map) |> Beaver.Deferred.create(ctx)
+    bounds = Keyword.get(options, :in_bounds, [])
+    mask = Keyword.get(options, :mask)
+
+    arguments = [
+      {:base, base},
+      {:indices, indices},
+      {:padding, padding},
+      {:mask, List.wrap(mask)},
+      {:permutation_map, MLIR.Attribute.affine_map(map)},
+      {:in_bounds, in_bounds(bounds, ctx: ctx)},
+      {:operand_segment_sizes, :infer}
+    ]
+
+    MLIR.Operation.eval_ssa(%Beaver.SSA{ssa | op: transfer_read(), arguments: arguments})
+  end
+end

--- a/test/structured_compute_test.exs
+++ b/test/structured_compute_test.exs
@@ -1,0 +1,103 @@
+defmodule StructuredComputeTest do
+  use Beaver.Case, async: true
+  use Beaver
+
+  alias Beaver.MLIR
+  alias Beaver.MLIR.{AffineMap, Attribute, Type}
+  alias Beaver.MLIR.Dialect.{Arith, Func, Linalg, Tensor, Vector}
+
+  require Func
+  require Linalg
+
+  @moduletag :smoke
+
+  test "builds tensor slices from mixed static and dynamic entries", %{ctx: ctx} do
+    module =
+      mlir ctx: ctx do
+        module do
+          Func.func slice(function_type: Type.function([~t{tensor<8xf32>}], [~t{tensor<4xf32>}])) do
+            region do
+              block _entry(source >>> ~t{tensor<8xf32>}) do
+                result =
+                  Tensor.extract_slice_(source, Tensor.slice([2], [4], [1])) >>>
+                    ~t{tensor<4xf32>}
+
+                Func.return(result) >>> []
+              end
+            end
+          end
+        end
+      end
+
+    MLIR.verify!(module)
+    assert to_string(module) =~ "tensor.extract_slice %arg0[2] [4] [1]"
+  end
+
+  test "builds vector transfer reads with structured attributes", %{ctx: ctx} do
+    map = AffineMap.create(1, 0, [AffineMap.dim(0)])
+
+    module =
+      mlir ctx: ctx do
+        module do
+          Func.func read(function_type: Type.function([~t{memref<8xf32>}], [])) do
+            region do
+              block _entry(source >>> ~t{memref<8xf32>}) do
+                index = Arith.constant(value: Attribute.index(0)) >>> Type.index()
+                padding = Arith.constant(value: Attribute.float(Type.f32(), 0.0)) >>> Type.f32()
+
+                _vector =
+                  Vector.transfer_read_(source, padding,
+                    indices: [index],
+                    permutation_map: map,
+                    in_bounds: [true]
+                  ) >>> ~t{vector<4xf32>}
+
+                Func.return() >>> []
+              end
+            end
+          end
+        end
+      end
+
+    MLIR.verify!(module)
+    assert to_string(module) =~ "vector.transfer_read"
+    assert to_string(module) =~ "in_bounds = [true]"
+  end
+
+  test "builds linalg.generic and lowers it through bufferization to LLVM", %{ctx: ctx} do
+    tensor_type = ~t{tensor<4xf32>}
+    identity = AffineMap.create(1, 0, [AffineMap.dim(0)])
+
+    module =
+      mlir ctx: ctx do
+        module do
+          Func.func add(function_type: Type.function([tensor_type, tensor_type], [tensor_type])) do
+            region do
+              block _entry(lhs >>> tensor_type, rhs >>> tensor_type) do
+                init = Tensor.empty() >>> tensor_type
+
+                result =
+                  Linalg.generic inputs: [lhs, rhs],
+                                 outputs: [init],
+                                 indexing_maps: [identity, identity, identity],
+                                 iterators: [:parallel] do
+                    fn [left, right], [_out] -> Arith.addf(left, right) >>> Type.f32() end
+                  end
+
+                Func.return(result) >>> []
+              end
+            end
+          end
+        end
+      end
+
+    MLIR.verify!(module)
+    assert to_string(module) =~ "linalg.generic"
+
+    assert ^module = Linalg.lower_to_llvm!(module)
+    MLIR.verify!(module)
+    assert to_string(module) =~ "llvm.func @add"
+    refute to_string(module) =~ "linalg.generic"
+    refute to_string(module) =~ "tensor.empty"
+  end
+end


### PR DESCRIPTION
## What changed

- add `Linalg.generic` with structured inputs/outputs, indexing maps, iterator enums, scalar block arguments, inferred tensor results, and implicit yield
- add a Linalg → One-Shot Bufferization → loop/CF/memref → LLVM pipeline
- add mixed static/dynamic Tensor slice specs plus extract/insert builders
- add Vector `in_bounds` and structured transfer-read construction
- retain all generated raw operations as escape hatches
- add verifier-backed and end-to-end lowering tests

## Why

This is PR 5 and the final implementation layer for [Forgejo #39](http://localhost:3000/tsai/beaver/issues/39). Linalg, Tensor, Vector, and Bufferization are most valuable as one composable structured-compute path rather than unrelated thin wrappers.

## Impact

Authors can construct elementwise structured computations, tensor slices, and vector transfers from Elixir data, then lower a tensor-signature `linalg.generic` function all the way to LLVM dialect IR.

## Validation

- focused stack tests: 18 passed
- full default suite: 391 passed, 5 skipped, 21 excluded
- end-to-end `linalg.generic` → bufferization → `llvm.func`
- tensor slice and vector transfer verifier tests
- `mix format --check-formatted`
- `git diff --check`

## Stack

1. #591 — SCF region DSL
2. #592 — DLTI target/layout API
3. #594 — LLVM ABI helpers
4. #595 — Bufferization pipeline
5. **Linalg/Tensor/Vector structured-compute API** (this PR)