### PR TITLE
ex: add native actor worker intrinsic

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -97,6 +97,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.cont_load_cursor", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.schedule_next", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.worker_run", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.process_wait", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.mailbox_len", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.mailbox_peek", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.mailbox_remove", &convert_term_read/3, version: "1.0")
@@ -206,6 +207,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     processes_runnable: "ex.term.processes_runnable",
     process_result: "ex.term.process_result",
     worker_run: "ex.term.worker_run",
+    process_wait: "ex.term.process_wait",
     to_int: "ex.term.to_int",
     reduction_tick: "ex.term.clock_tick",
     clock_init: "ex.term.clock_init",
@@ -916,6 +918,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.cont_load_cursor"), do: @term_intrinsics.cont_load_cursor
   defp read_intrinsic("ex.schedule_next"), do: @term_intrinsics.schedule_next
   defp read_intrinsic("ex.worker_run"), do: @term_intrinsics.worker_run
+  defp read_intrinsic("ex.process_wait"), do: @term_intrinsics.process_wait
   defp read_intrinsic("ex.mailbox_len"), do: @term_intrinsics.mailbox_len
   defp read_intrinsic("ex.mailbox_peek"), do: @term_intrinsics.mailbox_peek
   defp read_intrinsic("ex.mailbox_remove"), do: @term_intrinsics.mailbox_remove

--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -96,6 +96,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.cont_load_acc", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.cont_load_cursor", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.schedule_next", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.worker_run", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.mailbox_len", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.mailbox_peek", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.mailbox_remove", &convert_term_read/3, version: "1.0")
@@ -204,6 +205,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     process_done: "ex.term.process_done",
     processes_runnable: "ex.term.processes_runnable",
     process_result: "ex.term.process_result",
+    worker_run: "ex.term.worker_run",
     to_int: "ex.term.to_int",
     reduction_tick: "ex.term.clock_tick",
     clock_init: "ex.term.clock_init",
@@ -913,6 +915,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.cont_load_acc"), do: @term_intrinsics.cont_load_acc
   defp read_intrinsic("ex.cont_load_cursor"), do: @term_intrinsics.cont_load_cursor
   defp read_intrinsic("ex.schedule_next"), do: @term_intrinsics.schedule_next
+  defp read_intrinsic("ex.worker_run"), do: @term_intrinsics.worker_run
   defp read_intrinsic("ex.mailbox_len"), do: @term_intrinsics.mailbox_len
   defp read_intrinsic("ex.mailbox_peek"), do: @term_intrinsics.mailbox_peek
   defp read_intrinsic("ex.mailbox_remove"), do: @term_intrinsics.mailbox_remove
@@ -1252,6 +1255,13 @@ defmodule Beaver.MLIR.Conversion.Ex do
         MLIR.Type.i64(),
         MLIR.Type.function([MLIR.Type.i64(), MLIR.Type.i64()], [MLIR.Type.i64()])
       ],
+      [MLIR.Type.i64()]
+    )
+  end
+
+  defp intrinsic_function_type("ex.term.worker_run", _ctx) do
+    MLIR.Type.function(
+      [MLIR.Type.i64(), MLIR.Type.function([MLIR.Type.i64()], [MLIR.Type.i64()])],
       [MLIR.Type.i64()]
     )
   end

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -232,6 +232,11 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop process_result(pid = base(dyn())),
     results: [result: all_of([base("!builtin.integer"), any()])]
 
