### PR TITLE
mlir: preserve and inspect location provenance

### DIFF
--- a/lib/beaver/mlir/location.ex
+++ b/lib/beaver/mlir/location.ex
@@ -1,59 +1,395 @@
 defmodule Beaver.MLIR.Location do
   @moduledoc """
-  This module defines functions working with MLIR #{__MODULE__ |> Module.split() |> List.last()}.
+  Constructors and safe inspection helpers for MLIR locations.
+
+  Locations are owned and uniqued by an MLIR context. In addition to source
+  ranges, MLIR can represent named provenance, call sites, and fused
+  provenance with an arbitrary metadata attribute. `fused/2` accepts locations
+  as well as location-bearing operations and values so transformations can
+  preserve provenance without dropping to the C API.
+
+  MLIR may canonicalize a fused location without metadata to its only child.
+  Use `with_metadata/3` when the metadata itself must be retained even for a
+  single source location.
   """
-  alias Beaver.MLIR.CAPI
-  alias Beaver.MLIR
   alias Beaver.Deferred
+  alias Beaver.MLIR
+  alias Beaver.MLIR.CAPI
 
   use Kinda.ResourceKind, raw_module: Beaver.MLIR.CAPI.Raw, codec: Beaver.Native
 
+  @type source() ::
+          t()
+          | MLIR.Operation.t()
+          | MLIR.Value.t()
+          | Deferred.contextual(t() | MLIR.Operation.t() | MLIR.Value.t())
+
+  @type file_opts() :: [
+          name: String.t(),
+          line: non_neg_integer(),
+          column: non_neg_integer() | nil,
+          ctx: Deferred.context_arg()
+        ]
+  @type file_range_opts() :: [
+          name: String.t(),
+          start_line: non_neg_integer(),
+          start_column: non_neg_integer(),
+          end_line: non_neg_integer(),
+          end_column: non_neg_integer(),
+          ctx: Deferred.context_arg()
+        ]
+  @type env_opts() :: [column: non_neg_integer() | nil, ctx: Deferred.context_arg()]
+  @type env_like() :: %{optional(:file) => String.t() | nil, optional(:line) => integer() | nil}
+  @type source_range() :: %{
+          file: String.t(),
+          start_line: non_neg_integer(),
+          start_column: non_neg_integer(),
+          end_line: non_neg_integer(),
+          end_column: non_neg_integer()
+        }
+  @type kind() :: :unknown | :file_range | :name | :call_site | :fused | :other
+
   @doc """
-  Get a location of file line. Column is zero by default because in Elixir it is usually omitted.
+  Creates a file, line, and column location.
+
+  The column defaults to zero because Elixir metadata usually omits it.
 
   ## Examples
+
       iex> ctx = MLIR.Context.create()
       iex> MLIR.Location.file(name: "filename", line: 1, column: 1, ctx: ctx) |> MLIR.to_string()
       ~s{filename:1:1}
       iex> MLIR.Context.destroy(ctx)
   """
-
-  @type file_opts() :: [
-          name: String.t(),
-          line: integer(),
-          column: integer() | nil,
-          ctx: Deferred.context_arg()
-        ]
-  @type env_opts() :: [column: integer() | nil, ctx: Deferred.context_arg()]
-  @type env_like() :: %{optional(:file) => String.t() | nil, optional(:line) => integer() | nil}
-  @spec file(file_opts()) :: Deferred.contextual(MLIR.Location.t())
+  @spec file(file_opts()) :: Deferred.contextual(t())
   def file(opts) do
-    name = opts |> Keyword.fetch!(:name)
-    line = opts |> Keyword.fetch!(:line)
-    column = opts |> Keyword.get(:column, 0)
+    name = Keyword.fetch!(opts, :name)
+    line = Keyword.fetch!(opts, :line)
+    column = Keyword.get(opts, :column) || 0
 
