### PR TITLE
triton: thread compute-capability/ptx-version from the target

### DIFF
--- a/lib/beaver/mlir/triton.ex
+++ b/lib/beaver/mlir/triton.ex
@@ -66,6 +66,15 @@ defmodule Beaver.Triton do
     num_warps = Keyword.get(opts, :num_warps, 4)
     remove_layouts? = Keyword.get(opts, :remove_layout_conversions, true)
     from_ttgir? = Keyword.get(opts, :from_ttgir, false)
+    # `convert-triton-gpu-to-llvm` (and the NV passes with the same options)
+    # take compute-capability/ptx-version as pass options; driven by name they
+    # default to 80, which breaks fp8 lowering on sm_89+ targets. Derive them
+    # from the target string (cuda:120 -> 120).
+    capability =
+      case Regex.run(~r/cuda:(\d+)/, target) do
+        [_, cc] -> String.to_integer(cc)
+        _ -> 80
+      end
 
     ttgpu_pipeline =
       [
@@ -93,12 +102,16 @@ defmodule Beaver.Triton do
       |> Beaver.Composer.append("tritongpu-combine-tensor-select-and-if")
       |> Beaver.Composer.append("tritongpu-allocate-warp-groups")
       |> Beaver.Composer.append("convert-scf-to-cf")
-      |> Beaver.Composer.append("allocate-shared-memory-nv")
+      |> Beaver.Composer.append(
+        "allocate-shared-memory-nv{compute-capability=#{capability} ptx-version=#{capability}}"
+      )
       |> Beaver.Composer.append("triton-tensor-memory-allocation")
       |> Beaver.Composer.append("triton-nvidia-check-matmul-two-cta")
       |> Beaver.Composer.append("triton-nvidia-gpu-proxy-fence-insertion")
       |> Beaver.Composer.append("triton-nvidia-gpu-tmem-barrier-insertion")
-      |> Beaver.Composer.append("convert-triton-gpu-to-llvm")
+      |> Beaver.Composer.append(
+        "convert-triton-gpu-to-llvm{compute-capability=#{capability} ptx-version=#{capability}}"
+      )
       |> Beaver.Composer.append("convert-warp-specialize-to-llvm")
       |> Beaver.Composer.append("convert-nv-gpu-to-llvm")
       |> Beaver.Composer.append("convert-nvvm-to-llvm")


### PR DESCRIPTION
When the Triton pipeline is driven by pass name, `convert-triton-gpu-to-llvm` (and `allocate-shared-memory-nv`) use their default compute-capability/ptx-version of 80. That breaks fp8 lowering on sm_89+ targets with `LLVM ERROR: Conversion from/to f8e4m3nv is only supported on compute capability >= 89`.

Derive both options from the `cuda:NN` target in `Beaver.Triton.compile_to_llvm/2`. Note the pass registration in the pinned Triton prebuilt rejects the comma-separated option form, so the options are space-separated.

Unblocks fp8 (e4m3) tensor-core kernels in mycelium on sm_120.