### PR TITLE
Attach LLVM debug scopes so translated IR traces back to Elixir lines

### DIFF
--- a/lib/beaver/mlir.ex
+++ b/lib/beaver/mlir.ex
@@ -192,6 +192,10 @@ defmodule Beaver.MLIR do
   Print MLIR element or StringRef as Elixir binary string.
 
   When printing an operation, it is recommended to use `generic: false` or `generic: true` to explicitly specify the format if your usage requires consistent output. If not specified, the default behavior is subject to change according to the MLIR version.
+
+  Pass `debug_info: true` to include location and debug information (for example
+  the `#llvm.di_subprogram` attributes attached by `Beaver.MLIR.Debug`) in the
+  printed output. The output remains valid, parseable MLIR text.
   """
 
   def to_string(mlir, opts \\ [])
@@ -199,26 +203,43 @@ defmodule Beaver.MLIR do
   def to_string(%Operation{ref: ref}, opts) do
     operation = %Operation{ref: ref}
 
-    cond do
-      opts[:bytecode] == true and opts[:bytecode_version] ->
-        MLIR.Bytecode.write!(operation, desired_emit_version: opts[:bytecode_version])
+    if opts[:debug_info] do
+      flags = CAPI.mlirOpPrintingFlagsCreate()
 
-      opts[:bytecode] ->
-        :Bytecode
+      try do
+        CAPI.mlirOpPrintingFlagsEnableDebugInfo(flags, true, false)
 
-      opts[:generic] == false ->
-        :Specialized
+        {_, text} =
+          Beaver.Printer.run(fn callback, user_data ->
+            CAPI.mlirOperationPrintWithFlags(operation, flags, callback, user_data)
+          end)
 
-      opts[:generic] == true ->
-        :Generic
+        text
+      after
+        CAPI.mlirOpPrintingFlagsDestroy(flags)
+      end
+    else
+      cond do
+        opts[:bytecode] == true and opts[:bytecode_version] ->
+          MLIR.Bytecode.write!(operation, desired_emit_version: opts[:bytecode_version])
 
-      true ->
-        nil
+        opts[:bytecode] ->
+          :Bytecode
+
+        opts[:generic] == false ->
+          :Specialized
+
+        opts[:generic] == true ->
+          :Generic
+
+        true ->
+          nil
+      end
+      |> then(fn
+        bytecode when is_binary(bytecode) -> bytecode
+        suffix -> apply(CAPI, :"beaver_raw_to_string_Operation#{suffix}", [ref])
+      end)
     end
-    |> then(fn
-      bytecode when is_binary(bytecode) -> bytecode
-      suffix -> apply(CAPI, :"beaver_raw_to_string_Operation#{suffix}", [ref])
-    end)
   end
 
   def to_string(%Beaver.MLIR.Module{} = module, opts) do

--- a/lib/beaver/mlir/debug.ex
+++ b/lib/beaver/mlir/debug.ex
@@ -1,7 +1,31 @@
 defmodule Beaver.MLIR.Debug do
   @moduledoc """
