### PR TITLE
Remove the llc executable dependency

### DIFF
--- a/lib/beaver/mlir/capi_handwritten.ex
+++ b/lib/beaver/mlir/capi_handwritten.ex
@@ -31,6 +31,7 @@ defmodule Beaver.MLIR.CAPI.Handwritten do
     beaver_raw_infer_return_types: 7,
     beaver_raw_infer_return_type_components: 7,
     beaver_raw_translate_module_to_llvm_ir: 1,
+    beaver_raw_compile_llvm_ir_to_ptx: 3,
     beaver_raw_transform_state_payload_ops: 2,
     beaver_raw_transform_state_payload_values: 2,
     beaver_raw_transform_state_params: 2,

--- a/lib/beaver/mlir/shadow/optimization_trial.ex
+++ b/lib/beaver/mlir/shadow/optimization_trial.ex
@@ -177,29 +177,9 @@ defmodule Beaver.Shadow.OptimizationTrial do
   end
 
   defp llvm_to_ptx(llvm) do
-    llvm_path =
-      Path.join(System.tmp_dir!(), "shadow_trial_#{System.unique_integer([:positive])}.ll")
-
-    ptx_path =
-      Path.join(System.tmp_dir!(), "shadow_trial_#{System.unique_integer([:positive])}.ptx")
-
-    File.write!(llvm_path, Beaver.MLIR.Target.LLVMIR.translate!(llvm))
-
-    llvm_bin =
-      System.get_env("LLVM_CONFIG_PATH")
-      |> Path.dirname()
-
-    {_, 0} =
-      System.cmd(
-        Path.join(llvm_bin, "llc"),
-        ["-march=nvptx64", "-mcpu=sm_80", llvm_path, "-o", ptx_path],
-        stderr_to_stdout: true
-      )
-
-    ptx = File.read!(ptx_path)
-    File.rm!(llvm_path)
-    File.rm!(ptx_path)
-    ptx
+    llvm
+    |> Beaver.MLIR.Target.LLVMIR.translate!()
+    |> Beaver.MLIR.Target.LLVMIR.compile_to_ptx!(cpu: "sm_80")
   end
 
   defp launch_latency_ns(ptx, launch) do

--- a/lib/beaver/mlir/target/llvmir.ex
+++ b/lib/beaver/mlir/target/llvmir.ex
@@ -35,4 +35,26 @@ defmodule Beaver.MLIR.Target.LLVMIR do
               MLIR.Diagnostic.format(diagnostics, "failed to translate module to LLVM IR")
     end
   end
+
+  @doc "Compile textual LLVM IR to NVPTX assembly in-process."
+  @spec compile_to_ptx(binary(), keyword()) :: {:ok, binary()} | {:error, binary()}
+  def compile_to_ptx(llvm_ir, opts \\ []) when is_binary(llvm_ir) and is_list(opts) do
+    cpu = Keyword.get(opts, :cpu, "sm_80")
+    features = Keyword.get(opts, :features, "")
+
+    unless is_binary(cpu) and is_binary(features) do
+      raise ArgumentError, ":cpu and :features must be strings"
+    end
+
+    MLIR.CAPI.beaver_raw_compile_llvm_ir_to_ptx(llvm_ir, cpu, features)
+  end
+
+  @doc "Compile textual LLVM IR to NVPTX assembly, raising on failure."
+  @spec compile_to_ptx!(binary(), keyword()) :: binary()
+  def compile_to_ptx!(llvm_ir, opts \\ []) do
+    case compile_to_ptx(llvm_ir, opts) do
+      {:ok, ptx} -> ptx
+      {:error, message} -> raise ArgumentError, "failed to compile LLVM IR to PTX: #{message}"
+    end
+  end
 end

--- a/lib/beaver/shadow/tuning/gpu.ex
+++ b/lib/beaver/shadow/tuning/gpu.ex
@@ -106,29 +106,9 @@ defmodule Beaver.Shadow.Tuning.GPU do
   end
 
   defp llvm_to_ptx(llvm) do
-    llvm_path =
-      Path.join(System.tmp_dir!(), "shadow_tune_#{System.unique_integer([:positive])}.ll")
-
-    ptx_path =
-      Path.join(System.tmp_dir!(), "shadow_tune_#{System.unique_integer([:positive])}.ptx")
-
-    File.write!(llvm_path, Beaver.MLIR.Target.LLVMIR.translate!(llvm))
-
-    llvm_bin =
-      System.get_env("LLVM_CONFIG_PATH")
-      |> Path.dirname()
-
-    {_, 0} =
-      System.cmd(
-        Path.join(llvm_bin, "llc"),
-        ["-march=nvptx64", "-mcpu=sm_80", llvm_path, "-o", ptx_path],
-        stderr_to_stdout: true
-      )
-
-    ptx = File.read!(ptx_path)
-    File.rm!(llvm_path)
-    File.rm!(ptx_path)
-    ptx
+    llvm
+    |> Beaver.MLIR.Target.LLVMIR.translate!()
+    |> Beaver.MLIR.Target.LLVMIR.compile_to_ptx!(cpu: "sm_80")
   end
 
   defp alloc_buffers(buffer_sizes) do

