### PR TITLE
ci: pin paired kinda revision in kinda.ref with Hex fallback

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -70,19 +70,24 @@ jobs:
       - name: Read Triton version
         if: matrix.llvm == 'triton'
         run: echo "TRITON_REF=$(jq -er '.triton_ref' triton.json)" >> "$GITHUB_ENV"
-      # Kinda 0.11.0 on Hex predates the LLP64 integer conversion fix; the
-      # Windows lane needs the paired checkout until a release containing
-      # beaver-lodge/kinda#68 is published.
-      - uses: actions/checkout@v4
-        name: Check out paired Kinda
+      # Kinda 0.11.0 on Hex predates the LLP64 integer conversion fix, so the
+      # Windows lane uses the paired revision pinned in kinda.ref until a
+      # release containing beaver-lodge/kinda#68 is published.
+      - name: Check out paired Kinda
         if: runner.os == 'Windows'
-        with:
-          repository: beaver-lodge/kinda
-          path: kinda
-          ref: 81a51065952cb644b10cb60dacc4370ec653c9ed
-      - name: Point Mix at the paired Kinda checkout
-        if: runner.os == 'Windows'
-        run: echo "BEAVER_KINDA_PATH=${GITHUB_WORKSPACE}/kinda" >> "$GITHUB_ENV"
+        run: |
+          ref="$(awk 'NF && $1 !~ /^#/ {print $1; exit}' kinda.ref 2>/dev/null || true)"
+          if [ -n "$ref" ]; then
+            git clone https://github.com/beaver-lodge/kinda.git kinda
+            if git -C kinda cat-file -e "$ref^{commit}" 2>/dev/null; then
+              git -C kinda checkout "$ref"
+              echo "BEAVER_KINDA_PATH=${GITHUB_WORKSPACE}/kinda" >> "$GITHUB_ENV"
+            else
+              echo "warning: paired kinda ref $ref unavailable, using Hex release" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          else
+            echo "no paired kinda ref, using Hex release" >> "$GITHUB_STEP_SUMMARY"
+          fi
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,18 +53,24 @@ jobs:
       - uses: actions/checkout@v4
         name: Check-out beaver
       # Kinda 0.11.0 on Hex predates the LLP64 integer conversion and Windows
-      # synchronization fixes; the Windows lane needs the paired checkout until
-      # a release containing beaver-lodge/kinda#66 and #68 is published.
-      - uses: actions/checkout@v4
-        name: Check out paired Kinda
+      # synchronization fixes, so the Windows lane uses the paired revision
+      # pinned in kinda.ref until a release containing beaver-lodge/kinda#66
+      # and #68 is published.
+      - name: Check out paired Kinda
         if: runner.os == 'Windows'
-        with:
-          repository: beaver-lodge/kinda
-          path: kinda
-          ref: 81a51065952cb644b10cb60dacc4370ec653c9ed
-      - name: Point Mix at the paired Kinda checkout
-        if: runner.os == 'Windows'
-        run: echo "BEAVER_KINDA_PATH=${GITHUB_WORKSPACE}/kinda" >> "$GITHUB_ENV"
+        run: |
+          ref="$(awk 'NF && $1 !~ /^#/ {print $1; exit}' kinda.ref 2>/dev/null || true)"
+          if [ -n "$ref" ]; then
+            git clone https://github.com/beaver-lodge/kinda.git kinda
+            if git -C kinda cat-file -e "$ref^{commit}" 2>/dev/null; then
+              git -C kinda checkout "$ref"
+              echo "BEAVER_KINDA_PATH=${GITHUB_WORKSPACE}/kinda" >> "$GITHUB_ENV"
+            else
+              echo "warning: paired kinda ref $ref unavailable, using Hex release" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          else
+            echo "no paired kinda ref, using Hex release" >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:

--- a/kinda.ref
+++ b/kinda.ref
@@ -1,0 +1,8 @@
+# Paired beaver-lodge/kinda revision to test against while the fixes it
+# contains are not yet published to Hex.
+#
+# Keep this as a single commit SHA per line. CI reads the first non-comment
+# line, probes the revision on beaver-lodge/kinda, and falls back to the Hex
+# release when it is unavailable. Delete this file once the fixes land in a
+# Hex release.
+81a51065952cb644b10cb60dacc4370ec653c9ed


### PR DESCRIPTION
## Why

Kinda 0.11.0 on Hex predates the LLP64 integer conversion fix (beaver-lodge/kinda#68), so the Windows lanes of both CI workflows check out a hardcoded kinda commit — the same SHA duplicated in two files, with "until a release containing #68 is published" comments.

## What

- Add `kinda.ref` at the repo root: the single source of truth for the paired kinda revision (a commit SHA, `#` comments allowed).
- Both `elixir.yml` and `release.yml` resolve it at runtime: read the first non-comment line, clone beaver-lodge/kinda, verify the revision exists with `git cat-file`, and check it out — falling back to the Hex release (no `BEAVER_KINDA_PATH`) when the revision is unavailable.
- Deleting `kinda.ref` once the fixes land in a Hex release switches every lane back to Hex automatically; no workflow edits needed.

## Notes

- Probe is `clone + cat-file -e` rather than `git ls-remote`: the pinned commit is an ancestor of kinda `main` (merged PR), so it is present in a full clone but not advertised as a ref, which `ls-remote` cannot resolve.
- Verified locally: valid SHA checks out, bogus SHA warns and stays on Hex.