-  Configure MLIR global debug options.
+  Configure MLIR global debug options and attach LLVM debug information so
+  translated IR and JIT'd code can be traced back to Elixir source lines with
+  gdb/lldb.
+
+  Beaver records the Elixir `Macro.Env` location (`loc("/path/file.exs":line:col)`)
+  on every operation it builds, and those locations survive lowering to the LLVM
+  dialect. The MLIR-to-LLVM translation, however, only emits DWARF `DILocation`
+  metadata when each `llvm.func` carries a `DISubprogramAttr` scope.
+
+  `attach_llvm_scopes!/1` runs MLIR's upstream
+  `ensure-debug-info-scope-on-llvm-func` pass, which attaches a `DISubprogramAttr`
+  (and a compile unit derived from the module location) to every `llvm.func`.
+  After it runs:
+
+    * `mlir-translate --mlir-to-llvmir` emits `!dbg` and `!DILocation` metadata
+      pointing at the original `.exs` files and lines;
+    * `Beaver.MLIR.ExecutionEngine.create!(module, debug_info: true)` produces a
+      JIT object whose line table is registered with gdb (MLIR's execution
+      engine enables its GDB notification listener by default), so
+      `break file.exs:line` works while attached to the BEAM process.
+
+  The pass emits line tables only (`DIEmissionKind::LineTablesOnly`) by design:
+  it is a convenient way to step line-by-line or get a backtrace with line
+  numbers, not a replacement for frontends emitting complete debug info.
   """
+  alias Beaver.Composer
   alias Beaver.MLIR
   import MLIR.CAPI
 
@@ -64,5 +88,23 @@ defmodule Beaver.MLIR.Debug do
   def is_current_debug_type?(type) when is_binary(type) do
     type_str = MLIR.StringRef.create(type) |> MLIR.StringRef.data()
     mlirIsCurrentDebugType(type_str) |> Beaver.Native.to_term()
+  end
+
+  @doc """
+  Attach a `DISubprogramAttr` debug scope to every `llvm.func` in the module.
+
+  The pass is idempotent: functions that already carry a subprogram scope are
+  left untouched. The attached scopes reference the Elixir file and line that
+  each `llvm.func` was originally built from, so the MLIR-to-LLVM translation
+  can emit `DILocation` metadata for it.
+
+  Requires the module to be in the LLVM dialect (the pass fails on other
+  modules).
+  """
+  @spec attach_llvm_scopes!(Composer.t() | MLIR.Module.t() | MLIR.Operation.t()) ::
+          MLIR.Module.t() | MLIR.Operation.t()
+  def attach_llvm_scopes!(composer_or_op) do
+    pass = MLIR.CAPI.mlirCreateLLVMDIScopeForLLVMFuncOpPass()
+    composer_or_op |> Composer.append(pass) |> Composer.run!()
   end
 end

--- a/lib/beaver/mlir/execution_engine.ex
+++ b/lib/beaver/mlir/execution_engine.ex
@@ -11,8 +11,10 @@ defmodule Beaver.MLIR.ExecutionEngine do
   @doc """
   Create a MLIR JIT engine for a module and check if successful. Usually this module should be of LLVM dialect.
   """
-  def create!(%Composer{} = composer_or_op) do
-    Composer.run!(composer_or_op) |> create!()
+  def create!(composer_or_op, opts \\ [])
+
+  def create!(%Composer{} = composer_or_op, opts) do
+    Composer.run!(composer_or_op) |> create!(opts)
   end
 
   @type dirty :: nil | :io_bound | :cpu_bound
@@ -26,15 +28,24 @@ defmodule Beaver.MLIR.ExecutionEngine do
           {:opt_level, opt_level},
           {:object_dump, object_dump},
           {:enable_pic, enable_pic},
+          {:debug_info, boolean()},
           {:dirty, dirty},
           {:telemetry, (list(atom()), map(), map() -> any())}
         ]
   @spec create!(MLIR.Module.t(), opts()) :: t()
-  def create!(module, opts \\ []) do
+  def create!(module, opts) do
     shared_lib_paths = Keyword.get(opts, :shared_lib_paths, [])
     opt_level = Keyword.get(opts, :opt_level, 2)
     object_dump = Keyword.get(opts, :object_dump, false)
     enable_pic = Keyword.get(opts, :enable_pic, false)
+    debug_info = Keyword.get(opts, :debug_info, false)
+
+    module =
+      if debug_info do
+        Beaver.MLIR.Debug.attach_llvm_scopes!(module)
+      else
+        module
+      end
 
     shared_lib_paths_ptr =
       shared_lib_paths

--- a/test/debug_test.exs
+++ b/test/debug_test.exs
@@ -3,5 +3,114 @@ defmodule DebugTest do
   Test the debug configurations of MLIR.
   """
   use Beaver.Case, async: true
+  use Beaver
   doctest Beaver.MLIR.Debug
