### PR TITLE
Remove the mlir-translate executable dependency

### DIFF
--- a/lib/beaver/mlir/debug.ex
+++ b/lib/beaver/mlir/debug.ex
@@ -14,8 +14,8 @@ defmodule Beaver.MLIR.Debug do
   (and a compile unit derived from the module location) to every `llvm.func`.
   After it runs:
 
-    * `mlir-translate --mlir-to-llvmir` emits `!dbg` and `!DILocation` metadata
-      pointing at the original `.exs` files and lines;
+    * `Beaver.MLIR.Target.LLVMIR.translate!/1` emits `!dbg` and `!DILocation`
+      metadata pointing at the original `.exs` files and lines;
     * `Beaver.MLIR.ExecutionEngine.create!(module, debug_info: true)` produces a
       JIT object whose line table is registered with gdb (MLIR's execution
       engine enables its GDB notification listener by default), so

--- a/lib/beaver/mlir/shadow/optimization_trial.ex
+++ b/lib/beaver/mlir/shadow/optimization_trial.ex
@@ -164,8 +164,7 @@ defmodule Beaver.Shadow.OptimizationTrial do
     result =
       try do
         llvm = Beaver.Triton.compile_to_llvm(module, Keyword.put(compile_opts, :target, target))
-        llvm_text = MLIR.to_string(llvm)
-        ptx = llvm_to_ptx(llvm_text)
+        ptx = llvm_to_ptx(llvm)
         launch_latency_ns(ptx, launch)
       rescue
         exception ->
@@ -177,14 +176,14 @@ defmodule Beaver.Shadow.OptimizationTrial do
     result
   end
 
-  defp llvm_to_ptx(llvm_text) do
+  defp llvm_to_ptx(llvm) do
     llvm_path =
       Path.join(System.tmp_dir!(), "shadow_trial_#{System.unique_integer([:positive])}.ll")
 
     ptx_path =
       Path.join(System.tmp_dir!(), "shadow_trial_#{System.unique_integer([:positive])}.ptx")
 
-    File.write!(llvm_path, llvm_text)
+    File.write!(llvm_path, Beaver.MLIR.Target.LLVMIR.translate!(llvm))
 
     llvm_bin =
       System.get_env("LLVM_CONFIG_PATH")
@@ -192,21 +191,13 @@ defmodule Beaver.Shadow.OptimizationTrial do
 
     {_, 0} =
       System.cmd(
-        Path.join(llvm_bin, "mlir-translate"),
-        ["--mlir-to-llvmir", llvm_path, "-o", llvm_path <> ".ll"],
-        stderr_to_stdout: true
-      )
-
-    {_, 0} =
-      System.cmd(
         Path.join(llvm_bin, "llc"),
-        ["-march=nvptx64", "-mcpu=sm_80", llvm_path <> ".ll", "-o", ptx_path],
+        ["-march=nvptx64", "-mcpu=sm_80", llvm_path, "-o", ptx_path],
         stderr_to_stdout: true
       )
 
     ptx = File.read!(ptx_path)
     File.rm!(llvm_path)
-    File.rm!(llvm_path <> ".ll")
     File.rm!(ptx_path)
     ptx
   end

--- a/lib/beaver/shadow/tuning/gpu.ex
+++ b/lib/beaver/shadow/tuning/gpu.ex
@@ -37,7 +37,7 @@ defmodule Beaver.Shadow.Tuning.GPU do
           num_warps: num_warps
         )
 
-      ptx = llvm_to_ptx(MLIR.to_string(llvm))
+      ptx = llvm_to_ptx(llvm)
       {:ok, launch_latency_ns(ptx, launch, num_warps)}
     rescue
       exception -> {:error, Exception.message(exception)}
@@ -105,14 +105,14 @@ defmodule Beaver.Shadow.Tuning.GPU do
     end
   end
 
-  defp llvm_to_ptx(llvm_text) do
+  defp llvm_to_ptx(llvm) do
     llvm_path =
       Path.join(System.tmp_dir!(), "shadow_tune_#{System.unique_integer([:positive])}.ll")
 
     ptx_path =
       Path.join(System.tmp_dir!(), "shadow_tune_#{System.unique_integer([:positive])}.ptx")
 
