### PR TITLE
Support LLVM DI compile unit dialects

### DIFF
--- a/lib/beaver/mlir/dialect/llvm.ex
+++ b/lib/beaver/mlir/dialect/llvm.ex
@@ -112,6 +112,16 @@ defmodule Beaver.MLIR.Dialect.LLVM do
     end
   end
 
+  @doc "Whether the installed LLVM exposes source-language dialects on `DICompileUnit`."
+  def di_compile_unit_source_language_dialect_supported? do
+    Code.ensure_loaded?(MLIR.CAPI) and
+      function_exported?(
+        MLIR.CAPI,
+        :mlirLLVMDICompileUnitAttrGetWithSourceLanguageDialect,
+        15
+      )
+  end
+
   @doc """
   Build an LLVM `DICompileUnit` attribute.
 
@@ -129,6 +139,12 @@ defmodule Beaver.MLIR.Dialect.LLVM do
         nil -> nil
         value -> debug_enum(value, @debug_language_dialects)
       end
+
+    if source_language_dialect != nil and
+         not di_compile_unit_source_language_dialect_supported?() do
+      raise ArgumentError,
+            "installed LLVM does not support DICompileUnit source-language dialects"
+    end
 
     id =
       Keyword.get_lazy(opts, :id, fn ->

--- a/lib/beaver/mlir/dialect/llvm.ex
+++ b/lib/beaver/mlir/dialect/llvm.ex
@@ -38,6 +38,11 @@ defmodule Beaver.MLIR.Dialect.LLVM do
     wasm_emscripten_invoke: "wasm_emscripten_invokecc"
   }
 
+  @debug_languages %{c: 0x0002}
+  @debug_language_dialects %{simt: 0x01, tile: 0x02}
+  @debug_emission_kinds %{none: 0, full: 1, line_tables_only: 2, debug_directives_only: 3}
+  @debug_name_table_kinds %{default: 0, gnu: 1, none: 2, apple: 3}
+
   @doc "Build an opaque LLVM pointer type for an address space."
   def pointer, do: pointer(0, [])
   def pointer(opts) when is_list(opts), do: pointer(0, opts)
@@ -104,6 +109,87 @@ defmodule Beaver.MLIR.Dialect.LLVM do
     case @calling_conventions do
       %{^value => spelling} -> MLIR.Attribute.get("#llvm.cconv<#{spelling}>", opts)
       _ -> raise ArgumentError, "unsupported LLVM calling convention: #{inspect(value)}"
+    end
+  end
+
+  @doc """
+  Build an LLVM `DICompileUnit` attribute.
+
+  `:source_language_dialect` is optional. Omitting it uses the established C
+  API; setting it uses the newer ABI while preserving all other defaults.
+  Languages and dialects accept their DWARF integer values. The common `:c`,
+  `:simt`, and `:tile` spellings are also accepted.
+  """
+  def di_compile_unit(opts) when is_list(opts) do
+    ctx = Keyword.fetch!(opts, :ctx)
+    source_language = debug_enum(Keyword.fetch!(opts, :source_language), @debug_languages)
+
+    source_language_dialect =
+      case Keyword.get(opts, :source_language_dialect) do
+        nil -> nil
+        value -> debug_enum(value, @debug_language_dialects)
+      end
+
+    id =
+      Keyword.get_lazy(opts, :id, fn ->
+        MLIR.CAPI.mlirDistinctAttrCreate(MLIR.Attribute.unit(ctx: ctx))
+      end)
+
+    rec_id =
+      Keyword.get_lazy(opts, :rec_id, fn ->
+        MLIR.CAPI.mlirDistinctAttrCreate(MLIR.Attribute.unit(ctx: ctx))
+      end)
+
+    file =
+      Keyword.get_lazy(opts, :file, fn ->
+        MLIR.CAPI.mlirLLVMDIFileAttrGet(
+          ctx,
+          MLIR.Attribute.string(Keyword.fetch!(opts, :filename), ctx: ctx),
+          MLIR.Attribute.string(Keyword.get(opts, :directory, ""), ctx: ctx)
+        )
+      end)
+
+    producer = MLIR.Attribute.string(Keyword.get(opts, :producer, ""), ctx: ctx)
+
+    split_debug_filename =
+      MLIR.Attribute.string(Keyword.get(opts, :split_debug_filename, ""), ctx: ctx)
+
+    imported_entities = Keyword.get(opts, :imported_entities, [])
+    imported_array = Beaver.Native.array(imported_entities, MLIR.Attribute)
+    emission_kind = debug_enum(Keyword.get(opts, :emission_kind, :full), @debug_emission_kinds)
+
+    name_table_kind =
+      debug_enum(Keyword.get(opts, :name_table_kind, :default), @debug_name_table_kinds)
+
+    common = [
+      ctx,
+      rec_id,
+      Keyword.get(opts, :rec_self, false),
+      id,
+      source_language,
+      file,
+      producer,
+      Keyword.get(opts, :optimized, false),
+      emission_kind,
+      Keyword.get(opts, :debug_info_for_profiling, false),
+      name_table_kind,
+      split_debug_filename,
+      length(imported_entities),
+      imported_array
+    ]
+
+    case source_language_dialect do
+      nil ->
+        apply(MLIR.CAPI, :mlirLLVMDICompileUnitAttrGet, common)
+
+      dialect ->
+        [head, rec_id, rec_self, id, language | tail] = common
+
+        apply(
+          MLIR.CAPI,
+          :mlirLLVMDICompileUnitAttrGetWithSourceLanguageDialect,
+          [head, rec_id, rec_self, id, language, dialect | tail]
+        )
     end
   end
 
@@ -204,5 +290,14 @@ defmodule Beaver.MLIR.Dialect.LLVM do
 
   defp maybe_i64(arguments, name, value, ctx) when is_integer(value) and value > 0 do
     arguments ++ [{name, MLIR.Attribute.integer(MLIR.Type.i64(ctx: ctx), value)}]
+  end
+
+  defp debug_enum(value, _known) when is_integer(value) and value >= 0, do: value
+
+  defp debug_enum(value, known) when is_atom(value) do
+    case known do
+      %{^value => encoded} -> encoded
+      _ -> raise ArgumentError, "unsupported LLVM debug enum value: #{inspect(value)}"
+    end
   end
 end

--- a/scripts/install_llvm/lib/mix/tasks/beaver.install_prebuilt_llvm.ex
+++ b/scripts/install_llvm/lib/mix/tasks/beaver.install_prebuilt_llvm.ex
@@ -28,7 +28,7 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
     * `--repo REPO` / `LLVM_EUDSL_REPO` — defaults to `llvm/eudsl`.
     * `--tag TAG` / `LLVM_EUDSL_TAG` — defaults to `llvm`.
     * `--asset-revision REV` / `LLVM_EUDSL_ASSET_REVISION` — defaults to
-      `20260804+eb50d8775`; `latest` resolves the newest asset through the
+      `20260809+9813315f2`; `latest` resolves the newest asset through the
       GitHub API.
     * `--asset-name NAME` / `LLVM_EUDSL_ASSET_NAME` — exact asset file name.
     * `--asset-url URL` / `LLVM_EUDSL_ASSET_URL` — download from an arbitrary
@@ -60,7 +60,7 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
 
   @shortdoc "Installs a prebuilt LLVM/MLIR distribution"
 
-  @default_revision "20260804+eb50d8775"
+  @default_revision "20260809+9813315f2"
 
   @switches [
     install_dir: :string,

--- a/scripts/install_llvm/test/install_prebuilt_llvm_test.exs
+++ b/scripts/install_llvm/test/install_prebuilt_llvm_test.exs
@@ -22,7 +22,7 @@ defmodule Beaver.InstallPrebuiltLlvmTest do
         ])
       end)
 
-    assert output =~ "LLVM_PREBUILT_ASSET_NAME=mlir_manylinux_x86_64_20260804+eb50d8775.tar.gz"
+    assert output =~ "LLVM_PREBUILT_ASSET_NAME=mlir_manylinux_x86_64_20260809+9813315f2.tar.gz"
     assert output =~ "https://github.com/llvm/eudsl/releases/download/llvm/"
   end
 
@@ -54,7 +54,7 @@ defmodule Beaver.InstallPrebuiltLlvmTest do
         ])
       end)
 
-    assert output =~ "LLVM_PREBUILT_ASSET_NAME=mlir_manylinux_x86_64_20260804+eb50d8775.tar.gz"
+    assert output =~ "LLVM_PREBUILT_ASSET_NAME=mlir_manylinux_x86_64_20260809+9813315f2.tar.gz"
   end
 
   test "triton suffix maps Beaver platforms to Triton archive names" do

--- a/test/capi_manifest_test.exs
+++ b/test/capi_manifest_test.exs
@@ -89,10 +89,18 @@ defmodule Beaver.MLIR.CAPI.ManifestTest do
             "mlirLLVMDICompileUnitAttrGetWithSourceLanguageDialect")
       )
 
-    assert Enum.at(get_in(signature_entry, ["function", "param_ctypes"]), 5) == %{
-             "kind" => "integer",
-             "spelling" => "unsigned int"
-           }
+    if signature_entry do
+      assert Enum.at(get_in(signature_entry, ["function", "param_ctypes"]), 5) == %{
+               "kind" => "integer",
+               "spelling" => "unsigned int"
+             }
+    else
+      refute function_exported?(
+               CAPI,
+               :mlirLLVMDICompileUnitAttrGetWithSourceLanguageDialect,
+               15
+             )
+    end
   end
 
   test "callback-heavy declarations remain in the callback bridge manifest" do

--- a/test/capi_manifest_test.exs
+++ b/test/capi_manifest_test.exs
@@ -79,6 +79,20 @@ defmodule Beaver.MLIR.CAPI.ManifestTest do
                declarations,
                &(&1.wrapper_name == :mlirTransformApplyNamedSequenceWithDiagnostics)
              )
+
+    signature_entry =
+      declaration_manifest
+      |> DeclarationManifest.signature_manifest()
+      |> Map.fetch!("entries")
+      |> Enum.find(
+        &(get_in(&1, ["function", "name"]) ==
+            "mlirLLVMDICompileUnitAttrGetWithSourceLanguageDialect")
+      )
+
+    assert Enum.at(get_in(signature_entry, ["function", "param_ctypes"]), 5) == %{
+             "kind" => "integer",
+             "spelling" => "unsigned int"
+           }
   end
 
   test "callback-heavy declarations remain in the callback bridge manifest" do

--- a/test/llvm_dialect_test.exs
+++ b/test/llvm_dialect_test.exs
@@ -86,4 +86,30 @@ defmodule LLVMDialectTest do
     assert to_string(module) =~ "llvm.mlir.global internal constant @answer"
     assert to_string(module) =~ "alignment = 4"
   end
+
+  test "builds compatible DICompileUnit attributes with an optional source language dialect", %{
+    ctx: ctx
+  } do
+    legacy =
+      LLVM.di_compile_unit(
+        ctx: ctx,
+        source_language: :c,
+        filename: "legacy.c",
+        producer: "Beaver"
+      )
+
+    assert to_string(legacy) =~ "sourceLanguage = DW_LANG_C"
+    refute to_string(legacy) =~ "sourceLanguageDialect"
+
+    dialect =
+      LLVM.di_compile_unit(
+        ctx: ctx,
+        source_language: :c,
+        source_language_dialect: :tile,
+        filename: "kernel.c",
+        producer: "Beaver"
+      )
+
+    assert to_string(dialect) =~ "sourceLanguageDialect = DW_LLVM_LANG_DIALECT_tile"
+  end
 end

--- a/test/llvm_dialect_test.exs
+++ b/test/llvm_dialect_test.exs
@@ -101,15 +101,21 @@ defmodule LLVMDialectTest do
     assert to_string(legacy) =~ "sourceLanguage = DW_LANG_C"
     refute to_string(legacy) =~ "sourceLanguageDialect"
 
-    dialect =
-      LLVM.di_compile_unit(
-        ctx: ctx,
-        source_language: :c,
-        source_language_dialect: :tile,
-        filename: "kernel.c",
-        producer: "Beaver"
-      )
+    dialect_opts = [
+      ctx: ctx,
+      source_language: :c,
+      source_language_dialect: :tile,
+      filename: "kernel.c",
+      producer: "Beaver"
+    ]
 
-    assert to_string(dialect) =~ "sourceLanguageDialect = DW_LLVM_LANG_DIALECT_tile"
+    if LLVM.di_compile_unit_source_language_dialect_supported?() do
+      dialect = LLVM.di_compile_unit(dialect_opts)
+      assert to_string(dialect) =~ "sourceLanguageDialect = DW_LLVM_LANG_DIALECT_tile"
+    else
+      assert_raise ArgumentError, ~r/does not support DICompileUnit/, fn ->
+        LLVM.di_compile_unit(dialect_opts)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- bump the default LLVM eudsl prebuilt to 20260809+9813315f2
- expose an LLVM DICompileUnit helper with an optional source language dialect
- retain the established C API when the dialect is omitted and use the new ABI only when requested
- verify the generated manifest preserves the new unsigned integer parameter

## Compatibility

Existing callers keep the old mlirLLVMDICompileUnitAttrGet path. source_language_dialect selects mlirLLVMDICompileUnitAttrGetWithSourceLanguageDialect, with symbolic SIMT and Tile values plus raw DWARF integers.

## Validation

- installer tests: 8 passed
- focused final-stack tests: 10 passed
- full suite on LLVM eudsl 20260809+9813315f2: 402 passed, 5 skipped, 21 excluded
- mix format --check-formatted
- git diff --check

## Stack

1. #600
2. #601
3. #602
4. This PR