-    Beaver.Deferred.from_opts(
+    Deferred.from_opts(
       opts,
       &CAPI.mlirLocationFileLineColGet(&1, MLIR.StringRef.create(name), line, column)
     )
   end
 
   @doc """
-  Create an MLIR location from `Macro.Env`
+  Creates a source range location.
+
+  Unlike `file/1`, all range coordinates are explicit so an accidentally
+  truncated range cannot silently be constructed.
   """
-  @spec from_env(env_like(), env_opts()) :: Deferred.contextual(MLIR.Location.t())
+  @spec file_range(file_range_opts()) :: Deferred.contextual(t())
+  def file_range(opts) when is_list(opts) do
+    name = Keyword.fetch!(opts, :name)
+    start_line = Keyword.fetch!(opts, :start_line)
+    start_column = Keyword.fetch!(opts, :start_column)
+    end_line = Keyword.fetch!(opts, :end_line)
+    end_column = Keyword.fetch!(opts, :end_column)
+
+    Deferred.from_opts(opts, fn ctx ->
+      CAPI.mlirLocationFileLineColRangeGet(
+        ctx,
+        MLIR.StringRef.create(name),
+        start_line,
+        start_column,
+        end_line,
+        end_column
+      )
+    end)
+  end
+
+  @doc "Creates an MLIR location from `Macro.Env`-like metadata."
+  @spec from_env(env_like(), env_opts()) :: Deferred.contextual(t())
   def from_env(env, opts \\ []) when is_map(env) do
     name = env |> Map.get(:file, "nofile") |> to_string()
-    line = env |> Map.get(:line)
+    line = Map.get(env, :line)
     line = if is_integer(line), do: line, else: 0
 
     file(env_file_opts(name, line, opts))
   end
 
-  @spec unknown(Deferred.opts()) :: Deferred.contextual(MLIR.Location.t())
+  @doc "Creates an unknown location."
+  @spec unknown(Deferred.opts()) :: Deferred.contextual(t())
   def unknown(opts \\ []) do
-    Beaver.Deferred.from_opts(opts, &CAPI.mlirLocationUnknownGet/1)
+    Deferred.from_opts(opts, &CAPI.mlirLocationUnknownGet/1)
   end
+
+  @doc """
+  Creates a named location with an unknown child.
+
+  Pass an operation, value, or location as the second argument to retain its
+  existing provenance as the child.
+  """
+  @spec named(String.Chars.t(), Deferred.opts()) :: Deferred.contextual(t())
+  def named(name, opts) when is_list(opts) do
+    Deferred.from_opts(opts, fn ctx ->
+      CAPI.mlirLocationNameGet(
+        ctx,
+        MLIR.StringRef.create(name),
+        CAPI.mlirLocationUnknownGet(ctx)
+      )
+    end)
+  end
+
+  @spec named(String.Chars.t(), source(), Deferred.opts()) :: Deferred.contextual(t())
+  def named(name, child, opts \\ []) do
+    opts = infer_context(opts, [child])
+
+    Deferred.from_opts(opts, fn ctx ->
+      CAPI.mlirLocationNameGet(
+        ctx,
+        MLIR.StringRef.create(name),
+        resolve(child, ctx)
+      )
+    end)
+  end
+
+  @doc """
+  Creates a call-site location from callee and caller provenance.
+
+  Each argument may be a location, operation, value, or deferred equivalent.
+  """
+  @spec call_site(source(), source(), Deferred.opts()) :: Deferred.contextual(t())
+  def call_site(callee, caller, opts \\ []) do
+    opts = infer_context(opts, [callee, caller])
+
+    Deferred.from_opts(opts, fn ctx ->
+      CAPI.mlirLocationCallSiteGet(resolve(callee, ctx), resolve(caller, ctx))
+    end)
+  end
+
+  @doc """
+  Fuses location-bearing sources, optionally retaining an MLIR attribute as
+  metadata.
+
+  `sources` may contain locations, operations, values, or deferred
+  equivalents. MLIR removes unknown children, deduplicates children, and may
+  return a non-fused location when no metadata is supplied and only one unique
+  child remains.
+  """
+  @spec fused([source()], keyword()) :: Deferred.contextual(t())
+  def fused(sources, opts \\ []) when is_list(sources) do
+    metadata = Keyword.get(opts, :metadata)
+    opts = infer_context(opts, sources ++ List.wrap(metadata))
+
+    Deferred.from_opts(opts, fn ctx ->
+      locations = Enum.map(sources, &resolve(&1, ctx))
+      metadata = resolve_metadata(metadata, ctx)
+
+      CAPI.mlirLocationFusedGet(
+        ctx,
+        length(locations),
+        Beaver.Native.array(locations, __MODULE__),
+        metadata
+      )
+    end)
+  end
+
+  @doc """
+  Attaches metadata while retaining all supplied source provenance.
+
+  This is the explicit metadata-preserving form of `fused/2` and is useful for
+  transformation tags, debug scopes, and other provenance attributes.
+  """
+  @spec with_metadata(source() | [source()], MLIR.Attribute.t() | Deferred.attribute(), keyword()) ::
+          Deferred.contextual(t())
+  def with_metadata(sources, metadata, opts \\ []) do
+    fused(List.wrap(sources), Keyword.put(opts, :metadata, metadata))
+  end
+
+  @doc "Returns the location carried by a location, operation, or value."
+  @spec of(source()) :: Deferred.contextual(t())
+  def of(%__MODULE__{} = location), do: location
+  def of(%MLIR.Operation{} = operation), do: MLIR.Operation.location(operation)
+  def of(%MLIR.Value{} = value), do: MLIR.Value.location(value)
+
+  def of(deferred) when is_function(deferred, 1) do
+    fn ctx -> deferred |> Deferred.create(ctx) |> of() end
+  end
+
+  def of(other) do
+    raise ArgumentError,
+          "expected an MLIR location, operation, value, or deferred equivalent, got: #{inspect(other)}"
+  end
+
+  @doc "Resolves a location-bearing value in `ctx` and verifies context ownership."
+  @spec resolve(source(), MLIR.Context.t()) :: t()
+  def resolve(source, %MLIR.Context{} = ctx) do
+    location = source |> Deferred.create(ctx) |> of()
+
+    unless MLIR.equal?(MLIR.context(location), ctx) do
+      raise ArgumentError, "location belongs to a different MLIR context"
+    end
+
+    location
+  end
+
+  @doc "Returns the built-in location kind, or `:other` for dialect-defined locations."
+  @spec kind(t()) :: kind()
+  def kind(%__MODULE__{} = location) do
+    cond do
+      unknown?(location) -> :unknown
+      file_range?(location) -> :file_range
+      name?(location) -> :name
+      call_site?(location) -> :call_site
+      fused?(location) -> :fused
+      true -> :other
+    end
+  end
+
+  @doc "Returns structured source coordinates for a file range location."
+  @spec source_range(t()) :: {:ok, source_range()} | :error
+  def source_range(%__MODULE__{} = location) do
+    if file_range?(location) do
+      {:ok,
+       %{
+         file: CAPI.mlirLocationFileLineColRangeGetFilename(location) |> to_string(),
+         start_line: location |> CAPI.mlirLocationFileLineColRangeGetStartLine() |> to_term(),
+         start_column: location |> CAPI.mlirLocationFileLineColRangeGetStartColumn() |> to_term(),
+         end_line: location |> CAPI.mlirLocationFileLineColRangeGetEndLine() |> to_term(),
+         end_column: location |> CAPI.mlirLocationFileLineColRangeGetEndColumn() |> to_term()
+       }}
+    else
+      :error
+    end
+  end
+
+  @doc "Returns the label of a named location."
+  @spec name(t()) :: {:ok, String.t()} | :error
+  def name(%__MODULE__{} = location) do
+    if name?(location) do
+      {:ok, location |> CAPI.mlirLocationNameGetName() |> to_string()}
+    else
+      :error
+    end
+  end
+
+  @doc "Returns the child provenance of a named location."
+  @spec child(t()) :: {:ok, t()} | :error
+  def child(%__MODULE__{} = location) do
+    if name?(location), do: {:ok, CAPI.mlirLocationNameGetChildLoc(location)}, else: :error
+  end
+
+  @doc "Returns the callee provenance of a call-site location."
+  @spec callee(t()) :: {:ok, t()} | :error
+  def callee(%__MODULE__{} = location) do
+    if call_site?(location), do: {:ok, CAPI.mlirLocationCallSiteGetCallee(location)}, else: :error
+  end
+
+  @doc "Returns the caller provenance of a call-site location."
+  @spec caller(t()) :: {:ok, t()} | :error
+  def caller(%__MODULE__{} = location) do
+    if call_site?(location), do: {:ok, CAPI.mlirLocationCallSiteGetCaller(location)}, else: :error
+  end
+
+  @doc "Returns the number of source locations retained by a fused location."
+  @spec location_count(t()) :: {:ok, non_neg_integer()} | :error
+  def location_count(%__MODULE__{} = location) do
+    if fused?(location) do
+      {:ok, location |> CAPI.mlirLocationFusedGetNumLocations() |> to_term()}
+    else
+      :error
+    end
+  end
+
+  @doc "Returns the source locations retained by a fused location."
+  @spec locations(t()) :: {:ok, [t()]} | :error
+  def locations(%__MODULE__{} = location) do
+    with true <- fused?(location),
+         {:ok, count} <- location_count(location) do
+      {:ok,
+       for position <- zero_based_range(count) do
+         CAPI.beaverLocationFusedGetLocationAt(location, position)
+       end}
+    else
+      _ -> :error
+    end
+  end
+
+  @doc """
+  Returns a fused location's metadata attribute.
+
+  The returned attribute may be MLIR's null attribute when the fused location
+  has no metadata; use `Beaver.MLIR.null?/1` to distinguish that case.
+  """
+  @spec metadata(t()) :: {:ok, MLIR.Attribute.t()} | :error
+  def metadata(%__MODULE__{} = location) do
+    if fused?(location), do: {:ok, CAPI.mlirLocationFusedGetMetadata(location)}, else: :error
+  end
+
+  @doc "Returns the location as its underlying location attribute."
+  @spec attribute(t()) :: MLIR.Attribute.t()
+  def attribute(%__MODULE__{} = location), do: CAPI.mlirLocationGetAttribute(location)
+
+  @doc "Converts a location attribute back to a location."
+  @spec from_attribute(MLIR.Attribute.t()) :: t()
+  def from_attribute(%MLIR.Attribute{} = attribute) do
+    unless MLIR.Attribute.location?(attribute) do
+      raise ArgumentError, "expected an MLIR location attribute"
+    end
+
+    CAPI.mlirLocationFromAttribute(attribute)
+  end
+
+  @doc "Returns whether the location is an MLIR unknown location."
+  @spec unknown?(t()) :: boolean()
+  def unknown?(%__MODULE__{} = location),
+    do: location |> CAPI.mlirLocationIsAUnknown() |> to_term()
+
+  @doc "Returns whether the location is an MLIR file range location."
+  @spec file_range?(t()) :: boolean()
+  def file_range?(%__MODULE__{} = location),
+    do: location |> CAPI.mlirLocationIsAFileLineColRange() |> to_term()
+
+  @doc "Returns whether the location is an MLIR named location."
+  @spec name?(t()) :: boolean()
+  def name?(%__MODULE__{} = location),
+    do: location |> CAPI.mlirLocationIsAName() |> to_term()
+
+  @doc "Returns whether the location is an MLIR call-site location."
+  @spec call_site?(t()) :: boolean()
+  def call_site?(%__MODULE__{} = location),
+    do: location |> CAPI.mlirLocationIsACallSite() |> to_term()
+
+  @doc "Returns whether the location is an MLIR fused location."
+  @spec fused?(t()) :: boolean()
+  def fused?(%__MODULE__{} = location),
+    do: location |> CAPI.mlirLocationIsAFused() |> to_term()
+
+  defp resolve_metadata(nil, _ctx), do: MLIR.Attribute.null()
+
+  defp resolve_metadata(metadata, ctx) do
+    case Deferred.create(metadata, ctx) do
+      %MLIR.Attribute{} = attribute ->
+        unless MLIR.equal?(MLIR.context(attribute), ctx) do
+          raise ArgumentError, "location metadata belongs to a different MLIR context"
+        end
+
+        attribute
+
+      other ->
+        raise ArgumentError, "location metadata must be an MLIR attribute, got: #{inspect(other)}"
+    end
+  end
+
+  defp infer_context(opts, sources) do
+    case opts[:ctx] || Enum.find_value(sources, &context_of/1) do
+      nil -> opts
+      ctx -> Keyword.put(opts, :ctx, ctx)
+    end
+  end
+
+  defp context_of(%module{} = entity)
+       when module in [__MODULE__, MLIR.Operation, MLIR.Value, MLIR.Attribute],
+       do: MLIR.context(entity)
+
+  defp context_of(_other), do: nil
+
+  defp zero_based_range(0), do: []
+  defp zero_based_range(count), do: 0..(count - 1)
+
+  defp to_term(value), do: Beaver.Native.to_term(value)
 
   @spec env_file_opts(String.t(), integer(), env_opts()) :: file_opts()
   defp env_file_opts(name, line, opts) do

--- a/lib/beaver/mlir/operation.ex
+++ b/lib/beaver/mlir/operation.ex
@@ -59,6 +59,15 @@ defmodule Beaver.MLIR.Operation do
   end
 
   defdelegate location(op), to: MLIR.CAPI, as: :mlirOperationGetLocation
+
+  @doc "Sets an operation's location and returns the operation."
+  @spec set_location(__MODULE__.t(), MLIR.Location.source()) :: __MODULE__.t()
+  def set_location(%__MODULE__{} = operation, location) do
+    location = MLIR.Location.resolve(location, MLIR.context(operation))
+    :ok = mlirOperationSetLocation(operation, location)
+    operation
+  end
+
   defdelegate parent(op), to: MLIR.CAPI, as: :mlirOperationGetParentOperation
   defdelegate destroy(op), to: MLIR.CAPI, as: :mlirOperationDestroy
   defdelegate clone(op), to: MLIR.CAPI, as: :mlirOperationClone

--- a/lib/beaver/mlir/value.ex
+++ b/lib/beaver/mlir/value.ex
@@ -55,6 +55,26 @@ defmodule Beaver.MLIR.Value do
   """
   defdelegate type(value), to: CAPI, as: :mlirValueGetType
 
+  @doc "Returns the source location carried by this value."
+  defdelegate location(value), to: CAPI, as: :mlirValueGetLocation
+
+  @doc """
+  Sets the location of a block argument and returns the value.
+
+  Operation-result locations are inherited from their defining operation and
+  cannot be set independently.
+  """
+  @spec set_location(t(), MLIR.Location.source()) :: t()
+  def set_location(%__MODULE__{} = value, location) do
+    unless argument?(value) do
+      raise ArgumentError, "only block argument locations can be set"
+    end
+
+    location = MLIR.Location.resolve(location, MLIR.context(value))
+    :ok = CAPI.mlirBlockArgumentSetLocation(value, location)
+    value
+  end
+
   @doc """
   Replaces uses of `value` for which `predicate` returns `true`.
 

--- a/native/include/mlir-c/Beaver/Op.h
+++ b/native/include/mlir-c/Beaver/Op.h
@@ -96,6 +96,11 @@ MLIR_CAPI_EXPORTED MlirAttribute beaverGetReassociationIndicesForReshape(
 MLIR_CAPI_EXPORTED void beaverLocationPrint(MlirLocation location,
                                             MlirStringCallback callback,
                                             void *userData);
+// MLIR's upstream C API exposes fused children through a caller-owned output
+// buffer. An indexed accessor keeps that buffer and its lifetime behind
+// Beaver's native ABI boundary.
+MLIR_CAPI_EXPORTED MlirLocation
+beaverLocationFusedGetLocationAt(MlirLocation location, intptr_t position);
 MLIR_CAPI_EXPORTED void mlirIdentifierPrint(MlirIdentifier identifier,
                                             MlirStringCallback callback,
                                             void *userData);

--- a/native/lib/CAPI/Beaver.cpp
+++ b/native/lib/CAPI/Beaver.cpp
@@ -319,6 +319,15 @@ MLIR_CAPI_EXPORTED void beaverLocationPrint(MlirLocation location,
   }
 }
 
+MLIR_CAPI_EXPORTED MlirLocation
+beaverLocationFusedGetLocationAt(MlirLocation location, intptr_t position) {
+  FusedLoc fused = llvm::cast<FusedLoc>(unwrap(location));
+  ArrayRef<Location> locations = fused.getLocations();
+  assert(position >= 0 && static_cast<size_t>(position) < locations.size() &&
+         "fused location index out of bounds");
+  return wrap(locations[position]);
+}
+
 MLIR_CAPI_EXPORTED void mlirIdentifierPrint(MlirIdentifier identifier,
                                             MlirStringCallback callback,
                                             void *userData) {

--- a/test/analysis_and_rewrite_utilities_test.exs
+++ b/test/analysis_and_rewrite_utilities_test.exs
@@ -152,7 +152,7 @@ defmodule AnalysisAndRewriteUtilitiesTest do
 
     try do
       new_location = MLIR.Location.file(name: "clone.mlir", line: 7, column: 11, ctx: ctx)
-      :ok = MLIR.CAPI.mlirOperationSetLocation(clone, new_location)
+      assert ^clone = MLIR.Operation.set_location(clone, new_location)
 
       refute MLIR.Operation.equivalent?(func, clone)
       assert MLIR.Operation.equivalent?(func, clone, ignore_locations: true)

--- a/test/location_test.exs
+++ b/test/location_test.exs
@@ -1,0 +1,123 @@
+defmodule Beaver.MLIR.LocationTest do
+  use Beaver.Case, async: true
+
+  alias Beaver.Changeset
+  alias Beaver.MLIR
+
+  test "constructs and safely inspects source ranges", %{ctx: ctx} do
+    location =
+      MLIR.Location.file_range(
+        name: "source.ex",
+        start_line: 4,
+        start_column: 2,
+        end_line: 6,
+        end_column: 9,
+        ctx: ctx
+      )
+
+    assert MLIR.Location.kind(location) == :file_range
+    assert MLIR.Location.file_range?(location)
+
+    assert MLIR.Location.source_range(location) ==
+             {:ok,
+              %{
+                file: "source.ex",
+                start_line: 4,
+                start_column: 2,
+                end_line: 6,
+                end_column: 9
+              }}
+
+    assert MLIR.Location.name(location) == :error
+  end
+
+  test "retains nested named and call-site provenance", %{ctx: ctx} do
+    callee = MLIR.Location.file(name: "callee.ex", line: 11, column: 3, ctx: ctx)
+    caller = MLIR.Location.file(name: "caller.ex", line: 29, column: 7, ctx: ctx)
+    named = MLIR.Location.named("lowered", callee)
+    call_site = MLIR.Location.call_site(named, caller)
+
+    assert MLIR.Location.kind(named) == :name
+    assert MLIR.Location.name(named) == {:ok, "lowered"}
+    assert {:ok, child} = MLIR.Location.child(named)
+    assert MLIR.equal?(child, callee)
+
+    assert MLIR.Location.kind(call_site) == :call_site
+    assert {:ok, actual_callee} = MLIR.Location.callee(call_site)
+    assert {:ok, actual_caller} = MLIR.Location.caller(call_site)
+    assert MLIR.equal?(actual_callee, named)
+    assert MLIR.equal?(actual_caller, caller)
+    assert MLIR.Location.metadata(call_site) == :error
+  end
+
+  test "retains fused children and metadata and round-trips its attribute", %{ctx: ctx} do
+    source = MLIR.Location.file(name: "origin.ex", line: 5, ctx: ctx)
+    second_source = MLIR.Location.file(name: "generated.ex", line: 8, ctx: ctx)
+    metadata = MLIR.Attribute.string("rewrite-stage", ctx: ctx)
+    single_source_fused = MLIR.Location.with_metadata(source, metadata)
+    fused = MLIR.Location.with_metadata([source, second_source], metadata)
+
+    assert MLIR.Location.fused?(single_source_fused)
+    assert MLIR.Location.location_count(single_source_fused) == {:ok, 1}
+
+    assert MLIR.Location.kind(fused) == :fused
+    assert MLIR.Location.location_count(fused) == {:ok, 2}
+    assert {:ok, [actual_source, actual_second_source]} = MLIR.Location.locations(fused)
+    assert MLIR.equal?(actual_source, source)
+    assert MLIR.equal?(actual_second_source, second_source)
+    assert {:ok, actual_metadata} = MLIR.Location.metadata(fused)
+    assert MLIR.equal?(actual_metadata, metadata)
+
+    attribute = MLIR.Location.attribute(fused)
+    assert MLIR.Attribute.location?(attribute)
+    assert attribute |> MLIR.Location.from_attribute() |> MLIR.equal?(fused)
+  end
+
+  test "reads and updates operation, result, and block argument provenance", %{ctx: ctx} do
+    original = MLIR.Location.file(name: "original.ex", line: 1, ctx: ctx)
+    replacement = MLIR.Location.file(name: "replacement.ex", line: 2, ctx: ctx)
+
+    operation =
+      %Changeset{name: "arith.constant", context: ctx, location: original}
+      |> Changeset.add_result(MLIR.Type.i32(ctx: ctx))
+      |> MLIR.Operation.create()
+
+    block = MLIR.Block.create([MLIR.Type.i32(ctx: ctx)], [original])
+
+    try do
+      result = MLIR.Operation.result(operation, 0)
+      argument = MLIR.Block.get_arg!(block, 0)
+
+      assert MLIR.equal?(MLIR.Value.location(result), original)
+      assert MLIR.equal?(MLIR.Value.location(argument), original)
+
+      assert ^operation = MLIR.Operation.set_location(operation, replacement)
+      assert MLIR.equal?(MLIR.Operation.location(operation), replacement)
+      assert MLIR.equal?(MLIR.Value.location(result), replacement)
+
+      assert ^argument = MLIR.Value.set_location(argument, replacement)
+      assert MLIR.equal?(MLIR.Value.location(argument), replacement)
+
+      assert_raise ArgumentError, "only block argument locations can be set", fn ->
+        MLIR.Value.set_location(result, original)
+      end
+    after
+      MLIR.Block.destroy(block)
+      MLIR.Operation.destroy(operation)
+    end
+  end
+
+  test "rejects provenance from a different context", %{ctx: ctx} do
+    other_ctx = MLIR.Context.create()
+
+    try do
+      source = MLIR.Location.file(name: "other.ex", line: 1, ctx: other_ctx)
+
+      assert_raise ArgumentError, "location belongs to a different MLIR context", fn ->
+        MLIR.Location.named("wrong-context", source, ctx: ctx)
+      end
+    after
+      MLIR.Context.destroy(other_ctx)
+    end
+  end
+end


### PR DESCRIPTION
## What changed

- expose high-level constructors and safe inspectors for file ranges, named, call-site, fused, and attribute-backed MLIR locations
- preserve fused metadata and accept operations or values directly as provenance sources, with cross-context validation
- add operation and block-argument location setters plus value location access
- add a native indexed fused-child accessor so caller-owned C buffers do not cross the BEAM ABI boundary

## Why

Beaver already generated the current upstream location C API, but users had to call unsafe kind-specific C getters directly and manually thread locations through transformations. Fused metadata and child provenance were especially awkward because upstream returns children through a mutable output buffer.

## Impact

Transformations can now retain, combine, inspect, and update provenance without dropping to raw CAPI calls. Invalid kind inspection returns error instead of reaching MLIR assertions, and locations or metadata from a different context are rejected before native calls.

## Root cause

The generated ABI surface had advanced with MLIR, while Beaver Location remained limited to file, from_env, and unknown constructors. There was no high-level propagation contract or BEAM-safe fused-child read path.

## Verification

- mix format --check-formatted
- mix compile --warnings-as-errors with paired LLVM 24
- mix test: 421 passed, 30 excluded
- focused location and structural-equivalence tests: 14 passed
- mix docs generated successfully
- clang-format --dry-run --Werror on changed C/C++ files

Full-repo Credo strict and Dialyzer remain non-zero on existing main baseline findings; neither reported a new finding in the location implementation.