### PR TITLE
Fix macOS logical result handling

### DIFF
--- a/native/src/infer_type.zig
+++ b/native/src/infer_type.zig
@@ -169,7 +169,7 @@ fn inferTypesWithoutDiagnostics(
         TypeCollector.append,
         &collector,
     );
-    if (c.mlirLogicalResultIsFailure(status)) {
+    if (c.beaverLogicalResultIsFailure(status)) {
         c.mlirEmitError(request.location, "failed to infer operation return types");
         return beam.make_atom(environment, "error");
     }
@@ -199,7 +199,7 @@ fn inferShapedTypesWithoutDiagnostics(
         ShapedTypeCollector.append,
         &collector,
     );
-    if (c.mlirLogicalResultIsFailure(status)) {
+    if (c.beaverLogicalResultIsFailure(status)) {
         c.mlirEmitError(request.location, "failed to infer shaped operation return components");
         return beam.make_atom(environment, "error");
     }

--- a/native/src/llvm_ir.zig
+++ b/native/src/llvm_ir.zig
@@ -27,7 +27,7 @@ const Translation = struct {
         defer self.buffer.deinit();
 
         const status = c.beaverTranslateModuleToLLVMIRText(operation, appendString, &self);
-        if (c.mlirLogicalResultIsFailure(status))
+        if (c.beaverLogicalResultIsFailure(status))
             return beam.make_atom(environment, "error");
 
         return beam.make_slice(environment, self.buffer.items);


### PR DESCRIPTION
## What changed

- route LLVM IR translation logical-result checks through the exported Beaver C helper
- route InferType and InferShapedType collector result checks through the same stable C ABI boundary

## Why

Zig 0.16 miscompiles the translated inline `mlirLogicalResultIsFailure` helper on Apple arm64. In ReleaseSafe it treats successful results as failures; in Debug it can trigger a stack-check trap. The underlying MLIR calls succeed.

Using the existing exported `beaverLogicalResultIsFailure` helper avoids the one-byte `MlirLogicalResult` inline ABI/optimization boundary already avoided elsewhere in Beaver.

## Impact

The macOS precompiled-NIF lane can successfully export LLVM IR and collect inferred types again. Linux and Windows retain the same C ABI behavior.

## Validation

- macOS Debug targeted tests: 7 passed
- macOS ReleaseSafe targeted tests: 7 passed
- full tracked test suite: 406 passed, 30 excluded
- `zig fmt --check native/src/llvm_ir.zig native/src/infer_type.zig`
- `git diff --check`