### PR TITLE
ex: native_time and unique_integer logical-clock intrinsics

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -103,6 +103,8 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.monotonic_time", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.receive_start", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.receive_start_set", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.native_time", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.unique_integer", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.current_entry", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.process_done", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.processes_runnable", &convert_term_read/3, version: "1.0")
@@ -196,6 +198,8 @@ defmodule Beaver.MLIR.Conversion.Ex do
     monotonic_time: "ex.term.monotonic_time",
     receive_start: "ex.term.receive_start",
     receive_start_set: "ex.term.receive_start_set",
+    native_time: "ex.term.native_time",
+    unique_integer: "ex.term.unique_integer",
     current_entry: "ex.term.current_entry",
     process_done: "ex.term.process_done",
     processes_runnable: "ex.term.processes_runnable",
@@ -916,6 +920,8 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.monotonic_time"), do: @term_intrinsics.monotonic_time
   defp read_intrinsic("ex.receive_start"), do: @term_intrinsics.receive_start
   defp read_intrinsic("ex.receive_start_set"), do: @term_intrinsics.receive_start_set
+  defp read_intrinsic("ex.native_time"), do: @term_intrinsics.native_time
+  defp read_intrinsic("ex.unique_integer"), do: @term_intrinsics.unique_integer
   defp read_intrinsic("ex.current_entry"), do: @term_intrinsics.current_entry
   defp read_intrinsic("ex.process_done"), do: @term_intrinsics.process_done
   defp read_intrinsic("ex.processes_runnable"), do: @term_intrinsics.processes_runnable
@@ -1176,6 +1182,14 @@ defmodule Beaver.MLIR.Conversion.Ex do
   end
 
   defp intrinsic_function_type("ex.term.receive_start_set", _ctx) do
+    MLIR.Type.function([MLIR.Type.i64()], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.native_time", _ctx) do
+    MLIR.Type.function([], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.unique_integer", _ctx) do
     MLIR.Type.function([MLIR.Type.i64()], [MLIR.Type.i64()])
   end
 

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -214,6 +214,12 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop receive_start_set(value = all_of([base("!builtin.integer"), any()])),
     results: [result: all_of([base("!builtin.integer"), any()])]
 
+  defop native_time(),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
+  defop unique_integer(negative = all_of([base("!builtin.integer"), any()])),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
   defop current_entry(),
     results: [result: all_of([base("!builtin.integer"), any()])]
 

--- a/lib/beaver/wasm/term_abi.ex
+++ b/lib/beaver/wasm/term_abi.ex
@@ -45,6 +45,8 @@ defmodule Beaver.Wasm.TermABI do
     "ex.term.monotonic_time" => %{params: [], result: :i64},
     "ex.term.receive_start" => %{params: [], result: :i64},
     "ex.term.receive_start_set" => %{params: [:i64], result: :i64},
+    "ex.term.native_time" => %{params: [], result: :i64},
+    "ex.term.unique_integer" => %{params: [:i64], result: :i64},
     "ex.term.mailbox_clear" => %{params: [], result: :i64},
     # process table / scheduler driver
     "ex.term.spawn" => %{params: [:i64], result: :i64},

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -707,11 +707,13 @@ defmodule ExConversionTest do
             %19 = "ex.monotonic_time"() : () -> i64
             %20 = "ex.receive_start"() : () -> i64
             %21 = "ex.receive_start_set"(%0) : (i64) -> i64
-            %22 = "ex.current_entry"() : () -> i64
-            %23 = "ex.process_done"(%0) : (i64) -> i64
-            %24 = "ex.processes_runnable"() : () -> i64
-            %25 = "ex.process_result"(%4) : (!ex.dyn) -> i64
-            "ex.return"(%24) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+            %22 = "ex.native_time"() : () -> i64
+            %23 = "ex.unique_integer"(%0) : (i64) -> i64
+            %24 = "ex.current_entry"() : () -> i64
+            %25 = "ex.process_done"(%0) : (i64) -> i64
+            %26 = "ex.processes_runnable"() : () -> i64
+            %27 = "ex.process_result"(%4) : (!ex.dyn) -> i64
+            "ex.return"(%26) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
           }) {sym_name = "main"} : () -> ()
         }
         """,
@@ -739,6 +741,8 @@ defmodule ExConversionTest do
     assert rendered =~ "ex.term.monotonic_time"
     assert rendered =~ "ex.term.receive_start"
     assert rendered =~ "ex.term.receive_start_set"
+    assert rendered =~ "ex.term.native_time"
+    assert rendered =~ "ex.term.unique_integer"
     assert rendered =~ "ex.term.current_entry"
     assert rendered =~ "ex.term.process_done"
     assert rendered =~ "ex.term.processes_runnable"


### PR DESCRIPTION
## Summary

Slice 8 of tsai/beaver#35 (logical-clock mapping for `erlang.monotonic_time`/`unique_integer`).

- `ex.native_time`: BEAM native time unit (nanoseconds) for `erlang.monotonic_time/0,1`
- `ex.unique_integer(negative)`: fresh logical-clock value for `erlang.unique_integer/0,1`
- wasm TermABI manifest updated

## Tests

ex_conversion_test: new ops lower to `ex.term.*` calls; wasm_term_abi_test coverage exact. Full suite 410/414 (4 remaining failures are the environmental WasmPackagingTest/Shadow.WasmTest — mlir-translate/node not on PATH, unrelated).