--- a/native/include/mlir-c/Beaver/CAPIPolicy.h
+++ b/native/include/mlir-c/Beaver/CAPIPolicy.h
@@ -20,6 +20,7 @@ typedef enum {
   BeaverCapiPolicyManualAdapter__mlirTransformStateForEachPayloadOp,
   BeaverCapiPolicyManualAdapter__mlirTransformStateForEachPayloadValue,
   BeaverCapiPolicyManualAdapter__beaverTranslateModuleToLLVMIRText,
+  BeaverCapiPolicyManualAdapter__beaverCompileLLVMIRToPTX,
 
   BeaverCapiPolicyManualRuntime__mlirValueReplaceUsesWithIf,
 

--- a/native/include/mlir-c/Beaver/LLVMIR.h
+++ b/native/include/mlir-c/Beaver/LLVMIR.h
@@ -14,6 +14,14 @@ extern "C" {
 MLIR_CAPI_EXPORTED MlirLogicalResult beaverTranslateModuleToLLVMIRText(
     MlirOperation module, MlirStringCallback callback, void *userData);
 
+/// Compiles textual LLVM IR to NVPTX assembly and streams the result to
+/// outputCallback. Diagnostics are streamed to errorCallback. All temporary
+/// LLVM objects and buffers are owned and released by this call.
+MLIR_CAPI_EXPORTED MlirLogicalResult beaverCompileLLVMIRToPTX(
+    MlirStringRef llvmIR, MlirStringRef cpu, MlirStringRef features,
+    MlirStringCallback outputCallback, MlirStringCallback errorCallback,
+    void *userData);
+
 #ifdef __cplusplus
 }
 #endif

--- a/native/lib/CAPI/BeaverLLVMIR.cpp
+++ b/native/lib/CAPI/BeaverLLVMIR.cpp
@@ -1,9 +1,43 @@
 #include "mlir-c/Beaver/LLVMIR.h"
 
 #include "llvm-c/Core.h"
+#include "llvm-c/IRReader.h"
+#include "llvm-c/Target.h"
+#include "llvm-c/TargetMachine.h"
 #include "mlir-c/Target/LLVMIR.h"
 
 #include <cstring>
+#include <mutex>
+#include <string>
+
+namespace {
+
+void initializeNVPTX() {
+  static std::once_flag once;
+  std::call_once(once, [] {
+    LLVMInitializeNVPTXTargetInfo();
+    LLVMInitializeNVPTXTarget();
+    LLVMInitializeNVPTXTargetMC();
+    LLVMInitializeNVPTXAsmPrinter();
+  });
+}
+
+void emitString(MlirStringCallback callback, void *userData,
+                const char *message) {
+  if (callback && message)
+    callback(mlirStringRefCreate(message, std::strlen(message)), userData);
+}
+
+MlirLogicalResult failWithMessage(MlirStringCallback callback, void *userData,
+                                  char *message) {
+  emitString(callback, userData,
+             message ? message : "LLVM target compilation failed");
+  if (message)
+    LLVMDisposeMessage(message);
+  return mlirLogicalResultFailure();
+}
+
+} // namespace
 
 MlirLogicalResult beaverTranslateModuleToLLVMIRText(
     MlirOperation module, MlirStringCallback callback, void *userData) {
@@ -31,5 +65,73 @@ MlirLogicalResult beaverTranslateModuleToLLVMIRText(
   LLVMDisposeMessage(message);
   LLVMDisposeModule(llvmModule);
   LLVMContextDispose(llvmContext);
+  return mlirLogicalResultSuccess();
+}
+
+MlirLogicalResult beaverCompileLLVMIRToPTX(
+    MlirStringRef llvmIR, MlirStringRef cpu, MlirStringRef features,
+    MlirStringCallback outputCallback, MlirStringCallback errorCallback,
+    void *userData) {
+  if (!llvmIR.data || !outputCallback)
+    return mlirLogicalResultFailure();
+
+  initializeNVPTX();
+
+  const std::string triple = "nvptx64-nvidia-cuda";
+  const std::string cpuString(cpu.data ? cpu.data : "", cpu.length);
+  const std::string featureString(features.data ? features.data : "",
+                                  features.length);
+
+  LLVMContextRef context = LLVMContextCreate();
+  LLVMMemoryBufferRef input = LLVMCreateMemoryBufferWithMemoryRangeCopy(
+      llvmIR.data, llvmIR.length, "beaver.ll");
+  LLVMModuleRef module = nullptr;
+  char *message = nullptr;
+
+  if (LLVMParseIRInContext2(context, input, &module, &message)) {
+    LLVMDisposeMemoryBuffer(input);
+    LLVMContextDispose(context);
+    return failWithMessage(errorCallback, userData, message);
+  }
+  LLVMDisposeMemoryBuffer(input);
+
+  LLVMTargetRef target = nullptr;
+  if (LLVMGetTargetFromTriple(triple.c_str(), &target, &message)) {
+    LLVMDisposeModule(module);
+    LLVMContextDispose(context);
+    return failWithMessage(errorCallback, userData, message);
+  }
+
+  LLVMTargetMachineRef machine = LLVMCreateTargetMachine(
+      target, triple.c_str(), cpuString.c_str(), featureString.c_str(),
+      LLVMCodeGenLevelDefault, LLVMRelocDefault, LLVMCodeModelDefault);
+  if (!machine) {
+    LLVMDisposeModule(module);
+    LLVMContextDispose(context);
+    emitString(errorCallback, userData, "failed to create NVPTX target machine");
+    return mlirLogicalResultFailure();
+  }
+
+  LLVMSetTarget(module, triple.c_str());
+  LLVMTargetDataRef layout = LLVMCreateTargetDataLayout(machine);
+  LLVMSetModuleDataLayout(module, layout);
+  LLVMDisposeTargetData(layout);
+
+  LLVMMemoryBufferRef output = nullptr;
+  if (LLVMTargetMachineEmitToMemoryBuffer(machine, module, LLVMAssemblyFile,
+                                          &message, &output)) {
+    LLVMDisposeTargetMachine(machine);
+    LLVMDisposeModule(module);
+    LLVMContextDispose(context);
+    return failWithMessage(errorCallback, userData, message);
+  }
+
+  outputCallback(mlirStringRefCreate(LLVMGetBufferStart(output),
+                                     LLVMGetBufferSize(output)),
+                 userData);
+  LLVMDisposeMemoryBuffer(output);
+  LLVMDisposeTargetMachine(machine);
+  LLVMDisposeModule(module);
+  LLVMContextDispose(context);
   return mlirLogicalResultSuccess();
 }

--- a/native/lib/CAPI/CMakeLists.txt
+++ b/native/lib/CAPI/CMakeLists.txt
@@ -14,7 +14,12 @@ add_mlir_public_c_api_library(
   Triton.cpp
   LINK_LIBS
   PUBLIC
-  MLIRDebug)
+  MLIRDebug
+  LLVMCore
+  LLVMIRReader
+  LLVMTarget
+  LLVMCodeGen
+  LLVMNVPTXCodeGen)
 
 if(BEAVER_TRITON_PREBUILT_DIR)
   foreach(_target MLIRCAPIBeaver obj.MLIRCAPIBeaver)

--- a/native/src/llvm_ir.zig
+++ b/native/src/llvm_ir.zig
@@ -49,11 +49,64 @@ const Translation = struct {
     }
 };
 
