### PR TITLE
Seal LogicalResult behind C ABI wrappers

### DIFF
--- a/lib/beaver/slang.ex
+++ b/lib/beaver/slang.ex
@@ -1056,7 +1056,7 @@ defmodule Beaver.Slang do
 
     result =
       if dynamic_dialect_loaded?(ctx, dialect_name) do
-        MLIR.CAPI.mlirLogicalResultSuccess()
+        MLIR.CAPI.beaverLogicalResultSuccess()
       else
         apply(mod, :__slang_dialect__, [ctx])
         |> Beaver.MLIR.Transform.canonicalize()

--- a/native/include/mlir-c/Beaver/CAPIPolicy.h
+++ b/native/include/mlir-c/Beaver/CAPIPolicy.h
@@ -14,6 +14,14 @@ typedef enum {
 
   BeaverCapiPolicyDirtyCPUAndIO__mlirExecutionEngineInvokePacked,
 
+  // MlirLogicalResult is a one-byte struct returned by value. Keep Zig out of
+  // its ABI entirely: the public MLIR names are backed by external C++
+  // wrappers instead of translated-C inline functions.
+  BeaverCapiPolicyNIFAlias__mlirLogicalResultSuccess,
+  BeaverCapiPolicyNIFAlias__mlirLogicalResultFailure,
+  BeaverCapiPolicyNIFAlias__mlirLogicalResultIsSuccess,
+  BeaverCapiPolicyNIFAlias__mlirLogicalResultIsFailure,
+
   BeaverCapiPolicyManualAdapter__mlirInferShapedTypeOpInterfaceInferReturnTypes,
   BeaverCapiPolicyManualAdapter__mlirInferTypeOpInterfaceInferReturnTypes,
   BeaverCapiPolicyManualAdapter__mlirTransformStateForEachParam,

--- a/native/include/mlir-c/Beaver/Op.h
+++ b/native/include/mlir-c/Beaver/Op.h
@@ -68,6 +68,8 @@ beaverOperationStateGetNumRegions(MlirOperationState state);
 MLIR_CAPI_EXPORTED intptr_t
 beaverOperationStateGetNumAttributes(MlirOperationState state);
 
+MLIR_CAPI_EXPORTED MlirLogicalResult beaverLogicalResultSuccess(void);
+MLIR_CAPI_EXPORTED MlirLogicalResult beaverLogicalResultFailure(void);
 MLIR_CAPI_EXPORTED bool beaverLogicalResultIsSuccess(MlirLogicalResult res);
 MLIR_CAPI_EXPORTED bool beaverLogicalResultIsFailure(MlirLogicalResult res);
 

--- a/native/lib/CAPI/Beaver.cpp
+++ b/native/lib/CAPI/Beaver.cpp
@@ -264,6 +264,14 @@ beaverOperationStateGetContext(MlirOperationState state) {
   return mlirLocationGetContext(state.location);
 }
 
+MLIR_CAPI_EXPORTED MlirLogicalResult beaverLogicalResultSuccess() {
+  return mlirLogicalResultSuccess();
+}
+
+MLIR_CAPI_EXPORTED MlirLogicalResult beaverLogicalResultFailure() {
+  return mlirLogicalResultFailure();
+}
+
 MLIR_CAPI_EXPORTED bool beaverLogicalResultIsSuccess(MlirLogicalResult res) {
   return mlirLogicalResultIsSuccess(res);
 }

--- a/native/src/callback_bridge.zig
+++ b/native/src/callback_bridge.zig
@@ -326,7 +326,7 @@ const DynamicTraitState = struct {
         comptime callback: []const u8,
         operation: mlir_capi.Operation.T,
     ) mlir_capi.LogicalResult.T {
-        if (!self.dispatcher.hasCallback(callback)) return c.mlirLogicalResultSuccess();
+        if (!self.dispatcher.hasCallback(callback)) return c.beaverLogicalResultSuccess();
         const environment = e.enif_alloc_env() orelse
             return callbackFailure(operation);
         const operation_term = makeHandle(mlir_capi.Operation, environment, operation) orelse
@@ -334,7 +334,7 @@ const DynamicTraitState = struct {
         const response = self.dispatcher.invoke(callback, environment, .{operation_term}) catch
             return callbackFailure(operation);
         if (response.status != .replied) return callbackFailure(operation);
-        return if (response.success) c.mlirLogicalResultSuccess() else c.mlirLogicalResultFailure();
+        return if (response.success) c.beaverLogicalResultSuccess() else c.beaverLogicalResultFailure();
     }
 
     fn callbackFailure(operation: mlir_capi.Operation.T) mlir_capi.LogicalResult.T {
@@ -342,7 +342,7 @@ const DynamicTraitState = struct {
             c.mlirOperationGetLocation(operation),
             "dynamic trait callback timed out or its owner is unavailable",
         );
-        return c.mlirLogicalResultFailure();
+        return c.beaverLogicalResultFailure();
     }
 
     fn verify(
@@ -350,7 +350,7 @@ const DynamicTraitState = struct {
         user_data: ?*anyopaque,
     ) callconv(.c) mlir_capi.LogicalResult.T {
         const self: *@This() = @ptrCast(@alignCast(user_data orelse
-            return c.mlirLogicalResultFailure()));
+            return c.beaverLogicalResultFailure()));
         return self.invokeVerifier("verify", operation);
     }
 
@@ -359,7 +359,7 @@ const DynamicTraitState = struct {
         user_data: ?*anyopaque,
     ) callconv(.c) mlir_capi.LogicalResult.T {
         const self: *@This() = @ptrCast(@alignCast(user_data orelse
-            return c.mlirLogicalResultFailure()));
+            return c.beaverLogicalResultFailure()));
         return self.invokeVerifier("verify_regions", operation);
     }
 };

