### PR TITLE
ex: spawn and scheduler continuation ops for the preemptive process table

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -85,6 +85,19 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.send", &convert_send/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.receive", &convert_receive/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.mailbox_clear", &convert_mailbox_clear/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.spawn", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.process_table_reset", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.cont_save", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.cont_pending", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.cont_clear", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.cont_load_arg", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.cont_load_acc", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.cont_load_cursor", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.schedule_next", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.current_entry", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.process_done", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.processes_runnable", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.process_result", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.to_int", &convert_to_int/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.reduction_tick", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.clock_init", &convert_term_read/3, version: "1.0")
@@ -156,6 +169,19 @@ defmodule Beaver.MLIR.Conversion.Ex do
     send: "ex.term.send",
     receive: "ex.term.receive",
     mailbox_clear: "ex.term.mailbox_clear",
+    spawn: "ex.term.spawn",
+    process_table_reset: "ex.term.process_table_reset",
+    cont_save: "ex.term.cont_save",
+    cont_pending: "ex.term.cont_pending",
+    cont_clear: "ex.term.cont_clear",
+    cont_load_arg: "ex.term.cont_load_arg",
+    cont_load_acc: "ex.term.cont_load_acc",
+    cont_load_cursor: "ex.term.cont_load_cursor",
+    schedule_next: "ex.term.schedule_next",
+    current_entry: "ex.term.current_entry",
+    process_done: "ex.term.process_done",
+    processes_runnable: "ex.term.processes_runnable",
+    process_result: "ex.term.process_result",
     to_int: "ex.term.to_int",
     reduction_tick: "ex.term.clock_tick",
     clock_init: "ex.term.clock_init",
@@ -842,6 +868,19 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.reduction_tick"), do: @term_intrinsics.reduction_tick
   defp read_intrinsic("ex.clock_init"), do: @term_intrinsics.clock_init
   defp read_intrinsic("ex.yield_mark"), do: @term_intrinsics.yield_mark
+  defp read_intrinsic("ex.spawn"), do: @term_intrinsics.spawn
+  defp read_intrinsic("ex.process_table_reset"), do: @term_intrinsics.process_table_reset
+  defp read_intrinsic("ex.cont_save"), do: @term_intrinsics.cont_save
+  defp read_intrinsic("ex.cont_pending"), do: @term_intrinsics.cont_pending
+  defp read_intrinsic("ex.cont_clear"), do: @term_intrinsics.cont_clear
+  defp read_intrinsic("ex.cont_load_arg"), do: @term_intrinsics.cont_load_arg
+  defp read_intrinsic("ex.cont_load_acc"), do: @term_intrinsics.cont_load_acc
+  defp read_intrinsic("ex.cont_load_cursor"), do: @term_intrinsics.cont_load_cursor
+  defp read_intrinsic("ex.schedule_next"), do: @term_intrinsics.schedule_next
+  defp read_intrinsic("ex.current_entry"), do: @term_intrinsics.current_entry
+  defp read_intrinsic("ex.process_done"), do: @term_intrinsics.process_done
+  defp read_intrinsic("ex.processes_runnable"), do: @term_intrinsics.processes_runnable
+  defp read_intrinsic("ex.process_result"), do: @term_intrinsics.process_result
   defp read_intrinsic("ex.binary_length"), do: @term_intrinsics.binary_length
   defp read_intrinsic("ex.binary_get"), do: @term_intrinsics.binary_get
   defp read_intrinsic("ex.binary_slice"), do: @term_intrinsics.binary_slice