+const PTXCompilation = struct {
+    const Buffer = std.array_list.Managed(u8);
+
+    output: Buffer,
+    error_message: Buffer,
+
+    fn appendOutput(value: mlir_capi.StringRef.T, user_data: ?*anyopaque) callconv(.c) void {
+        const self: *@This() = @ptrCast(@alignCast(user_data orelse return));
+        self.output.appendSlice(value.data[0..value.length]) catch @panic("failed to collect PTX");
+    }
+
+    fn appendError(value: mlir_capi.StringRef.T, user_data: ?*anyopaque) callconv(.c) void {
+        const self: *@This() = @ptrCast(@alignCast(user_data orelse return));
+        self.error_message.appendSlice(value.data[0..value.length]) catch @panic("failed to collect LLVM target diagnostic");
+    }
+
+    fn compile(environment: beam.env, _: c_int, args: [*c]const beam.term) !beam.term {
+        const llvm_ir = try beam.get_binary(environment, args[0]);
+        const cpu = try beam.get_binary(environment, args[1]);
+        const features = try beam.get_binary(environment, args[2]);
+        var self = @This(){
+            .output = Buffer.init(beam.allocator),
+            .error_message = Buffer.init(beam.allocator),
+        };
+        defer self.output.deinit();
+        defer self.error_message.deinit();
+
+        const status = c.beaverCompileLLVMIRToPTX(
+            c.mlirStringRefCreate(llvm_ir.data, llvm_ir.size),
+            c.mlirStringRefCreate(cpu.data, cpu.size),
+            c.mlirStringRefCreate(features.data, features.size),
+            appendOutput,
+            appendError,
+            &self,
+        );
+        if (c.beaverLogicalResultIsFailure(status)) {
+            const message = if (self.error_message.items.len == 0)
+                "LLVM target compilation failed"
+            else
+                self.error_message.items;
+            return beam.make_error_binary(environment, message);
+        }
+
+        return beam.make_ok_binary(environment, self.output.items);
+    }
+};
+
 pub const nifs = .{
     result.nif_with_flags(
         "beaver_raw_translate_module_to_llvm_ir",
         1,
         Translation.translate,
+        e.ERL_NIF_DIRTY_JOB_CPU_BOUND,
+    ).entry,
+    result.nif_with_flags(
+        "beaver_raw_compile_llvm_ir_to_ptx",
+        3,
+        PTXCompilation.compile,
         e.ERL_NIF_DIRTY_JOB_CPU_BOUND,
     ).entry,
 };