--- a/native/src/capi_registry.zig
+++ b/native/src/capi_registry.zig
@@ -16,6 +16,7 @@ fn isCandidate(comptime name: []const u8) bool {
         std.mem.startsWith(u8, name, "beaver");
     return has_supported_prefix and
         !hasPolicy("Exclude", name) and
+        !hasPolicy("NIFAlias", name) and
         !hasPolicy("CallbackBridge", name) and
         !hasPolicy("CallbackRuntime", name) and
         !hasPolicy("ManualAdapter", name) and

--- a/native/src/conversion.zig
+++ b/native/src/conversion.zig
@@ -478,46 +478,46 @@ const TypeCallbackState = struct {
         user_data: ?*anyopaque,
     ) callconv(.c) mlir_capi.LogicalResult.T {
         const self: *@This() = @ptrCast(@alignCast(user_data orelse
-            return c.mlirLogicalResultFailure()));
-        const environment = e.enif_alloc_env() orelse return c.mlirLogicalResultFailure();
+            return c.beaverLogicalResultFailure()));
+        const environment = e.enif_alloc_env() orelse return c.beaverLogicalResultFailure();
         const original_term = if (c.mlirTypeIsNull(original_type))
             beam.make_nil(environment)
         else
             kinda.callback_adapter.handle(mlir_capi.Type, environment, original_type) catch {
                 e.enif_free_env(environment);
-                return c.mlirLogicalResultFailure();
+                return c.beaverLogicalResultFailure();
             };
         const args = .{
             kinda.callback_adapter.handle(mlir_capi.RewriterBase, environment, rewriter) catch {
                 e.enif_free_env(environment);
-                return c.mlirLogicalResultFailure();
+                return c.beaverLogicalResultFailure();
             },
             handleSlice(mlir_capi.Type, environment, n_output_types, output_types) catch {
                 e.enif_free_env(environment);
-                return c.mlirLogicalResultFailure();
+                return c.beaverLogicalResultFailure();
             },
             handleSlice(mlir_capi.Value, environment, n_inputs, inputs) catch {
                 e.enif_free_env(environment);
-                return c.mlirLogicalResultFailure();
+                return c.beaverLogicalResultFailure();
             },
             kinda.callback_adapter.handle(mlir_capi.Location, environment, location) catch {
                 e.enif_free_env(environment);
-                return c.mlirLogicalResultFailure();
+                return c.beaverLogicalResultFailure();
             },
             original_term,
         };
         const response = self.dispatcher.invoke("target_materialization_1_to_n", environment, args) catch