@@ -1027,6 +1066,58 @@ defmodule Beaver.MLIR.Conversion.Ex do
 
   defp intrinsic_function_type("ex.term.mailbox_clear", _ctx) do
     MLIR.Type.function([], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.spawn", _ctx) do
+    MLIR.Type.function([MLIR.Type.i64()], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.process_table_reset", _ctx) do
+    MLIR.Type.function([], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.cont_save", _ctx) do
+    MLIR.Type.function(List.duplicate(MLIR.Type.i64(), 3), [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.cont_pending", _ctx) do
+    MLIR.Type.function([], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.cont_clear", _ctx) do
+    MLIR.Type.function([], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.cont_load_arg", _ctx) do
+    MLIR.Type.function([], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.cont_load_acc", _ctx) do
+    MLIR.Type.function([], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.cont_load_cursor", _ctx) do
+    MLIR.Type.function([], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.schedule_next", _ctx) do
+    MLIR.Type.function([], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.current_entry", _ctx) do
+    MLIR.Type.function([], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.process_done", _ctx) do
+    MLIR.Type.function([MLIR.Type.i64()], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.processes_runnable", _ctx) do
+    MLIR.Type.function([], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.process_result", _ctx) do
+    MLIR.Type.function([MLIR.Type.i64()], [MLIR.Type.i64()])
   end
 
   defp intrinsic_function_type("ex.term.jmp_buf_size", _ctx) do

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -141,6 +141,58 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop mailbox_clear(),
     results: [result: base(dyn())]
 
+  # Actor process spawn: registers a closure word as a new process entry and
+  # returns its pid. The scheduler driver executes spawned entries.
+  defop spawn(fun = optional(base(dyn()))),
+    results: [result: base(dyn())]
+
+  # Resets the runtime process table to a single fresh initial process; the
+  # scheduler driver calls this at program start.
+  defop process_table_reset(),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
+  # Preemptive scheduler continuation primitives (#35 slice 5): a budgeted
+  # cursor loop saves its (arg, acc, cursor) state before yielding; the
+  # scheduler driver round-robins runnable processes and resumes the saved
+  # continuation. A message arrival bumps the recipient's epoch, so a stale
+  # continuation reads as not pending (restart from the top).
+  defop cont_save(
+          arg = all_of([base("!builtin.integer"), any()]),
+          acc = all_of([base("!builtin.integer"), any()]),
+          cursor = all_of([base("!builtin.integer"), any()])
+        ),
+        results: [result: all_of([base("!builtin.integer"), any()])]
+
+  defop cont_pending(),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
+  defop cont_clear(),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
+  defop cont_load_arg(),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
+  defop cont_load_acc(),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
+  defop cont_load_cursor(),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
+  defop schedule_next(),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
+  defop current_entry(),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
+  defop process_done(result = all_of([base("!builtin.integer"), any()])),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
+  defop processes_runnable(),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
+  defop process_result(pid = base(dyn())),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
   # Untags an integer term word to its scalar value (a passthrough for
   # values that are already scalar).
   defop to_int(word = base(dyn())),

--- a/lib/beaver/mlir/dialect/scf.ex
+++ b/lib/beaver/mlir/dialect/scf.ex
@@ -1,0 +1,130 @@
+defmodule Beaver.MLIR.Dialect.SCF do
+  @moduledoc """
+  Operations and semantic builders for the MLIR `scf` dialect.
+
+  The generated operation functions remain available. `if_/2` and `for_/5`
+  add a small Elixir-shaped layer that owns the mechanical region, block
+  argument, result, and `scf.yield` construction.
+  """
+
+  use Beaver.MLIR.Dialect,
+    dialect: "scf",
+    ops: Beaver.MLIR.Dialect.Registry.ops("scf")
+
+  @doc """
+  Build an `scf.if` with implicit regions and yields.
+
+  The value of each branch is yielded. Use `result_types: []` (the default)
+  for a statement-like if and end each branch with an expression returning
+  `nil` or `[]`.
+
+      require Beaver.MLIR.Dialect.SCF
+
+      SCF.if_(condition, result_types: [Type.i32()]) do
+        lhs
+      else
+        rhs
+      end
+
+  An else branch is required when the operation has results.
+  """
+  defmacro if_(condition, branches) do
+    build_if(condition, [], branches)
+  end
+
+  defmacro if_(condition, opts, branches) do
+    build_if(condition, opts, branches)
+  end
+
+  defp build_if(condition, opts, branches) do
+    then_body = Keyword.fetch!(branches, :do)
+    else_body = Keyword.get(branches, :else)
+    result_types = Keyword.get(opts, :result_types, [])
+
+    if else_body == nil and result_types != [] do
+      raise ArgumentError, "SCF.if_ requires an else branch when result_types is not empty"
+    end
+
+    regions =
+      [branch_region(then_body)] ++
+        if else_body == nil, do: [], else: [branch_region(else_body)]
+
+    quote do
+      Beaver.mlir do
+        Beaver.MLIR.Dialect.SCF.if unquote(condition) do
+          (unquote_splicing(regions))
+        end >>> unquote(result_types)
+      end
+    end
+  end
+
+  @doc """
+  Build an `scf.for` with implicit block arguments and yield.
+
+  The body is a two-argument function receiving the induction variable and a
+  list of loop-carried values. Its return value is passed to `scf.yield`.
+
+      require Beaver.MLIR.Dialect.SCF
+
+      SCF.for_(lower, upper, step, iter_args: [initial]) do
+        fn iv, [acc] -> Arith.addi(acc, iv) >>> Type.index() end
+      end
+
+  Result types default to the types of `iter_args`. Pass `result_types:` to
+  override them explicitly.
+  """
+  defmacro for_(lower, upper, step, opts, do: body) do
+    iter_args = Keyword.get(opts, :iter_args, [])
+
+    unless is_list(iter_args) do
+      raise ArgumentError, "SCF.for_/5 expects :iter_args to be a list"
+    end
+
+    iv = Macro.var(:scf_iv, nil)
+
+    carried =
+      for index <- 0..(length(iter_args) - 1)//1 do
+        Macro.var(:"scf_iter_#{index}", nil)
+      end
+
+    block_args =
+      [quote(do: unquote(iv) >>> Beaver.MLIR.Type.index())] ++
+        Enum.zip_with(carried, iter_args, fn variable, initial ->
+          quote do
+            unquote(variable) >>> Beaver.MLIR.Value.type(unquote(initial))
+          end
+        end)
+
+    block_call = {:_scf_for_body, [], block_args}
+    operands = [lower, upper, step] ++ iter_args
+
+    result_types =
+      Keyword.get_lazy(opts, :result_types, fn ->
+        Enum.map(iter_args, fn initial ->
+          quote(do: Beaver.MLIR.Value.type(unquote(initial)))
+        end)
+      end)
+
+    quote do
+      Beaver.mlir do
+        Beaver.MLIR.Dialect.SCF.for unquote(operands) do
+          region do
+            block unquote(block_call) do
+              Beaver.MLIR.Dialect.SCF.yield(unquote(body).(unquote(iv), unquote(carried))) >>> []
+            end
+          end
+        end >>> unquote(result_types)
+      end
+    end
+  end
+
+  defp branch_region(body) do
+    quote do
+      region do
+        block do
+          Beaver.MLIR.Dialect.SCF.yield(unquote(body)) >>> []
+        end
+      end
+    end
+  end
+end

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -678,6 +678,55 @@ defmodule ExConversionTest do
     assert rendered =~ "ex.term.binary_utf8_get"
   end
 
+  test "converts spawn and scheduler continuation ops to Zig runtime ABI calls", %{ctx: ctx} do
+    module =
+      term_module!(
+        ~S"""
+        module {
+          "ex.func"() ({
+          ^bb0:
+            %0 = "ex.lit"() {value = 0 : i64} : () -> i64
+            %1 = "ex.lit"() {value = 1 : i64} : () -> i64
+            %2 = "ex.lit"() {value = 2 : i64} : () -> i64
+            %3 = "ex.box"(%0) : (i64) -> !ex.dyn
+            %4 = "ex.spawn"(%3) : (!ex.dyn) -> !ex.dyn
+            %5 = "ex.process_table_reset"() : () -> i64
+            %6 = "ex.cont_save"(%1, %2, %0) : (i64, i64, i64) -> i64
+            %7 = "ex.cont_pending"() : () -> i64
+            %8 = "ex.cont_clear"() : () -> i64
+            %9 = "ex.cont_load_arg"() : () -> i64
+            %10 = "ex.cont_load_acc"() : () -> i64
+            %11 = "ex.cont_load_cursor"() : () -> i64
+            %12 = "ex.schedule_next"() : () -> i64
+            %13 = "ex.current_entry"() : () -> i64
+            %14 = "ex.process_done"(%0) : (i64) -> i64
+            %15 = "ex.processes_runnable"() : () -> i64
+            %16 = "ex.process_result"(%4) : (!ex.dyn) -> i64
+            "ex.return"(%15) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+          }) {sym_name = "main"} : () -> ()
+        }
+        """,
+        ctx
+      )
+
+    assert {:ok, _module, []} = Plan.run(Ex.plan(), module)
+
+    rendered = MLIR.to_string(module, generic: true)
+    assert rendered =~ "ex.term.spawn"
+    assert rendered =~ "ex.term.process_table_reset"
+    assert rendered =~ "ex.term.cont_save"
+    assert rendered =~ "ex.term.cont_pending"
+    assert rendered =~ "ex.term.cont_clear"
+    assert rendered =~ "ex.term.cont_load_arg"
+    assert rendered =~ "ex.term.cont_load_acc"
+    assert rendered =~ "ex.term.cont_load_cursor"
+    assert rendered =~ "ex.term.schedule_next"
+    assert rendered =~ "ex.term.current_entry"
+    assert rendered =~ "ex.term.process_done"
+    assert rendered =~ "ex.term.processes_runnable"
+    assert rendered =~ "ex.term.process_result"
+  end
+
   test "passes nested term operands through without re-tagging", %{ctx: ctx} do
     module =
       term_module!(

--- a/test/scf_test.exs
+++ b/test/scf_test.exs
@@ -1,0 +1,84 @@
+defmodule SCFTest do
+  use Beaver.Case, async: true
+  use Beaver
+
+  alias Beaver.MLIR
+  alias Beaver.MLIR.{Attribute, Type}
+  alias Beaver.MLIR.Dialect.{Arith, Func, SCF}
+
+  require Func
+  require SCF
+
+  @moduletag :smoke
+
+  test "builds if regions and yields branch results", %{ctx: ctx} do
+    module =
+      mlir ctx: ctx do
+        module do
+          Func.func choose(function_type: Type.function([Type.i1()], [Type.i32()])) do
+            region do
+              block _entry(condition >>> Type.i1()) do
+                value =
+                  SCF.if_ condition, result_types: [Type.i32()] do
+                    Arith.constant(value: Attribute.integer(Type.i32(), 1)) >>> Type.i32()
+                  else
+                    Arith.constant(value: Attribute.integer(Type.i32(), 2)) >>> Type.i32()
+                  end
+
+                Func.return(value) >>> []
+              end
+            end
+          end
+        end
+      end
+
+    MLIR.verify!(module)
+    assert to_string(module) =~ "scf.if"
+    assert to_string(module) =~ "else"
+  end
+
+  test "builds for with loop-carried values", %{ctx: ctx} do
+    module =
+      mlir ctx: ctx do
+        module do
+          Func.func sum(function_type: Type.function([], [Type.index()])) do
+            region do
+              block do
+                lower = Arith.constant(value: Attribute.index(0)) >>> Type.index()
+                upper = Arith.constant(value: Attribute.index(4)) >>> Type.index()
+                step = Arith.constant(value: Attribute.index(1)) >>> Type.index()
+                initial = Arith.constant(value: Attribute.index(0)) >>> Type.index()
+
+                sum =
+                  SCF.for_ lower, upper, step, iter_args: [initial] do
+                    fn iv, [acc] -> Arith.addi(acc, iv) >>> Type.index() end
+                  end
+
+                Func.return(sum) >>> []
+              end
+            end
+          end
+        end
+      end
+
+    MLIR.verify!(module)
+    assert to_string(module) =~ "scf.for"
+    assert to_string(module) =~ "iter_args"
+  end
+
+  test "rejects a result-bearing if without else" do
+    assert_raise ArgumentError, ~r/requires an else branch/, fn ->
+      Code.compile_string("""
+      defmodule InvalidResultBearingSCFIf do
+        require Beaver.MLIR.Dialect.SCF
+
+        def build do
+          Beaver.MLIR.Dialect.SCF.if_ true, result_types: [:result] do
+            :value
+          end
+        end
+      end
+      """)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Slice 5 of tsai/beaver#35 (true multiprocess scheduling): term intrinsics for the preemptive process table and the scheduler driver.

- `ex.spawn`: register a closure word as a new process entry (→ `ex.term.spawn`)
- `ex.process_table_reset`: fresh actor table per program run
- `ex.cont_save` / `cont_pending` / `cont_clear` / `cont_load_arg/acc/cursor`: cursor-loop continuation save/restore per process
- `ex.schedule_next` / `current_entry` / `process_done` / `processes_runnable` / `process_result`: round-robin scheduler driver primitives
- all ops are defops + conversion patterns to the Zig term runtime ABI

## Tests

ex_conversion_test: spawn + scheduler continuation ops lower to `ex.term.*` calls (24 → 25 passed); full beaver suite 377 passed.