### PR TITLE
Add safe LLVM IR text export

### DIFF
--- a/lib/beaver/mlir/capi_handwritten.ex
+++ b/lib/beaver/mlir/capi_handwritten.ex
@@ -28,6 +28,7 @@ defmodule Beaver.MLIR.CAPI.Handwritten do
     beaver_raw_external_interface_release: 1,
     beaver_raw_module_create_parse_async: 3,
     beaver_raw_operation_verify_async: 2,
+    beaver_raw_translate_module_to_llvm_ir: 1,
     beaver_raw_transform_state_payload_ops: 2,
     beaver_raw_transform_state_payload_values: 2,
     beaver_raw_transform_state_params: 2,

--- a/lib/beaver/mlir/target/llvmir.ex
+++ b/lib/beaver/mlir/target/llvmir.ex
@@ -1,0 +1,38 @@
+defmodule Beaver.MLIR.Target.LLVMIR do
+  @moduledoc """
+  Safe export of fully lowered MLIR modules to textual LLVM IR.
+
+  The native adapter owns and releases the temporary LLVM context, module and
+  printed message. LLVM opaque handles never cross the NIF boundary.
+  """
+
+  alias Beaver.MLIR
+
+  @spec translate(MLIR.Module.t()) :: {:ok, binary()} | {:error, MLIR.diagnostics()}
+  def translate(%MLIR.Module{} = module) do
+    module
+    |> MLIR.context()
+    |> MLIR.Context.register_translations()
+
+    module
+    |> MLIR.Operation.from_module()
+    |> then(&MLIR.CAPI.beaver_raw_translate_module_to_llvm_ir(&1.ref))
+    |> Beaver.Native.check!()
+    |> case do
+      {llvm_ir, _diagnostics} when is_binary(llvm_ir) -> {:ok, llvm_ir}
+      {:error, diagnostics} when is_list(diagnostics) -> {:error, diagnostics}
+    end
+  end
+
+  @spec translate!(MLIR.Module.t()) :: binary()
+  def translate!(%MLIR.Module{} = module) do
+    case translate(module) do
+      {:ok, llvm_ir} ->
+        llvm_ir
+
+      {:error, diagnostics} ->
+        raise ArgumentError,
+              MLIR.Diagnostic.format(diagnostics, "failed to translate module to LLVM IR")
+    end
+  end
+end

--- a/lib/beaver/native.ex
+++ b/lib/beaver/native.ex
@@ -87,6 +87,9 @@ defmodule Beaver.Native do
            UndefinedFunctionError -> ref
          end, Enum.map(diagnostics, &postprocess_diagnostics/1)}
 
+      {value, diagnostics} when is_list(diagnostics) ->
+        {normalize(value), Enum.map(diagnostics, &postprocess_diagnostics/1)}
+
       ret ->
         ret
     end