-            return c.mlirLogicalResultFailure();
-        if (!response.success) return c.mlirLogicalResultFailure();
+            return c.beaverLogicalResultFailure();
+        if (!response.success) return c.beaverLogicalResultFailure();
         const projection = kinda.callback_adapter.projection(response) orelse
-            return c.mlirLogicalResultFailure();
+            return c.beaverLogicalResultFailure();
         const projected: *HandleProjection(mlir_capi.Value) = @ptrFromInt(projection);
         defer projected.deinit();
         if (projected.values.len != @as(usize, @intCast(n_output_types)))
-            return c.mlirLogicalResultFailure();
+            return c.beaverLogicalResultFailure();
         if (projected.values.len != 0)
             @memcpy(outputs[0..projected.values.len], projected.values);
-        return c.mlirLogicalResultSuccess();
+        return c.beaverLogicalResultSuccess();
     }
 };
 
@@ -730,25 +730,25 @@ const ConversionPatternState = struct {
         user_data: ?*anyopaque,
     ) callconv(.c) mlir_capi.LogicalResult.T {
         const self: *@This() = @ptrCast(@alignCast(user_data orelse
-            return c.mlirLogicalResultFailure()));
-        const environment = e.enif_alloc_env() orelse return c.mlirLogicalResultFailure();
+            return c.beaverLogicalResultFailure()));
+        const environment = e.enif_alloc_env() orelse return c.beaverLogicalResultFailure();
         const args = .{
             kinda.callback_adapter.handle(mlir_capi.Operation, environment, operation) catch {
                 e.enif_free_env(environment);
-                return c.mlirLogicalResultFailure();
+                return c.beaverLogicalResultFailure();
             },
             handleSlice(mlir_capi.Value, environment, n_operands, operands) catch {
                 e.enif_free_env(environment);
-                return c.mlirLogicalResultFailure();
+                return c.beaverLogicalResultFailure();
             },
             kinda.callback_adapter.handle(mlir_capi.ConversionPatternRewriter, environment, rewriter) catch {
                 e.enif_free_env(environment);
-                return c.mlirLogicalResultFailure();
+                return c.beaverLogicalResultFailure();
             },
         };
         const response = self.dispatcher.invoke("conversion_pattern", environment, args) catch
-            return c.mlirLogicalResultFailure();
-        return if (response.success) c.mlirLogicalResultSuccess() else c.mlirLogicalResultFailure();
+            return c.beaverLogicalResultFailure();
+        return if (response.success) c.beaverLogicalResultSuccess() else c.beaverLogicalResultFailure();
     }
 
     fn rewrite1ToN(
@@ -762,12 +762,12 @@ const ConversionPatternState = struct {
         user_data: ?*anyopaque,
     ) callconv(.c) mlir_capi.LogicalResult.T {
         const self: *@This() = @ptrCast(@alignCast(user_data orelse
-            return c.mlirLogicalResultFailure()));
-        const environment = e.enif_alloc_env() orelse return c.mlirLogicalResultFailure();
+            return c.beaverLogicalResultFailure()));
+        const environment = e.enif_alloc_env() orelse return c.beaverLogicalResultFailure();
         const count: usize = @intCast(n_ranges);
         const ranges = beam.allocator.alloc(beam.term, count) catch {
             e.enif_free_env(environment);
-            return c.mlirLogicalResultFailure();
+            return c.beaverLogicalResultFailure();
         };
         defer beam.allocator.free(ranges);
         var offset: usize = 0;
