### PR TITLE
ex: take process capacity in process_table_reset

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -1124,7 +1124,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
   end
 
   defp intrinsic_function_type("ex.term.process_table_reset", _ctx) do
-    MLIR.Type.function([], [MLIR.Type.i64()])
+    MLIR.Type.function([MLIR.Type.i64()], [MLIR.Type.i64()])
   end
 
   defp intrinsic_function_type("ex.term.cont_save", _ctx) do

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -146,9 +146,9 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop spawn(fun = optional(base(dyn()))),
     results: [result: base(dyn())]
 
-  # Resets the runtime process table to a single fresh initial process; the
-  # scheduler driver calls this at program start.
-  defop process_table_reset(),
+  # Resets the runtime process table to a single fresh initial process with
+  # the given capacity; the scheduler driver calls this at program start.
+  defop process_table_reset(cap = all_of([base("!builtin.integer"), any()])),
     results: [result: all_of([base("!builtin.integer"), any()])]
 
   # Preemptive scheduler continuation primitives (#35 slice 5): a budgeted

--- a/lib/beaver/wasm/term_abi.ex
+++ b/lib/beaver/wasm/term_abi.ex
@@ -55,7 +55,7 @@ defmodule Beaver.Wasm.TermABI do
     "ex.term.mailbox_clear" => %{params: [], result: :i64},
     # process table / scheduler driver
     "ex.term.spawn" => %{params: [:i64], result: :i64},
-    "ex.term.process_table_reset" => %{params: [], result: :i64},
+    "ex.term.process_table_reset" => %{params: [:i64], result: :i64},
     "ex.term.schedule_next" => %{params: [], result: :i64},
     "ex.term.current_entry" => %{params: [], result: :i64},
     "ex.term.process_done" => %{params: [:i64], result: :i64},

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -690,7 +690,7 @@ defmodule ExConversionTest do
             %2 = "ex.lit"() {value = 2 : i64} : () -> i64
             %3 = "ex.box"(%0) : (i64) -> !ex.dyn
             %4 = "ex.spawn"(%3) : (!ex.dyn) -> !ex.dyn
-            %5 = "ex.process_table_reset"() : () -> i64
+            %5 = "ex.process_table_reset"(%1) : (i64) -> i64
             %6 = "ex.cont_save"(%1, %2, %0) : (i64, i64, i64) -> i64
             %7 = "ex.receive_cont_save"(%1, %2, %0) : (i64, i64, i64) -> i64
             %8 = "ex.cont_pending"() : () -> i64


### PR DESCRIPTION
batata 的 #42 收尾需要把 actor process 表容量参数化（默认 256、上限 4096），`ex.process_table_reset` 需要携带 cap 操作数。

改动：
- `ex.process_table_reset` op 增加 i64 `cap` 操作数；
- `ex.term.process_table_reset` ABI 签名由 `() -> i64` 改为 `(cap: i64) -> i64`；
- wasm 侧 `Beaver.Wasm.TermABI` manifest 同步；
- conversion 测试更新为新签名。

batata 侧 PR 将依赖此分支（通过 `BEAVER_REF` 指向，见 batata AGENTS.md 流程）。