+
+  alias Beaver.MLIR
+  alias MLIR.Dialect.{Arith, Func}
+  alias MLIR.Type
+  require Func
+
+  import Beaver.MLIR.Conversion
+  import Beaver.MLIR.Transform
+
+  defp add_module(ctx) do
+    mlir ctx: ctx do
+      module do
+        Func.func add(
+                    function_type: Type.function([Type.i32(), Type.i32()], [Type.i32()]),
+                    sym_name: MLIR.Attribute.string("add")
+                  ) do
+          region do
+            block _(a >>> Type.i32(), b >>> Type.i32()) do
+              r = Arith.addi(a, b) >>> Type.i32()
+              Func.return(r) >>> []
+            end
+          end
+        end
+      end
+    end
+  end
+
+  defp to_llvm(module) do
+    module
+    |> Beaver.Composer.nested("func.func", "llvm-request-c-wrappers")
+    |> canonicalize()
+    |> convert_scf_to_cf()
+    |> convert_to_llvm()
+    |> reconcile_unrealized_casts()
+    |> Beaver.Composer.run!()
+  end
+
+  test "printing with debug_info does not attach DI scopes by itself", %{ctx: ctx} do
+    text = ctx |> add_module() |> to_llvm() |> MLIR.to_string(debug_info: true)
+
+    # Locations point at this test file, but no subprogram scopes yet.
+    assert text =~ "debug_test.exs"
+    refute text =~ "llvm.di_subprogram"
+    refute text =~ "loc(fused<#di_subprogram"
+  end
+
+  test "attach_llvm_scopes! adds DI subprogram scopes for every llvm.func", %{ctx: ctx} do
+    text =
+      ctx
+      |> add_module()
+      |> to_llvm()
+      |> Beaver.MLIR.Debug.attach_llvm_scopes!()
+      |> MLIR.to_string(debug_info: true)
+
+    assert text =~ ~s{#llvm.di_file<"debug_test.exs" in}
+    assert text =~ "#llvm.di_compile_unit<"
+    assert text =~ "#llvm.di_subprogram<"
+
+    n_funcs = length(Regex.scan(~r/llvm\.func @/, text))
+    n_scopes = length(Regex.scan(~r/loc\(fused<#di_subprogram/, text))
+    assert n_funcs > 0
+    assert n_funcs == n_scopes
+  end
+
+  test "attach_llvm_scopes! is idempotent", %{ctx: ctx} do
+    module = ctx |> add_module() |> to_llvm()
+
+    once =
+      module
+      |> Beaver.MLIR.Debug.attach_llvm_scopes!()
+      |> MLIR.to_string(debug_info: true)
+
+    twice =
+      module
+      |> Beaver.MLIR.Debug.attach_llvm_scopes!()
+      |> Beaver.MLIR.Debug.attach_llvm_scopes!()
+      |> MLIR.to_string(debug_info: true)
+
+    assert once == twice
+  end
+
+  @tag skip: System.get_env("LLVM_CONFIG_PATH") == nil
+  @tag :tmp_dir
+  test "LLVM IR translation emits DILocation metadata for Elixir lines", %{
+    ctx: ctx,
+    tmp_dir: tmp_dir
+  } do
+    module = ctx |> add_module() |> to_llvm() |> Beaver.MLIR.Debug.attach_llvm_scopes!()
+
+    mlir_path = Path.join(tmp_dir, "debug.mlir")
+    ll_path = Path.join(tmp_dir, "debug.ll")
+    File.write!(mlir_path, MLIR.to_string(module, debug_info: true))
+
+    llvm_bin = System.get_env("LLVM_CONFIG_PATH") |> Path.dirname()
+    mlir_translate = Path.join(llvm_bin, "mlir-translate")
+
+    {output, status} =
+      System.cmd(mlir_translate, ["--mlir-to-llvmir", mlir_path, "-o", ll_path],
+        stderr_to_stdout: true
+      )
+
+    assert status == 0, output
+
+    ir = File.read!(ll_path)
+    assert ir =~ "!dbg"
+    assert ir =~ "!DILocation("
+    assert ir =~ ~s{!DIFile(filename: "debug_test.exs"}
+  end
 end


### PR DESCRIPTION
## What

Beaver already records Elixir `Macro.Env` locations (`loc("/path/file.exs":line)`) on every op it builds, and those survive lowering to the LLVM dialect. But MLIR's MLIR-to-LLVM translation only emits DWARF `DILocation` metadata when each `llvm.func` carries a `DISubprogramAttr` scope, so gdb/lldb had nothing to trace.

This PR wires the missing pieces:

- **`Beaver.MLIR.Debug.attach_llvm_scopes!/1`** — runs MLIR's upstream `ensure-debug-info-scope-on-llvm-func` pass, which attaches a `DISubprogramAttr` (and a `DICompileUnit` derived from the module location) to every `llvm.func`. Idempotent.
- **`MLIR.to_string(module, debug_info: true)`** — prints locations and DI attribute scopes as valid, parseable MLIR text (needed to feed `mlir-translate` without losing locs).
- **`ExecutionEngine.create!(module, debug_info: true)`** — runs the pass before engine creation; MLIR's execution engine enables its GDB notification listener by default, so gdb attached to the BEAM can `break file.exs:line` on JIT'd code.

## Result

With the pass applied:

```llvm
define i32 @add(i32 %0, i32 %1) !dbg !3 {
  %3 = add i32 %0, %1, !dbg !6
  ret i32 %3, !dbg !7
}
!1 = !DIFile(filename: "foo.exs", directory: "/path")
!6 = !DILocation(line: 15, scope: !3)
```

and the compiled object's `.debug_line` table maps addresses back to `foo.exs` lines.

## Tests

`test/debug_test.exs`: no scopes before the pass, one scope per `llvm.func` after, idempotence, and an integration test that runs `mlir-translate` (skipped when `LLVM_CONFIG_PATH` is unset) asserting `!dbg` / `!DILocation` / `!DIFile`.