@@ -775,7 +775,7 @@ const ConversionPatternState = struct {
             const len: usize = @intCast(range_sizes[index]);
             if (offset + len > @as(usize, @intCast(n_operands))) {
                 e.enif_free_env(environment);
-                return c.mlirLogicalResultFailure();
+                return c.beaverLogicalResultFailure();
             }
             if (len == 0) {
                 const empty = [_]beam.term{};
@@ -787,7 +787,7 @@ const ConversionPatternState = struct {
                     operands[offset .. offset + len],
                 ) catch {
                     e.enif_free_env(environment);
-                    return c.mlirLogicalResultFailure();
+                    return c.beaverLogicalResultFailure();
                 };
             }
             offset += len;
@@ -795,17 +795,17 @@ const ConversionPatternState = struct {
         const args = .{
             kinda.callback_adapter.handle(mlir_capi.Operation, environment, operation) catch {
                 e.enif_free_env(environment);
-                return c.mlirLogicalResultFailure();
+                return c.beaverLogicalResultFailure();
             },
             beam.make_term_list(environment, ranges),
             kinda.callback_adapter.handle(mlir_capi.ConversionPatternRewriter, environment, rewriter) catch {
                 e.enif_free_env(environment);
-                return c.mlirLogicalResultFailure();
+                return c.beaverLogicalResultFailure();
             },
         };
         const response = self.dispatcher.invoke("conversion_pattern_1_to_n", environment, args) catch
-            return c.mlirLogicalResultFailure();
-        return if (response.success) c.mlirLogicalResultSuccess() else c.mlirLogicalResultFailure();
+            return c.beaverLogicalResultFailure();
+        return if (response.success) c.beaverLogicalResultSuccess() else c.beaverLogicalResultFailure();
     }
 };
 

--- a/native/src/core.zig
+++ b/native/src/core.zig
@@ -19,10 +19,12 @@ const triton = @import("triton.zig");
 const llvm_ir = @import("llvm_ir.zig");
 const infer_type = @import("infer_type.zig");
 const capi_registry = @import("capi_registry.zig");
+const logical_result = @import("logical_result.zig");
 
 const callback_nifs = .{kinda.callback_runtime.ReplyToken.nif("beaver_raw_callback_reply")};
 
 pub const nifs = capi_registry.nifs ++
+    logical_result.nifs ++
     mlir_capi.EntriesOfKinds ++
     pass.nifs ++
     registry.nifs ++

