### PR TITLE
ex: receive-after timeout intrinsics (monotonic clock and per-process start)

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -100,6 +100,9 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.mailbox_peek", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.mailbox_remove", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.nil_word", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.monotonic_time", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.receive_start", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.receive_start_set", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.current_entry", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.process_done", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.processes_runnable", &convert_term_read/3, version: "1.0")
@@ -190,6 +193,9 @@ defmodule Beaver.MLIR.Conversion.Ex do
     mailbox_peek: "ex.term.mailbox_peek",
     mailbox_remove: "ex.term.mailbox_remove",
     nil_word: "ex.term.nil",
+    monotonic_time: "ex.term.monotonic_time",
+    receive_start: "ex.term.receive_start",
+    receive_start_set: "ex.term.receive_start_set",
     current_entry: "ex.term.current_entry",
     process_done: "ex.term.process_done",
     processes_runnable: "ex.term.processes_runnable",
@@ -907,6 +913,9 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.mailbox_peek"), do: @term_intrinsics.mailbox_peek
   defp read_intrinsic("ex.mailbox_remove"), do: @term_intrinsics.mailbox_remove
   defp read_intrinsic("ex.nil_word"), do: @term_intrinsics.nil_word
+  defp read_intrinsic("ex.monotonic_time"), do: @term_intrinsics.monotonic_time
+  defp read_intrinsic("ex.receive_start"), do: @term_intrinsics.receive_start
+  defp read_intrinsic("ex.receive_start_set"), do: @term_intrinsics.receive_start_set
   defp read_intrinsic("ex.current_entry"), do: @term_intrinsics.current_entry
   defp read_intrinsic("ex.process_done"), do: @term_intrinsics.process_done
   defp read_intrinsic("ex.processes_runnable"), do: @term_intrinsics.processes_runnable
@@ -1156,6 +1165,18 @@ defmodule Beaver.MLIR.Conversion.Ex do
 
   defp intrinsic_function_type("ex.term.nil", _ctx) do
     MLIR.Type.function([], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.monotonic_time", _ctx) do
+    MLIR.Type.function([], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.receive_start", _ctx) do
+    MLIR.Type.function([], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.receive_start_set", _ctx) do
+    MLIR.Type.function([MLIR.Type.i64()], [MLIR.Type.i64()])
   end
 
   defp intrinsic_function_type("ex.term.current_entry", _ctx) do

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -205,6 +205,15 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop nil_word(),
     results: [result: base(dyn())]
 
+  defop monotonic_time(),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
+  defop receive_start(),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
+  defop receive_start_set(value = all_of([base("!builtin.integer"), any()])),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
   defop current_entry(),
     results: [result: all_of([base("!builtin.integer"), any()])]
 

--- a/lib/beaver/wasm/term_abi.ex
+++ b/lib/beaver/wasm/term_abi.ex
@@ -42,6 +42,9 @@ defmodule Beaver.Wasm.TermABI do
     "ex.term.mailbox_peek" => %{params: [:i64], result: :i64},
     "ex.term.mailbox_remove" => %{params: [:i64], result: :i64},
     "ex.term.nil" => %{params: [], result: :i64},
+    "ex.term.monotonic_time" => %{params: [], result: :i64},
+    "ex.term.receive_start" => %{params: [], result: :i64},
+    "ex.term.receive_start_set" => %{params: [:i64], result: :i64},
     "ex.term.mailbox_clear" => %{params: [], result: :i64},
     # process table / scheduler driver
     "ex.term.spawn" => %{params: [:i64], result: :i64},

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -704,11 +704,14 @@ defmodule ExConversionTest do
             %16 = "ex.mailbox_peek"(%0) : (i64) -> !ex.dyn
             %17 = "ex.mailbox_remove"(%0) : (i64) -> i64
             %18 = "ex.nil_word"() : () -> !ex.dyn
-            %19 = "ex.current_entry"() : () -> i64
-            %20 = "ex.process_done"(%0) : (i64) -> i64
-            %21 = "ex.processes_runnable"() : () -> i64
-            %22 = "ex.process_result"(%4) : (!ex.dyn) -> i64
-            "ex.return"(%21) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+            %19 = "ex.monotonic_time"() : () -> i64
+            %20 = "ex.receive_start"() : () -> i64
+            %21 = "ex.receive_start_set"(%0) : (i64) -> i64
+            %22 = "ex.current_entry"() : () -> i64
+            %23 = "ex.process_done"(%0) : (i64) -> i64
+            %24 = "ex.processes_runnable"() : () -> i64
+            %25 = "ex.process_result"(%4) : (!ex.dyn) -> i64
+            "ex.return"(%24) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
           }) {sym_name = "main"} : () -> ()
         }
         """,
@@ -733,6 +736,9 @@ defmodule ExConversionTest do
     assert rendered =~ "ex.term.mailbox_peek"
     assert rendered =~ "ex.term.mailbox_remove"
     assert rendered =~ "ex.term.nil"
+    assert rendered =~ "ex.term.monotonic_time"
+    assert rendered =~ "ex.term.receive_start"
+    assert rendered =~ "ex.term.receive_start_set"
     assert rendered =~ "ex.term.current_entry"
     assert rendered =~ "ex.term.process_done"
     assert rendered =~ "ex.term.processes_runnable"


### PR DESCRIPTION
## Summary

Slice 7 of tsai/beaver#35 ( timeouts): intrinsics for the preemptible wait loop.

- `ex.monotonic_time`: wall-clock milliseconds (monotonic) for timeout comparisons
- `ex.receive_start` / `ex.receive_start_set`: per-process timeout start slot (0 = timing not started)
- wasm TermABI manifest updated

## Tests

ex_conversion_test: new ops lower to `ex.term.*` calls; wasm_term_abi_test coverage exact. Full suite 409/413 (4 remaining failures are environmental WasmPackagingTest/Shadow.WasmTest — mlir-translate/node not on PATH, unrelated).