### PR TITLE
Stabilize main release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,6 +305,7 @@ jobs:
         run: sed -i 's/-dev//g' mix.exs
       - name: Build ARM
         continue-on-error: true
+        timeout-minutes: 30
         if: ${{ matrix.image.platform == 'linux/arm64/v8' && github.event_name != 'pull_request' }}
         run: docker run --platform ${{ matrix.image.platform }} -v $PWD:/src -w /src/beaver ${{ vars.DOCKERHUB_USERNAME }}/beaver-livebook-${{ matrix.image.suffix }}:latest bash scripts/build-for-publish.sh
       - name: Publish archives and packages

--- a/scripts/install_llvm/lib/mix/tasks/beaver.install_prebuilt_llvm.ex
+++ b/scripts/install_llvm/lib/mix/tasks/beaver.install_prebuilt_llvm.ex
@@ -28,7 +28,7 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
     * `--repo REPO` / `LLVM_EUDSL_REPO` — defaults to `llvm/eudsl`.
     * `--tag TAG` / `LLVM_EUDSL_TAG` — defaults to `llvm`.
     * `--asset-revision REV` / `LLVM_EUDSL_ASSET_REVISION` — defaults to
-      `20260809+9813315f2`; `latest` resolves the newest asset through the
+      `20260804+eb50d8775`; `latest` resolves the newest asset through the
       GitHub API.
     * `--asset-name NAME` / `LLVM_EUDSL_ASSET_NAME` — exact asset file name.
     * `--asset-url URL` / `LLVM_EUDSL_ASSET_URL` — download from an arbitrary
@@ -60,7 +60,7 @@ defmodule Mix.Tasks.Beaver.InstallPrebuiltLlvm do
 
   @shortdoc "Installs a prebuilt LLVM/MLIR distribution"
 
-  @default_revision "20260809+9813315f2"
+  @default_revision "20260804+eb50d8775"
 
   @switches [
     install_dir: :string,

--- a/scripts/install_llvm/test/install_prebuilt_llvm_test.exs
+++ b/scripts/install_llvm/test/install_prebuilt_llvm_test.exs
@@ -22,7 +22,7 @@ defmodule Beaver.InstallPrebuiltLlvmTest do
         ])
       end)
 
-    assert output =~ "LLVM_PREBUILT_ASSET_NAME=mlir_manylinux_x86_64_20260809+9813315f2.tar.gz"
+    assert output =~ "LLVM_PREBUILT_ASSET_NAME=mlir_manylinux_x86_64_20260804+eb50d8775.tar.gz"
     assert output =~ "https://github.com/llvm/eudsl/releases/download/llvm/"
   end
 
@@ -54,7 +54,7 @@ defmodule Beaver.InstallPrebuiltLlvmTest do
         ])
       end)
 
-    assert output =~ "LLVM_PREBUILT_ASSET_NAME=mlir_manylinux_x86_64_20260809+9813315f2.tar.gz"
+    assert output =~ "LLVM_PREBUILT_ASSET_NAME=mlir_manylinux_x86_64_20260804+eb50d8775.tar.gz"
   end
 
   test "triton suffix maps Beaver platforms to Triton archive names" do


### PR DESCRIPTION
## What changed

- restore the last cross-platform LLVM/eudsl default (`20260804+eb50d8775`)
- cap the best-effort QEMU ARM build at 30 minutes

## Why

The current main run fails four native API tests on macOS ARM64 after the LLVM default moved to `20260809+9813315f2`, while Linux and Windows pass. Its ARM Docker publish step also exceeded seven hours without output; the previous successful run took about 19 minutes.

The DI compile-unit dialect API remains capability-detected and continues to work with LLVM installations that expose it.

## Validation

- `scripts/install_llvm`: 8 tests passed
- `git diff --check`