--- a/native/src/diagnostic.zig
+++ b/native/src/diagnostic.zig
@@ -41,13 +41,13 @@ const DiagnosticAggregator = struct {
 
     fn collectDiagnosticTopLevel(diagnostic: c.MlirDiagnostic, userData: ?*@This()) !mlir_capi.LogicalResult.T {
         try userData.?.container.append(try collectDiagnosticNested(diagnostic, userData));
-        return c.mlirLogicalResultSuccess();
+        return c.beaverLogicalResultSuccess();
     }
     fn errorHandler(diagnostic: c.MlirDiagnostic, userData: ?*anyopaque) callconv(.c) mlir_capi.LogicalResult.T {
-        const self: *@This() = @ptrCast(@alignCast(userData orelse return c.mlirLogicalResultFailure()));
+        const self: *@This() = @ptrCast(@alignCast(userData orelse return c.beaverLogicalResultFailure()));
         self.mutex.lock();
         defer self.mutex.unlock();
-        return collectDiagnosticTopLevel(diagnostic, self) catch return c.mlirLogicalResultFailure();
+        return collectDiagnosticTopLevel(diagnostic, self) catch return c.beaverLogicalResultFailure();
     }
     fn deleteUserData(userData: ?*anyopaque) callconv(.c) void {
         const this: ?*@This() = @ptrCast(@alignCast(userData));

--- a/native/src/logical_result.zig
+++ b/native/src/logical_result.zig
@@ -1,0 +1,11 @@
+const prelude = @import("prelude.zig");
+
+// MLIR implements these four functions as static inline C helpers. Export the
+// same NIF names through Beaver's externally compiled C++ wrappers so Zig
+// never owns the by-value MlirLogicalResult ABI boundary.
+pub const nifs = .{
+    prelude.nifAs("beaverLogicalResultSuccess", "mlirLogicalResultSuccess"),
+    prelude.nifAs("beaverLogicalResultFailure", "mlirLogicalResultFailure"),
+    prelude.nifAs("beaverLogicalResultIsSuccess", "mlirLogicalResultIsSuccess"),
+    prelude.nifAs("beaverLogicalResultIsFailure", "mlirLogicalResultIsFailure"),
+};

--- a/native/src/pass.zig
+++ b/native/src/pass.zig
@@ -28,13 +28,13 @@ const CallbackDispatcher = struct {
     fn initialize(ctx: mlir_capi.Context.T, userData: ?*anyopaque) callconv(.c) mlir_capi.LogicalResult.T {
         const this: *RuntimeDispatcher = @ptrCast(@alignCast(userData));
         const temp_env = e.enif_alloc_env() orelse unreachable;
-        const response = this.invoke("initialize", temp_env, .{mlir_capi.Context.resource.make_kind(temp_env, ctx) catch unreachable}) catch return c.mlirLogicalResultFailure();
+        const response = this.invoke("initialize", temp_env, .{mlir_capi.Context.resource.make_kind(temp_env, ctx) catch unreachable}) catch return c.beaverLogicalResultFailure();
         if (!response.success) {
             const loc = c.mlirLocationUnknownGet(ctx);
             c.mlirEmitError(loc, "Fail to initialize a pass implemented in Elixir");
-            return c.mlirLogicalResultFailure();
+            return c.beaverLogicalResultFailure();
         }
-        return c.mlirLogicalResultSuccess();
+        return c.beaverLogicalResultSuccess();
     }
     fn clone(userData: ?*anyopaque) callconv(.c) ?*anyopaque {
         const this: *RuntimeDispatcher = @ptrCast(@alignCast(userData));

--- a/native/src/prelude.zig
+++ b/native/src/prelude.zig
@@ -6,6 +6,10 @@ pub fn nif(comptime name: anytype) e.ErlNifFunc {
     @setEvalBranchQuota(10000);
     return kinda.NIFFunc(allKinds, c, name, .{});
 }
+pub fn nifAs(comptime implementation_name: []const u8, comptime nif_name: []const u8) e.ErlNifFunc {
+    @setEvalBranchQuota(10000);
+    return kinda.NIFFunc(allKinds, c, implementation_name, .{ .nif_name = nif_name.ptr });
+}
 pub fn nifDirtyCPU(comptime name: []const u8, comptime nif_name: ?[]const u8) e.ErlNifFunc {
     @setEvalBranchQuota(10000);
     const exported_name = if (nif_name) |v| v else name;

--- a/native/src/rewrite_pattern.zig
+++ b/native/src/rewrite_pattern.zig
@@ -35,7 +35,7 @@ const CallbackDispatcher = struct {
         const op_ = mlir_capi.Operation.resource.make_kind(temp_env, op) catch @panic("failed to make resource for Operation");
         const rewriter_ = mlir_capi.PatternRewriter.resource.make_kind(temp_env, rewriter) catch @panic("failed to make resource for PatternRewriter");
         const response = this.invoke("matchAndRewrite", temp_env, .{ pattern_, op_, rewriter_ }) catch @panic("failed to forward matchAndRewrite callback");
-        return if (response.success) c.mlirLogicalResultSuccess() else c.mlirLogicalResultFailure();
+        return if (response.success) c.beaverLogicalResultSuccess() else c.beaverLogicalResultFailure();
     }
 
     const PatternCreator = struct {

--- a/test/capi_manifest_test.exs
+++ b/test/capi_manifest_test.exs
@@ -103,6 +103,65 @@ defmodule Beaver.MLIR.CAPI.ManifestTest do
     end
   end
 
+  test "LogicalResult helpers keep generated surfaces behind the C ABI firewall" do
+    declaration_manifest = CAPI.CodeGen.declaration_manifest()
+
+    inline_helpers = [
+      "mlirLogicalResultFailure",
+      "mlirLogicalResultIsFailure",
+      "mlirLogicalResultIsSuccess",
+      "mlirLogicalResultSuccess"
+    ]
+
+    signature_entries =
+      declaration_manifest
+      |> DeclarationManifest.signature_manifest()
+      |> Map.fetch!("entries")
+
+    for name <- inline_helpers do
+      entry = Enum.find(signature_entries, &(get_in(&1, ["function", "name"]) == name))
+
+      assert entry["generation_blocker_reason"] == nil
+      assert entry["variants"] != []
+    end
+
+    generated_names =
+      declaration_manifest
+      |> DeclarationManifest.nif_decls()
+      |> Enum.map(&Atom.to_string(&1.wrapper_name))
+      |> MapSet.new()
+
+    for name <-
+          inline_helpers ++
+            [
+              "beaverLogicalResultFailure",
+              "beaverLogicalResultIsFailure",
+              "beaverLogicalResultIsSuccess",
+              "beaverLogicalResultSuccess"
+            ] do
+      assert MapSet.member?(generated_names, name)
+    end
+  end
+
+  test "native Zig sources do not call MLIR's inline LogicalResult helpers" do
+    forbidden = ~r/c\.mlirLogicalResult(?:Success|Failure|IsSuccess|IsFailure)/
+
+    offenders =
+      __DIR__
+      |> Path.join("../native/src/**/*.zig")
+      |> Path.wildcard()
+      |> Enum.flat_map(fn path ->
+        path
+        |> File.stream!()
+        |> Stream.with_index(1)
+        |> Enum.flat_map(fn {line, line_number} ->
+          if Regex.match?(forbidden, line), do: [{path, line_number}], else: []
+        end)
+      end)
+
+    assert offenders == []
+  end
+
   test "callback-heavy declarations remain in the callback bridge manifest" do
     priv_dir = :beaver |> :code.priv_dir() |> List.to_string()
 

--- a/test/capi_test.exs
+++ b/test/capi_test.exs
@@ -140,6 +140,25 @@ defmodule MlirTest do
     MLIR.Context.destroy(ctx)
   end
 
+  test "LogicalResult helpers cross the ABI through Beaver wrappers" do
+    logical_results = [
+      {mlirLogicalResultSuccess(), mlirLogicalResultFailure()},
+      {beaverLogicalResultSuccess(), beaverLogicalResultFailure()}
+    ]
+
+    for {success, failure} <- logical_results do
+      assert success |> mlirLogicalResultIsSuccess() |> Beaver.Native.to_term()
+      refute success |> mlirLogicalResultIsFailure() |> Beaver.Native.to_term()
+      assert success |> beaverLogicalResultIsSuccess() |> Beaver.Native.to_term()
+      refute success |> beaverLogicalResultIsFailure() |> Beaver.Native.to_term()
+
+      refute failure |> mlirLogicalResultIsSuccess() |> Beaver.Native.to_term()
+      assert failure |> mlirLogicalResultIsFailure() |> Beaver.Native.to_term()
+      refute failure |> beaverLogicalResultIsSuccess() |> Beaver.Native.to_term()
+      assert failure |> beaverLogicalResultIsFailure() |> Beaver.Native.to_term()
+    end
+  end
+
   test "Run a generic pass" do
     ctx = MLIR.Context.create()
     {:ok, module} = create_adder_module(ctx)


### PR DESCRIPTION
## Summary

- export Beaver-owned C++ constructors and predicates for `MlirLogicalResult`
- route every Zig call through those external symbols and keep MLIR's public NIF names as aliases
- prevent the generated Zig registry from compiling MLIR's static-inline LogicalResult helpers
- add manifest, source-boundary, and runtime regression coverage for both success and failure values

## Why

Zig 0.16 can miscompile the one-byte, by-value `MlirLogicalResult` ABI on macOS in optimized builds. This makes the boundary explicit: C++ owns construction and inspection, while Zig only transports the value through externally compiled symbols.

## Verification

- `zig fmt --check native build.zig`
- `mix format --check-formatted`
- `mix compile --force --warnings-as-errors`
- ReleaseSafe LogicalResult constructor/predicate probe
- `mix test --force --only smoke` (194 passed)
- all tracked tests (415 passed, 30 excluded)