+  # Parks the current actor when its mailbox has no message beyond the
+  # completed selective-receive scan cursor.
+  defop process_wait(cursor = all_of([base("!builtin.integer"), any()])),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
   # Runs the actor scheduler with a fixed worker count. `dispatcher` is a
   # stable native trampoline with the signature `(pid: i64) -> i64`.
   defop worker_run(

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -232,6 +232,14 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop process_result(pid = base(dyn())),
     results: [result: all_of([base("!builtin.integer"), any()])]
 
+  # Runs the actor scheduler with a fixed worker count. `dispatcher` is a
+  # stable native trampoline with the signature `(pid: i64) -> i64`.
+  defop worker_run(
+          worker_count = all_of([base("!builtin.integer"), any()]),
+          dispatcher = any()
+        ),
+        results: [result: all_of([base("!builtin.integer"), any()])]
+
   # Untags an integer term word to its scalar value (a passthrough for
   # values that are already scalar).
   defop to_int(word = base(dyn())),

--- a/lib/beaver/wasm/term_abi.ex
+++ b/lib/beaver/wasm/term_abi.ex
@@ -20,6 +20,11 @@ defmodule Beaver.Wasm.TermABI do
 
   @import_module "ex_term"
 
+  # These intrinsics coordinate native worker threads and pass a native
+  # function pointer across the ABI. They are intentionally unavailable to
+  # wasm hosts, where scheduling belongs to the host/runtime integration.
+  @native_only_intrinsics ["ex.term.process_wait", "ex.term.worker_run"]
+
   @type param :: :i64 | :ptr
   @type result :: :i64 | :void
 
@@ -172,6 +177,10 @@ defmodule Beaver.Wasm.TermABI do
   @spec symbols() :: [String.t()]
   def symbols, do: @intrinsics |> Map.keys() |> Enum.sort()
 
+  @doc "Term intrinsics intentionally provided only by the native runtime."
+  @spec native_only_symbols() :: [String.t()]
+  def native_only_symbols, do: @native_only_intrinsics
+
   @doc """
   Renders the manifest as a Markdown table (paste-ready for an upstream
   issue or the wasm host documentation).
@@ -197,7 +206,7 @@ defmodule Beaver.Wasm.TermABI do
   @doc false
   @spec coverage() :: %{missing: [String.t()], extra: [String.t()]}
   def coverage do
-    emitted = Ex.term_intrinsic_symbols()
+    emitted = Ex.term_intrinsic_symbols() -- native_only_symbols()
     declared = symbols()
 
     %{

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -713,7 +713,9 @@ defmodule ExConversionTest do
             %25 = "ex.process_done"(%0) : (i64) -> i64
             %26 = "ex.processes_runnable"() : () -> i64
             %27 = "ex.process_result"(%4) : (!ex.dyn) -> i64
-            "ex.return"(%26) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+            %28 = "ex.func_addr"() {sym_name = "actor_step"} : () -> ((i64) -> i64)
+            %29 = "ex.worker_run"(%1, %28) : (i64, (i64) -> i64) -> i64
+            "ex.return"(%29) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
           }) {sym_name = "main"} : () -> ()
         }
         """,
@@ -747,6 +749,7 @@ defmodule ExConversionTest do
     assert rendered =~ "ex.term.process_done"
     assert rendered =~ "ex.term.processes_runnable"
     assert rendered =~ "ex.term.process_result"
+    assert rendered =~ "ex.term.worker_run"
   end
 
   test "passes nested term operands through without re-tagging", %{ctx: ctx} do

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -715,6 +715,7 @@ defmodule ExConversionTest do
             %27 = "ex.process_result"(%4) : (!ex.dyn) -> i64
             %28 = "ex.func_addr"() {sym_name = "actor_step"} : () -> ((i64) -> i64)
             %29 = "ex.worker_run"(%1, %28) : (i64, (i64) -> i64) -> i64
+            %30 = "ex.process_wait"(%0) : (i64) -> i64
             "ex.return"(%29) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
           }) {sym_name = "main"} : () -> ()
         }
@@ -750,6 +751,7 @@ defmodule ExConversionTest do
     assert rendered =~ "ex.term.processes_runnable"
     assert rendered =~ "ex.term.process_result"
     assert rendered =~ "ex.term.worker_run"
+    assert rendered =~ "ex.term.process_wait"
   end
 
   test "passes nested term operands through without re-tagging", %{ctx: ctx} do

--- a/test/wasm_term_abi_test.exs
+++ b/test/wasm_term_abi_test.exs
@@ -9,7 +9,15 @@ defmodule WasmTermABITest do
     assert coverage.extra == []
 
     assert length(TermABI.manifest()) ==
-             length(Beaver.MLIR.Conversion.Ex.term_intrinsic_symbols())
+             length(Beaver.MLIR.Conversion.Ex.term_intrinsic_symbols()) -
+               length(TermABI.native_only_symbols())
+  end
+
+  test "excludes native scheduler intrinsics from the wasm host boundary" do
+    assert TermABI.native_only_symbols() == ["ex.term.process_wait", "ex.term.worker_run"]
+
+    refute TermABI.entry("ex.term.process_wait")
+    refute TermABI.entry("ex.term.worker_run")
   end
 
   test "declares the wasm import module and name" do


### PR DESCRIPTION
## Summary

- declare `ex.worker_run(worker_count, dispatcher)` in the Ex dialect
- declare `ex.process_wait(cursor)` for atomic selective-receive parking
- lower both operations to the native `ex.term.*` runtime symbols
- preserve the dispatcher function-pointer type through LLVM conversion
- cover the new conversions in the scheduler ABI test

## Why

Batata needs a stable generated actor trampoline that its native runtime can invoke from OS worker threads, plus a typed wait boundary that prevents lost wakeups between a mailbox scan and parking.

## Checks

- `mix test test/ex_conversion_test.exs:683 --warnings-as-errors`
- exercised end-to-end from the dependent Batata worker-pool/observability branches