--- a/native/tools/capi/gen_manifest.exs
+++ b/native/tools/capi/gen_manifest.exs
@@ -36,6 +36,14 @@ defmodule Beaver.CAPI.ManifestGenerator do
       "lifetime" => "nif_call",
       "destructor" => "native_owner"
     },
+    "beaverCompileLLVMIRToPTX" => %{
+      "wrapper_name" => "beaver_raw_compile_llvm_ir_to_ptx",
+      "runtime" => "native_collector",
+      "scheduler" => "dirty_cpu",
+      "owner" => "caller",
+      "lifetime" => "nif_call",
+      "destructor" => "native_owner"
+    },
     "mlirTransformStateForEachPayloadOp" => %{
       "wrapper_name" => "beaver_raw_transform_state_payload_ops",
       "runtime" => "native_collector",

--- a/test/capi_manifest_test.exs
+++ b/test/capi_manifest_test.exs
@@ -168,6 +168,7 @@ defmodule Beaver.MLIR.CAPI.ManifestTest do
     assert Enum.map(collector_entries, &get_in(&1, ["callback_bridge", "wrapper_name"]))
            |> MapSet.new() ==
              MapSet.new([
+               "beaver_raw_compile_llvm_ir_to_ptx",
                "beaver_raw_translate_module_to_llvm_ir",
                "beaver_raw_infer_return_types",
                "beaver_raw_infer_return_type_components",
@@ -176,10 +177,13 @@ defmodule Beaver.MLIR.CAPI.ManifestTest do
                "beaver_raw_transform_state_payload_values"
              ])
 
-    {llvm_ir_entries, transform_collector_entries} =
+    {llvm_entries, transform_collector_entries} =
       Enum.split_with(
         collector_entries,
-        &(get_in(&1, ["function", "name"]) == "beaverTranslateModuleToLLVMIRText")
+        &(get_in(&1, ["function", "name"]) in [
+            "beaverCompileLLVMIRToPTX",
+            "beaverTranslateModuleToLLVMIRText"
+          ])
       )
 
     for entry <- transform_collector_entries do
@@ -192,16 +196,22 @@ defmodule Beaver.MLIR.CAPI.ManifestTest do
       assert bridge["facets"] == ["native_collector", "context_owned_handles"]
     end
 
-    assert [llvm_ir_entry] = llvm_ir_entries
+    assert Enum.map(llvm_entries, &get_in(&1, ["callback_bridge", "wrapper_name"]))
+           |> MapSet.new() ==
+             MapSet.new([
+               "beaver_raw_compile_llvm_ir_to_ptx",
+               "beaver_raw_translate_module_to_llvm_ir"
+             ])
 
-    assert %{
-             "wrapper_name" => "beaver_raw_translate_module_to_llvm_ir",
-             "runtime_backed" => true,
-             "scheduler" => "dirty_cpu",
-             "owner" => "caller",
-             "destructor" => "native_owner",
-             "lifetime" => "nif_call"
-           } = llvm_ir_entry["callback_bridge"]
+    for entry <- llvm_entries do
+      assert %{
+               "runtime_backed" => true,
+               "scheduler" => "dirty_cpu",
+               "owner" => "caller",
+               "destructor" => "native_owner",
+               "lifetime" => "nif_call"
+             } = entry["callback_bridge"]
+    end
 
     assert [manual_runtime] = manual_runtime_entries
     assert get_in(manual_runtime, ["function", "name"]) == "mlirValueReplaceUsesWithIf"

--- a/test/llvm_ir_target_test.exs
+++ b/test/llvm_ir_target_test.exs
@@ -56,4 +56,19 @@ defmodule Beaver.MLIR.Target.LLVMIRTest do
       assert llvm_ir =~ "define void @noop()"
     end
   end
+
+  test "compiles LLVM IR to NVPTX assembly in-process" do
+    llvm_ir = """
+    define void @kernel() {
+      ret void
+    }
+    """
+
+    assert {:ok, ptx} = LLVMIR.compile_to_ptx(llvm_ir, cpu: "sm_80")
+    assert ptx =~ ".target sm_80"
+    assert ptx =~ "kernel"
+
+    assert {:error, message} = LLVMIR.compile_to_ptx("not LLVM IR")
+    assert message != ""
+  end
 end

--- a/test/shadow_gpu_test.exs
+++ b/test/shadow_gpu_test.exs
@@ -150,21 +150,11 @@ defmodule Beaver.Shadow.GPUTest do
     llvm = Beaver.Triton.compile_to_llvm(module)
 
     # compile LLVM IR to PTX through the prebuilt toolchain
-    tmp_dir = System.tmp_dir!()
-    ll_path = Path.join(tmp_dir, "matmul_test.ll")
-    ptx_path = Path.join(tmp_dir, "matmul_test.ptx")
-    File.write!(ll_path, Beaver.MLIR.Target.LLVMIR.translate!(llvm))
+    ptx =
+      llvm
+      |> Beaver.MLIR.Target.LLVMIR.translate!()
+      |> Beaver.MLIR.Target.LLVMIR.compile_to_ptx!(cpu: "sm_80")
 
-    llvm_bin = Path.dirname(System.get_env("LLVM_CONFIG_PATH"))
-
-    {_, 0} =
-      System.cmd(
-        Path.join(llvm_bin, "llc"),
-        ["-march=nvptx64", "-mcpu=sm_80", ll_path, "-o", ptx_path],
-        stderr_to_stdout: true
-      )
-
-    ptx = File.read!(ptx_path)
     assert ptx =~ ".visible .entry matmul_kernel_"
 
     escaped =

--- a/test/triton_test.exs
+++ b/test/triton_test.exs
@@ -73,8 +73,7 @@ defmodule TritonTest do
   end
 
   @tag skip: !@enabled
-  @tag :tmp_dir
-  test "compiles a Triton kernel to PTX on the CPU", %{ctx: ctx, tmp_dir: tmp_dir} do
+  test "compiles a Triton kernel to PTX on the CPU", %{ctx: ctx} do
     Beaver.Triton.register(ctx)
 
     module =
@@ -97,22 +96,12 @@ defmodule TritonTest do
       |> Beaver.Composer.append("canonicalize")
       |> Beaver.Composer.run!()
 
-    llvm_bin = System.get_env("LLVM_CONFIG_PATH") |> Path.dirname()
-    ll_path = Path.join(tmp_dir, "lowered.ll")
-    ptx_path = Path.join(tmp_dir, "lowered.ptx")
+    ptx =
+      lowered
+      |> Beaver.MLIR.Target.LLVMIR.translate!()
+      |> Beaver.MLIR.Target.LLVMIR.compile_to_ptx!(cpu: "sm_90")
 
-    File.write!(ll_path, Beaver.MLIR.Target.LLVMIR.translate!(lowered))
-
-    {ptx_output, 0} =
-      System.cmd(
-        Path.join(llvm_bin, "llc"),
-        ["-march=nvptx64", "-mcpu=sm_90", ll_path, "-o", ptx_path],
-        stderr_to_stdout: true
-      )
-
-    ptx = File.read!(ptx_path)
     assert ptx =~ ".visible .entry addptr"
     assert ptx =~ ".target sm_90"
-    assert ptx_output == ""
   end
 end


### PR DESCRIPTION
Stacked on #612.

## Summary
- add an in-process LLVM TargetMachine bridge for LLVM IR to NVPTX assembly
- expose `compile_to_ptx/2` and `compile_to_ptx!/2` through `Beaver.MLIR.Target.LLVMIR`
- replace all `llc` subprocess and temporary-file usage in Triton and Shadow paths
- describe the native collector in the C API manifest and cover success/error behavior

## Validation
- `mix test test/llvm_ir_target_test.exs test/capi_manifest_test.exs` (9 passed)
- `mix test --exclude vulkan --exclude todo` (415 passed, 5 skipped, 21 excluded)
- no remaining `llc` or `mlir-translate` references after this stack