--- a/native/include/mlir-c/Beaver/CAPIPolicy.h
+++ b/native/include/mlir-c/Beaver/CAPIPolicy.h
@@ -20,6 +20,7 @@ typedef enum {
   BeaverCapiPolicyManualAdapter__mlirTransformStateForEachParam,
   BeaverCapiPolicyManualAdapter__mlirTransformStateForEachPayloadOp,
   BeaverCapiPolicyManualAdapter__mlirTransformStateForEachPayloadValue,
+  BeaverCapiPolicyManualAdapter__beaverTranslateModuleToLLVMIRText,
 
   BeaverCapiPolicyManualRuntime__mlirValueReplaceUsesWithIf,
 

--- a/native/include/mlir-c/Beaver/LLVMIR.h
+++ b/native/include/mlir-c/Beaver/LLVMIR.h
@@ -1,0 +1,21 @@
+#ifndef MLIR_C_BEAVER_LLVM_IR_H
+#define MLIR_C_BEAVER_LLVM_IR_H
+
+#include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Translates an MLIR module to LLVM IR and streams its textual form to the
+/// callback. All LLVM objects and the printed message are owned and released
+/// by this call. Failure is reported without invoking the callback.
+MLIR_CAPI_EXPORTED MlirLogicalResult beaverTranslateModuleToLLVMIRText(
+    MlirOperation module, MlirStringCallback callback, void *userData);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MLIR_C_BEAVER_LLVM_IR_H

--- a/native/include/mlir/CAPI/Beaver.h
+++ b/native/include/mlir/CAPI/Beaver.h
@@ -3,6 +3,7 @@
 
 #include "mlir-c/Beaver/Context.h"
 #include "mlir-c/Beaver/Debug.h"
+#include "mlir-c/Beaver/LLVMIR.h"
 #include "mlir-c/Beaver/Op.h"
 #include "mlir-c/Beaver/Pass.h"
 #include "mlir/CAPI/Wrap.h"

--- a/native/lib/CAPI/BeaverLLVMIR.cpp
+++ b/native/lib/CAPI/BeaverLLVMIR.cpp
@@ -1,0 +1,35 @@
+#include "mlir-c/Beaver/LLVMIR.h"
+
+#include "llvm-c/Core.h"
+#include "mlir-c/Target/LLVMIR.h"
+
+#include <cstring>
+
+MlirLogicalResult beaverTranslateModuleToLLVMIRText(
+    MlirOperation module, MlirStringCallback callback, void *userData) {
+  if (!module.ptr || !callback)
+    return mlirLogicalResultFailure();
+
+  LLVMContextRef llvmContext = LLVMContextCreate();
+  if (!llvmContext)
+    return mlirLogicalResultFailure();
+
+  LLVMModuleRef llvmModule = mlirTranslateModuleToLLVMIR(module, llvmContext);
+  if (!llvmModule) {
+    LLVMContextDispose(llvmContext);
+    return mlirLogicalResultFailure();
+  }
+
+  char *message = LLVMPrintModuleToString(llvmModule);
+  if (!message) {
+    LLVMDisposeModule(llvmModule);
+    LLVMContextDispose(llvmContext);
+    return mlirLogicalResultFailure();
+  }
+
+  callback(mlirStringRefCreate(message, std::strlen(message)), userData);
+  LLVMDisposeMessage(message);
+  LLVMDisposeModule(llvmModule);
+  LLVMContextDispose(llvmContext);
+  return mlirLogicalResultSuccess();
+}

--- a/native/lib/CAPI/CMakeLists.txt
+++ b/native/lib/CAPI/CMakeLists.txt
@@ -9,6 +9,7 @@ add_mlir_public_c_api_library(
   BeaverIRDL.cpp
   BeaverDebug.cpp
   BeaverGPU.cpp
+  BeaverLLVMIR.cpp
   BeaverActionTracing.cpp
   Triton.cpp
   LINK_LIBS

--- a/native/src/core.zig
+++ b/native/src/core.zig
@@ -16,6 +16,7 @@ const unranked_memref_descriptor = @import("unranked_memref_descriptor.zig");
 const value = @import("value.zig");
 const action_tracing = @import("action_tracing.zig");
 const triton = @import("triton.zig");
+const llvm_ir = @import("llvm_ir.zig");
 const capi_registry = @import("capi_registry.zig");
 
 const callback_nifs = .{kinda.callback_runtime.ReplyToken.nif("beaver_raw_callback_reply")};
@@ -33,6 +34,7 @@ pub const nifs = capi_registry.nifs ++
     unranked_memref_descriptor.nifs ++
     value.nifs ++
     action_tracing.nifs ++
+    llvm_ir.nifs ++
     triton.nifs;
 
 export const core_nifs: [nifs.len]e.ErlNifFunc = nifs;

--- a/native/src/llvm_ir.zig
+++ b/native/src/llvm_ir.zig
@@ -1,0 +1,59 @@
+const std = @import("std");
+const kinda = @import("kinda");
+const e = kinda.erl_nif;
+const beam = kinda.beam;
+const result = kinda.result;
+const mlir_capi = @import("mlir_capi.zig");
+const diagnostic = @import("diagnostic.zig");
+const c = @import("prelude.zig").c;
+
+const Translation = struct {
+    const Buffer = std.array_list.Managed(u8);
+
+    buffer: Buffer,
+
+    fn appendString(value: mlir_capi.StringRef.T, user_data: ?*anyopaque) callconv(.c) void {
+        const self: *@This() = @ptrCast(@alignCast(user_data orelse return));
+        self.buffer.appendSlice(value.data[0..value.length]) catch @panic("failed to collect LLVM IR");
+    }
+
+    fn translateWithoutDiagnostics(
+        environment: beam.env,
+        _: c_int,
+        args: [*c]const beam.term,
+    ) !beam.term {
+        const operation = try mlir_capi.Operation.resource.fetch(environment, args[0]);
+        var self = @This(){ .buffer = Buffer.init(beam.allocator) };
+        defer self.buffer.deinit();
+
+        const status = c.beaverTranslateModuleToLLVMIRText(operation, appendString, &self);
+        if (c.mlirLogicalResultIsFailure(status))
+            return beam.make_atom(environment, "error");
+
+        return beam.make_slice(environment, self.buffer.items);
+    }
+
+    fn translate(
+        environment: beam.env,
+        argc: c_int,
+        args: [*c]const beam.term,
+    ) !beam.term {
+        const operation = try mlir_capi.Operation.resource.fetch(environment, args[0]);
+        const context = c.mlirOperationGetContext(operation);
+        return diagnostic.call_with_diagnostics(
+            environment,
+            context,
+            translateWithoutDiagnostics,
+            .{ environment, argc, args },
+        );
+    }
+};
+
+pub const nifs = .{
+    result.nif_with_flags(
+        "beaver_raw_translate_module_to_llvm_ir",
+        1,
+        Translation.translate,
+        e.ERL_NIF_DIRTY_JOB_CPU_BOUND,
+    ).entry,
+};

--- a/native/tools/capi/gen_header.exs
+++ b/native/tools/capi/gen_header.exs
@@ -23,6 +23,7 @@ beaver_headers = ~w[
   mlir-c/Beaver/Op.h
   mlir-c/Beaver/Pass.h
   mlir-c/Beaver/Debug.h
+  mlir-c/Beaver/LLVMIR.h
   mlir-c/Beaver/CallbackTypeDef.h
 ]
 

--- a/native/tools/capi/gen_manifest.exs
+++ b/native/tools/capi/gen_manifest.exs
@@ -12,6 +12,14 @@ defmodule Beaver.CAPI.ManifestGenerator do
   ]
 
   @manual_bridges %{
+    "beaverTranslateModuleToLLVMIRText" => %{
+      "wrapper_name" => "beaver_raw_translate_module_to_llvm_ir",
+      "runtime" => "native_collector",
+      "scheduler" => "dirty_cpu",
+      "owner" => "caller",
+      "lifetime" => "nif_call",
+      "destructor" => "native_owner"
+    },
     "mlirTransformStateForEachPayloadOp" => %{
       "wrapper_name" => "beaver_raw_transform_state_payload_ops",
       "runtime" => "native_collector",

--- a/test/capi_manifest_test.exs
+++ b/test/capi_manifest_test.exs
@@ -150,12 +150,19 @@ defmodule Beaver.MLIR.CAPI.ManifestTest do
     assert Enum.map(collector_entries, &get_in(&1, ["callback_bridge", "wrapper_name"]))
            |> MapSet.new() ==
              MapSet.new([
+               "beaver_raw_translate_module_to_llvm_ir",
                "beaver_raw_transform_state_params",
                "beaver_raw_transform_state_payload_ops",
                "beaver_raw_transform_state_payload_values"
              ])
 
-    for entry <- collector_entries do
+    {llvm_ir_entries, transform_collector_entries} =
+      Enum.split_with(
+        collector_entries,
+        &(get_in(&1, ["function", "name"]) == "beaverTranslateModuleToLLVMIRText")
+      )
+
+    for entry <- transform_collector_entries do
       bridge = Map.fetch!(entry, "callback_bridge")
       assert bridge["runtime_backed"]
       assert bridge["scheduler"] == "normal"
@@ -164,6 +171,17 @@ defmodule Beaver.MLIR.CAPI.ManifestTest do
       assert bridge["lifetime"] == "nif_call"
       assert bridge["facets"] == ["native_collector", "context_owned_handles"]
     end
+
+    assert [llvm_ir_entry] = llvm_ir_entries
+
+    assert %{
+             "wrapper_name" => "beaver_raw_translate_module_to_llvm_ir",
+             "runtime_backed" => true,
+             "scheduler" => "dirty_cpu",
+             "owner" => "caller",
+             "destructor" => "native_owner",
+             "lifetime" => "nif_call"
+           } = llvm_ir_entry["callback_bridge"]
 
     assert [manual_runtime] = manual_runtime_entries
     assert get_in(manual_runtime, ["function", "name"]) == "mlirValueReplaceUsesWithIf"

--- a/test/llvm_ir_target_test.exs
+++ b/test/llvm_ir_target_test.exs
@@ -1,0 +1,59 @@
+defmodule Beaver.MLIR.Target.LLVMIRTest do
+  use Beaver.Case, async: true
+
+  alias Beaver.MLIR
+  alias Beaver.MLIR.Target.LLVMIR
+
+  @moduletag :smoke
+
+  test "exports an LLVM dialect module as LLVM IR text", %{ctx: ctx} do
+    module =
+      MLIR.Module.create!(
+        """
+        module {
+          llvm.func @answer() -> i32 {
+            %answer = llvm.mlir.constant(42 : i32) : i32
+            llvm.return %answer : i32
+          }
+        }
+        """,
+        ctx: ctx
+      )
+
+    assert {:ok, llvm_ir} = LLVMIR.translate(module)
+    assert llvm_ir =~ "define i32 @answer()"
+    assert llvm_ir =~ "ret i32 42"
+    assert LLVMIR.translate!(module) == llvm_ir
+  end
+
+  test "returns diagnostics for a module that is not lowered to LLVM dialect", %{ctx: ctx} do
+    module =
+      MLIR.Module.create!(
+        """
+        module {
+          func.func @answer() -> i32 {
+            %answer = arith.constant 42 : i32
+            return %answer : i32
+          }
+        }
+        """,
+        ctx: ctx
+      )
+
+    assert {:error, diagnostics} = LLVMIR.translate(module)
+    assert diagnostics != []
+
+    assert_raise ArgumentError, ~r/failed to translate module to LLVM IR/, fn ->
+      LLVMIR.translate!(module)
+    end
+  end
+
+  test "can repeatedly translate the same module", %{ctx: ctx} do
+    module = MLIR.Module.create!("module { llvm.func @noop() { llvm.return } }", ctx: ctx)
+
+    for _ <- 1..20 do
+      assert {:ok, llvm_ir} = LLVMIR.translate(module)
+      assert llvm_ir =~ "define void @noop()"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- add a native MLIR-to-LLVM translation and text-export bridge
- own and dispose LLVM contexts, modules, and print messages inside the native call
- register translations through the module context and return structured diagnostics
- cover successful, invalid, and repeated exports

## Safety

The BEAM never receives an LLVMContextRef, LLVMModuleRef, or LLVM-owned message pointer. The native wrapper checks null results before printing and releases every owned LLVM resource on all paths.

## Validation

- 8 focused LLVM IR export tests passed
- included in the final 402-test run against LLVM eudsl 20260809+9813315f2

## Stack

1. #600
2. This PR
3. InferType and InferShapedType collectors
4. LLVM DICompileUnit source-language-dialect support and prebuilt bump