-    File.write!(llvm_path, llvm_text)
+    File.write!(llvm_path, Beaver.MLIR.Target.LLVMIR.translate!(llvm))
 
     llvm_bin =
       System.get_env("LLVM_CONFIG_PATH")
@@ -120,21 +120,13 @@ defmodule Beaver.Shadow.Tuning.GPU do
 
     {_, 0} =
       System.cmd(
-        Path.join(llvm_bin, "mlir-translate"),
-        ["--mlir-to-llvmir", llvm_path, "-o", llvm_path <> ".ll"],
-        stderr_to_stdout: true
-      )
-
-    {_, 0} =
-      System.cmd(
         Path.join(llvm_bin, "llc"),
-        ["-march=nvptx64", "-mcpu=sm_80", llvm_path <> ".ll", "-o", ptx_path],
+        ["-march=nvptx64", "-mcpu=sm_80", llvm_path, "-o", ptx_path],
         stderr_to_stdout: true
       )
 
     ptx = File.read!(ptx_path)
     File.rm!(llvm_path)
-    File.rm!(llvm_path <> ".ll")
     File.rm!(ptx_path)
     ptx
   end

--- a/lib/beaver/wasm.ex
+++ b/lib/beaver/wasm.ex
@@ -4,10 +4,10 @@ defmodule Beaver.Wasm do
   `gpu.binary` packaging.
 
   `package_binary!/2` lowers a module to LLVM IR (via the `ex` conversion
-  plan and the standard arith/scf/cf-to-llvm passes), translates it with
-  `mlir-translate --mlir-to-llvmir`, compiles it to a wasm binary with the
-  Zig wasm32 target, and returns a `Beaver.Wasm.Binary` carrying the bytes
-  plus the imports/exports manifest parsed from the binary.
+  plan and the standard arith/scf/cf-to-llvm passes), translates it in-process,
+  compiles it to a wasm binary with the Zig wasm32 target, and returns a
+  `Beaver.Wasm.Binary` carrying the bytes plus the imports/exports manifest
+  parsed from the binary.
 
   This is the host-boundary step of the batata WASM preparation (Forgejo
   #37): the manifest names the WASI/import surface that a runtime must
@@ -19,6 +19,7 @@ defmodule Beaver.Wasm do
 
   alias Beaver.MLIR
   alias Beaver.MLIR.Conversion.{Ex, Plan}
+  alias Beaver.MLIR.Target.LLVMIR
 
   @doc """
   Packages an MLIR module into a `Beaver.Wasm.Binary`.
@@ -53,16 +54,7 @@ defmodule Beaver.Wasm do
       |> reconcile_unrealized_casts()
       |> Beaver.Composer.run!()
 
-    mlir_path = tmp_path(".mlir")
-    ll_path = tmp_path(".ll")
-
-    File.write!(mlir_path, MLIR.to_string(llvm))
-
-    run_tool!(mlir_translate(), ["--mlir-to-llvmir", mlir_path, "-o", ll_path])
-
-    ir = File.read!(ll_path)
-    cleanup([mlir_path, ll_path])
-    ir
+    LLVMIR.translate!(llvm)
   end
 
   defp has_ex_ops?(module) do
@@ -98,13 +90,6 @@ defmodule Beaver.Wasm do
 
   defp zig do
     System.find_executable("zig") || raise "zig not found on PATH"
-  end
-
-  defp mlir_translate do
-    case System.get_env("LLVM_CONFIG_PATH") do
-      nil -> System.find_executable("mlir-translate") || raise("mlir-translate not found")
-      config -> Path.join([Path.dirname(config), "mlir-translate"])
-    end
   end
 
   defp run_tool!(executable, args) do

--- a/test/debug_test.exs
+++ b/test/debug_test.exs
@@ -86,29 +86,9 @@ defmodule DebugTest do
     assert once == twice
   end
 
-  @tag skip: System.get_env("LLVM_CONFIG_PATH") == nil
-  @tag :tmp_dir
-  test "LLVM IR translation emits DILocation metadata for Elixir lines", %{
-    ctx: ctx,
-    tmp_dir: tmp_dir
-  } do
+  test "LLVM IR translation emits DILocation metadata for Elixir lines", %{ctx: ctx} do
     module = ctx |> add_module() |> to_llvm() |> Beaver.MLIR.Debug.attach_llvm_scopes!()
-
-    mlir_path = Path.join(tmp_dir, "debug.mlir")
-    ll_path = Path.join(tmp_dir, "debug.ll")
-    File.write!(mlir_path, MLIR.to_string(module, debug_info: true))
-
-    llvm_bin = System.get_env("LLVM_CONFIG_PATH") |> Path.dirname()
-    mlir_translate = Path.join(llvm_bin, "mlir-translate")
-
-    {output, status} =
-      System.cmd(mlir_translate, ["--mlir-to-llvmir", mlir_path, "-o", ll_path],
-        stderr_to_stdout: true
-      )
-
-    assert status == 0, output
-
-    ir = File.read!(ll_path)
+    ir = Beaver.MLIR.Target.LLVMIR.translate!(module)
     assert ir =~ "!dbg"
     assert ir =~ "!DILocation("
     assert ir =~ ~s{!DIFile(filename: "debug_test.exs"}

--- a/test/shadow_gpu_test.exs
+++ b/test/shadow_gpu_test.exs
@@ -148,27 +148,19 @@ defmodule Beaver.Shadow.GPUTest do
     on_exit(fn -> MLIR.Module.destroy(module) end)
 
     llvm = Beaver.Triton.compile_to_llvm(module)
-    llvm_text = MLIR.to_string(llvm)
 
-    # translate LLVM IR to PTX through the prebuilt toolchain
+    # compile LLVM IR to PTX through the prebuilt toolchain
     tmp_dir = System.tmp_dir!()
     ll_path = Path.join(tmp_dir, "matmul_test.ll")
     ptx_path = Path.join(tmp_dir, "matmul_test.ptx")
-    File.write!(ll_path, llvm_text)
+    File.write!(ll_path, Beaver.MLIR.Target.LLVMIR.translate!(llvm))
 
     llvm_bin = Path.dirname(System.get_env("LLVM_CONFIG_PATH"))
 
     {_, 0} =
       System.cmd(
-        Path.join(llvm_bin, "mlir-translate"),
-        ["--mlir-to-llvmir", ll_path, "-o", ll_path <> ".ll"],
-        stderr_to_stdout: true
-      )
-
-    {_, 0} =
-      System.cmd(
         Path.join(llvm_bin, "llc"),
-        ["-march=nvptx64", "-mcpu=sm_80", ll_path <> ".ll", "-o", ptx_path],
+        ["-march=nvptx64", "-mcpu=sm_80", ll_path, "-o", ptx_path],
         stderr_to_stdout: true
       )
 

--- a/test/triton_test.exs
+++ b/test/triton_test.exs
@@ -98,18 +98,10 @@ defmodule TritonTest do
       |> Beaver.Composer.run!()
 
     llvm_bin = System.get_env("LLVM_CONFIG_PATH") |> Path.dirname()
-    mlir_path = Path.join(tmp_dir, "lowered.mlir")
     ll_path = Path.join(tmp_dir, "lowered.ll")
     ptx_path = Path.join(tmp_dir, "lowered.ptx")
 
-    File.write!(mlir_path, MLIR.to_string(lowered))
-
-    {_, 0} =
-      System.cmd(
-        Path.join(llvm_bin, "mlir-translate"),
-        ["--mlir-to-llvmir", mlir_path, "-o", ll_path],
-        stderr_to_stdout: true
-      )
+    File.write!(ll_path, Beaver.MLIR.Target.LLVMIR.translate!(lowered))
 
     {ptx_output, 0} =
       System.cmd(


### PR DESCRIPTION
## What changed

Use `Beaver.MLIR.Target.LLVMIR.translate!/1` for WASM packaging, Triton/Shadow PTX preparation, and debug translation tests. All temporary MLIR files and `mlir-translate` subprocess calls are removed.

## Why

Beaver already owns a safe in-process MLIR-to-LLVM-IR bridge, so requiring the companion executable adds deployment surface and duplicate serialization work.

## Validation

- repository search contains no `mlir-translate` references
- full local suite: 414 passed, 5 skipped
- focused debug/WASM suite after rebasing onto main: 8 passed