### PR TITLE
MLIR: make deferred context resolution explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ module {
     return %0 : tensor<2x3xf32>
   }
 }
-""".(ctx)
+""" |> Beaver.Deferred.resolve(ctx)
 |> Beaver.Composer.append(ToyPass)
 |> canonicalize
 |> Beaver.Composer.run!()
@@ -267,12 +267,14 @@ Each of these sub-ecosystems starts with a seed project/library. Beaver should e
 
 ## MLIR context management
 
-When calling higher-level APIs, it is ideal not to have MLIR context passing around everywhere.
-If no MLIR context provided, an attribute and type getter should return an anonymous function with MLIR context as argument.
-In Erlang, all values are copied, so it is very safe to pass around these anonymous functions.
-When creating an operation, these functions will be called with the MLIR context in an operation state.
-With this approach we achieve both succinctness and modularity, not having a global MLIR context.
-Usually a function accepting a MLIR context to create an operation or type is called a "creator" in Beaver.
+Higher-level builders accept `ctx:` for eager construction. Without it they
+return an explicit `%Beaver.Deferred{}` which can be composed into another
+builder or materialized with `Beaver.Deferred.resolve/2`.
+
+Deferred values are not anonymous callback functions: the distinct type keeps
+contextual construction separate from callback APIs and lets Beaver reject
+cross-context entities before entering MLIR's native boundary. This preserves
+succinct DSL code without introducing a process-global MLIR context.
 
 ## Development
 

--- a/lib/beaver.ex
+++ b/lib/beaver.ex
@@ -24,7 +24,11 @@ defmodule Beaver do
   - use `blk` for MLIR block
 
   ## Lazy creation of MLIR entities
-  In Beaver, various functions and sigils might return a function with a signature like `MLIR.Context.t() -> MLIR.Type.t()`, if the context is not provided. When a creator gets passed to a SSA expression, it will be called with the context to create the entity or later the operation. Deferring the creation of the entity until context available is intended to keep the DSL code clean and succinct. For more information, see the docs of module `Beaver.Deferred`.
+  In Beaver, contextual builders and sigils return a `%Beaver.Deferred{}` if a
+  context is not provided. When a deferred value is passed to an SSA
+  expression, Beaver resolves it with the operation's context. Explicit
+  deferred values keep contextual construction distinct from ordinary
+  callbacks. For more information, see `Beaver.Deferred`.
   """
 
   defmacro __using__(_) do
@@ -72,7 +76,7 @@ defmodule Beaver do
     dsl_block_ast = dsl_block |> Beaver.SSA.prewalk(&MLIR.Operation.eval_ssa/1)
 
     ctx_ast =
-      if ctx = Beaver.Deferred.fetch_context(opts) do
+      if ctx = Keyword.get(opts, :ctx) do
         quote do
           Kernel.var!(beaver_internal_env_ctx) = unquote(ctx)
 

--- a/lib/beaver/changeset.ex
+++ b/lib/beaver/changeset.ex
@@ -56,9 +56,12 @@ defmodule Beaver.Changeset do
     end
   end
 
-  def add_argument(%__MODULE__{context: context} = changeset, {tag, f})
-      when is_atom(tag) and is_function(f, 1) do
-    add_argument(changeset, {tag, Beaver.Deferred.create(f, context)})
+  def add_argument(
+        %__MODULE__{context: context} = changeset,
+        {tag, %Deferred{} = deferred}
+      )
+      when is_atom(tag) do
+    add_argument(changeset, {tag, Deferred.resolve(deferred, context)})
   end
 
   # f should return regions
@@ -75,14 +78,19 @@ defmodule Beaver.Changeset do
     %__MODULE__{changeset | regions: regions ++ [region]}
   end
 
-  def add_argument(%__MODULE__{} = changeset, {:loc, %Beaver.MLIR.Location{} = location}) do
-    %__MODULE__{changeset | location: location}
+  def add_argument(
+        %__MODULE__{context: context} = changeset,
+        {:loc, %MLIR.Location{} = location}
+      ) do
+    %__MODULE__{changeset | location: Deferred.resolve(location, context)}
   end
 
   def add_argument(
-        %__MODULE__{successors: successors, operands: operands} = changeset,
+        %__MODULE__{context: context, successors: successors, operands: operands} = changeset,
         {%MLIR.Block{} = successor_block, block_args}
       ) do
+    block_args = Enum.map(block_args, &Deferred.resolve(&1, context))
+
     %__MODULE__{
       changeset
       | successors: successors ++ [successor_block],
@@ -111,18 +119,20 @@ defmodule Beaver.Changeset do
   end
 
   def add_argument(
-        %__MODULE__{attributes: attributes} = changeset,
+        %__MODULE__{context: context, attributes: attributes} = changeset,
         {name, %MLIR.Attribute{} = attr}
       )
       when is_atom(name) do
+    attr = Deferred.resolve(attr, context)
     %__MODULE__{changeset | attributes: attributes ++ [{name, attr}]}
   end
 
   def add_argument(
-        %__MODULE__{attributes: attributes} = changeset,
+        %__MODULE__{context: context, attributes: attributes} = changeset,
         {name, %MLIR.Type{} = type}
       )
       when is_atom(name) do
+    type = Deferred.resolve(type, context)
     %__MODULE__{changeset | attributes: attributes ++ [{name, type}]}
   end
 
@@ -135,25 +145,28 @@ defmodule Beaver.Changeset do
   end
 
   def add_argument(
-        %__MODULE__{operands: operands} = changeset,
-        {operand_name, %MLIR.Value{}} = operand
+        %__MODULE__{context: context, operands: operands} = changeset,
+        {operand_name, %MLIR.Value{} = value}
       )
       when is_atom(operand_name) do
+    operand = {operand_name, Deferred.resolve(value, context)}
     %__MODULE__{changeset | operands: operands ++ [operand]}
   end
 
   def add_argument(
-        %__MODULE__{operands: operands} = changeset,
-        {operand_name, variadic_operands} = operand
+        %__MODULE__{context: context, operands: operands} = changeset,
+        {operand_name, variadic_operands}
       )
       when is_atom(operand_name) and is_list(variadic_operands) do
+    operand = {operand_name, Enum.map(variadic_operands, &Deferred.resolve(&1, context))}
     %__MODULE__{changeset | operands: operands ++ [operand]}
   end
 
   def add_argument(
-        %__MODULE__{operands: operands} = changeset,
+        %__MODULE__{context: context, operands: operands} = changeset,
         %MLIR.Value{} = operand
       ) do
+    operand = Deferred.resolve(operand, context)
     %__MODULE__{changeset | operands: operands ++ [operand]}
   end
 
@@ -181,8 +194,8 @@ defmodule Beaver.Changeset do
     end
   end
 
-  def add_result(%__MODULE__{context: context} = changeset, f) when is_function(f, 1) do
-    add_result(changeset, Beaver.Deferred.create(f, context))
+  def add_result(%__MODULE__{context: context} = changeset, %Deferred{} = deferred) do
+    add_result(changeset, Deferred.resolve(deferred, context))
   end
 
   def add_result(%__MODULE__{results: :infer}, type) when type != :infer do
@@ -193,7 +206,11 @@ defmodule Beaver.Changeset do
     %__MODULE__{changeset | results: :infer}
   end
 
-  def add_result(%__MODULE__{results: results} = changeset, %MLIR.Type{} = result_type) do
+  def add_result(
+        %__MODULE__{context: context, results: results} = changeset,
+        %MLIR.Type{} = result_type
+      ) do
+    result_type = Deferred.resolve(result_type, context)
     %__MODULE__{changeset | results: results ++ [result_type]}
   end
 
@@ -264,7 +281,7 @@ defmodule Beaver.Changeset do
           attributes
           |> Keyword.delete(:operand_segment_sizes)
           |> Keyword.delete(:operandSegmentSizes)
-          |> Keyword.put(:operand_segment_sizes, Beaver.Deferred.create(segment_sizes, context))
+          |> Keyword.put(:operand_segment_sizes, Beaver.Deferred.resolve(segment_sizes, context))
 
         _ ->
           attributes

--- a/lib/beaver/deferred.ex
+++ b/lib/beaver/deferred.ex
@@ -1,32 +1,68 @@
 defmodule Beaver.Deferred do
   @moduledoc """
-  Functions to work with IR entities not eagerly created. Usually it is an attribute/type doesn't get created until there is a MLIR context from block/op state.
+  Explicit, context-bound construction of MLIR entities.
+
+  MLIR types, attributes, locations, and similar entities belong to an
+  `Beaver.MLIR.Context`. Builders return a `%Beaver.Deferred{}` when no `:ctx`
+  option is supplied and return the concrete entity when one is supplied.
+
+  A deferred value is deliberately distinct from an ordinary one-argument
+  callback. Materialize it with `resolve/2`; passing a concrete context-owned
+  entity through `resolve/2` also verifies that it belongs to that context.
   """
   alias Beaver.MLIR
 
+  @enforce_keys [:resolver]
+  defstruct [:resolver]
+
   @type context_arg() :: MLIR.Context.t()
-  @type contextual(t) :: t | (context_arg() -> t)
-  @type deferred(t) :: contextual(t)
+  @opaque t(value) :: %__MODULE__{resolver: (context_arg() -> value)}
+  @type contextual(value) :: value | t(value)
   @type opts :: [ctx: context_arg()]
   @type type :: contextual(MLIR.Type.t())
   @type operation :: contextual(MLIR.Operation.t())
   @type attribute :: contextual(MLIR.Attribute.t())
 
-  @spec from_opts(opts(), (context_arg() -> t)) :: contextual(t) when t: var
-  def from_opts(opts, f) do
-    if ctx = fetch_context(opts) do
-      f.(ctx)
-    else
-      f
+  @doc "Wraps a context resolver as an explicit deferred value."
+  @spec defer((context_arg() -> value)) :: t(value) when value: var
+  def defer(resolver) when is_function(resolver, 1), do: %__MODULE__{resolver: resolver}
+
+  @doc """
+  Runs `resolver` immediately when `opts` contains `:ctx`; otherwise defers it.
+
+  An explicitly supplied `ctx: nil` or any non-context value is rejected rather
+  than being treated as if the option were absent.
+  """
+  @spec from_opts(opts(), (context_arg() -> value)) :: contextual(value) when value: var
+  def from_opts(opts, resolver) when is_list(opts) and is_function(resolver, 1) do
+    case Keyword.fetch(opts, :ctx) do
+      :error ->
+        defer(resolver)
+
+      {:ok, %MLIR.Context{} = ctx} ->
+        resolver.(ctx) |> MLIR.Context.ensure_same!(ctx)
+
+      {:ok, invalid} ->
+        raise ArgumentError, "expected :ctx to be an MLIR context, got: #{inspect(invalid)}"
     end
   end
 
-  @spec fetch_context(opts :: opts) :: MLIR.Context.t() | nil
-  def fetch_context(opts) do
-    opts[:ctx]
+  @doc "Returns the optional context in `opts`, validating an explicitly supplied value."
+  @spec context(opts()) :: context_arg() | nil
+  def context(opts) when is_list(opts) do
+    case Keyword.fetch(opts, :ctx) do
+      :error ->
+        nil
+
+      {:ok, %MLIR.Context{} = ctx} ->
+        ctx
+
+      {:ok, invalid} ->
+        raise ArgumentError, "expected :ctx to be an MLIR context, got: #{inspect(invalid)}"
+    end
   end
 
-  @spec fetch_insertion_point(opts :: opts) ::
+  @spec fetch_insertion_point(keyword()) ::
           MLIR.Block.t() | MLIR.PatternRewriter.t() | MLIR.RewriterBase.t() | Macro.t() | nil
   def fetch_insertion_point(opts) do
     for key <- [:block, :blk] do
@@ -38,27 +74,45 @@ defmodule Beaver.Deferred do
     opts[:ip]
   end
 
-  defp unwrap_f(f, ctx) do
-    case f.(ctx) do
-      {:ok, value} -> value
-      {:error, reason} -> raise ArgumentError, reason
-      entity -> entity
-    end
+  @doc """
+  Materializes a deferred value in `ctx`.
+
+  Concrete context-owned entities pass through unchanged after their context
+  ownership has been checked. Resolvers may return `{:ok, value}` or
+  `{:error, reason}`; success is unwrapped and errors become `ArgumentError`.
+  """
+  @spec resolve(contextual(value), context_arg()) :: value when value: var
+  def resolve(resolver, %MLIR.Context{}) when is_function(resolver, 1) do
+    raise ArgumentError,
+          "bare context resolvers are not deferred values; wrap the function with defer/1"
   end
 
-  def create({:parametric, _, _, f}, ctx) when is_function(f) and not is_nil(ctx) do
-    unwrap_f(f, ctx)
+  def resolve(value, %MLIR.Context{} = ctx) do
+    value
+    |> do_resolve(ctx)
+    |> MLIR.Context.ensure_same!(ctx)
   end
 
-  def create({:parametric, _, _, entity}, _ctx) do
-    entity
+  def resolve(_value, invalid) do
+    raise ArgumentError, "expected an MLIR context, got: #{inspect(invalid)}"
   end
 
-  def create(f, ctx) when is_function(f) do
-    unwrap_f(f, ctx)
+  defp do_resolve({:parametric, _, _, deferred}, ctx), do: do_resolve(deferred, ctx)
+
+  defp do_resolve(%__MODULE__{resolver: resolver}, ctx) do
+    resolver.(ctx)
+    |> unwrap()
+    |> do_resolve(ctx)
   end
 
-  def create(entity, _ctx) do
-    entity
+  defp do_resolve(entity, _ctx), do: entity
+
+  defp unwrap({:ok, value}), do: value
+
+  defp unwrap({:error, reason}) do
+    message = if is_binary(reason), do: reason, else: inspect(reason)
+    raise ArgumentError, message
   end
+
+  defp unwrap(value), do: value
 end

--- a/lib/beaver/mlir.ex
+++ b/lib/beaver/mlir.ex
@@ -82,14 +82,14 @@ defmodule Beaver.MLIR do
     apply(CAPI, :"mlir#{entity_name}Equal", [a, b]) |> Beaver.Native.to_term()
   end
 
-  def equal?(a, b) when is_function(a, 1) do
+  def equal?(%Deferred{} = a, b) do
     ctx = context(b)
-    equal?(Beaver.Deferred.create(a, ctx), b)
+    equal?(Beaver.Deferred.resolve(a, ctx), b)
   end
 
-  def equal?(a, b) when is_function(b, 1) do
+  def equal?(a, %Deferred{} = b) do
     ctx = context(a)
-    equal?(a, Beaver.Deferred.create(b, ctx))
+    equal?(a, Beaver.Deferred.resolve(b, ctx))
   end
 
   @type nullable() ::
@@ -250,8 +250,8 @@ defmodule Beaver.MLIR do
     pm |> mlirPassManagerGetAsOpPassManager() |> __MODULE__.to_string()
   end
 
-  def to_string(f, opts) when is_function(f) do
-    Beaver.Deferred.create(f, Keyword.fetch!(opts, :ctx)) |> to_string(opts)
+  def to_string(%Deferred{} = deferred, opts) do
+    Deferred.resolve(deferred, Deferred.context(opts)) |> to_string(opts)
   end
 
   def to_string(%m{} = entity, _opts) do

--- a/lib/beaver/mlir/affine_map.ex
+++ b/lib/beaver/mlir/affine_map.ex
@@ -14,7 +14,7 @@ defmodule Beaver.MLIR.AffineMap do
           exprs
           |> Enum.map(fn
             const when is_integer(const) -> MLIR.CAPI.mlirAffineConstantExprGet(ctx, const)
-            f when is_function(f, 1) -> f.(ctx)
+            %Beaver.Deferred{} = deferred -> Beaver.Deferred.resolve(deferred, ctx)
             expr -> expr
           end)
 

--- a/lib/beaver/mlir/attribute.ex
+++ b/lib/beaver/mlir/attribute.ex
@@ -176,12 +176,12 @@ defmodule Beaver.MLIR.Attribute do
       opts,
       fn ctx ->
         shaped_type =
-          case Beaver.Deferred.create(shaped_type, ctx) do
+          case Beaver.Deferred.resolve(shaped_type, ctx) do
             {:ok, %Beaver.MLIR.Type{} = t} -> t
             %Beaver.MLIR.Type{} = t -> t
           end
 
-        elements = elements_or_value |> Enum.map(&Beaver.Deferred.create(&1, ctx))
+        elements = elements_or_value |> Enum.map(&Beaver.Deferred.resolve(&1, ctx))
         num_elements = length(elements)
 
         shaped_type_num_elements =
@@ -201,8 +201,8 @@ defmodule Beaver.MLIR.Attribute do
     Beaver.Deferred.from_opts(
       opts,
       fn ctx ->
-        value = Beaver.Deferred.create(value, ctx)
-        shaped_type = Beaver.Deferred.create(shaped_type, ctx)
+        value = Beaver.Deferred.resolve(value, ctx)
+        shaped_type = Beaver.Deferred.resolve(shaped_type, ctx)
         dense_elements_splat_get(shaped_type, value, ctx)
       end
     )
@@ -216,7 +216,7 @@ defmodule Beaver.MLIR.Attribute do
           ctx,
           length(elements),
           elements
-          |> Enum.map(&Beaver.Deferred.create(&1, ctx))
+          |> Enum.map(&Beaver.Deferred.resolve(&1, ctx))
           |> Beaver.Native.array(MLIR.Attribute)
         )
       end
@@ -270,7 +270,7 @@ defmodule Beaver.MLIR.Attribute do
           ctx,
           length(elements),
           elements
-          |> Enum.map(&Beaver.Deferred.create(&1, ctx))
+          |> Enum.map(&Beaver.Deferred.resolve(&1, ctx))
           |> Beaver.Native.array(MLIR.NamedAttribute)
         )
       end
@@ -284,9 +284,8 @@ defmodule Beaver.MLIR.Attribute do
     )
   end
 
-  def type(t)
-      when is_function(t, 1) do
-    &type(t.(&1))
+  def type(%Beaver.Deferred{} = type) do
+    Beaver.Deferred.defer(&type(Beaver.Deferred.resolve(type, &1)))
   end
 
   def type(%MLIR.Type{} = t) do
@@ -298,7 +297,9 @@ defmodule Beaver.MLIR.Attribute do
     if validate.(t), do: get.(t), else: raise(ArgumentError, "incompatible type #{to_string(t)}")
   end
 
-  defp composite(t, validate, get) when is_function(t, 1), do: &composite(t.(&1), validate, get)
+  defp composite(%Beaver.Deferred{} = type, validate, get) do
+    Beaver.Deferred.defer(&composite(Beaver.Deferred.resolve(type, &1), validate, get))
+  end
 
   def integer(t, value) when is_integer(value) do
     composite(
@@ -327,8 +328,8 @@ defmodule Beaver.MLIR.Attribute do
     )
   end
 
-  def affine_map(map) when is_function(map, 1) do
-    &affine_map(map.(&1))
+  def affine_map(%Beaver.Deferred{} = map) do
+    Beaver.Deferred.defer(&affine_map(Beaver.Deferred.resolve(map, &1)))
   end
 
   def affine_map(%MLIR.AffineMap{} = map) do
@@ -371,7 +372,9 @@ defmodule Beaver.MLIR.Attribute do
   end
 
   def index(value, opts \\ []) when is_integer(value) do
-    Beaver.Deferred.from_opts(opts, ~a{#{value} : index})
+    Beaver.Deferred.from_opts(opts, fn ctx ->
+      Beaver.Deferred.resolve(~a{#{value} : index}, ctx)
+    end)
   end
 
   def null() do

--- a/lib/beaver/mlir/block.ex
+++ b/lib/beaver/mlir/block.ex
@@ -6,26 +6,30 @@ defmodule Beaver.MLIR.Block do
 
   use Kinda.ResourceKind, raw_module: Beaver.MLIR.CAPI.Raw, codec: Beaver.Native
 
-  defp do_add_args!(block, ctx, {t, loc}) when is_function(t, 1) or is_function(loc, 1) do
+  defp do_add_args!(block, ctx, {t, loc})
+       when is_struct(t, Beaver.Deferred) or is_struct(loc, Beaver.Deferred) do
     MLIR.CAPI.mlirBlockAddArgument(
       block,
-      t |> Beaver.Deferred.create(ctx),
-      loc |> Beaver.Deferred.create(ctx)
+      t |> Beaver.Deferred.resolve(ctx),
+      loc |> Beaver.Deferred.resolve(ctx)
     )
   end
 
   defp do_add_args!(block, ctx, {t = %Beaver.MLIR.Type{}, loc}) do
-    loc = loc |> Beaver.Deferred.create(ctx)
+    t = t |> Beaver.Deferred.resolve(ctx)
+    loc = loc |> Beaver.Deferred.resolve(ctx)
     MLIR.CAPI.mlirBlockAddArgument(block, t, loc)
   end
 
   defp do_add_args!(block, ctx, {t = {:parametric, _, _, _f}, loc}) do
-    t = Beaver.Deferred.create(t, ctx)
+    t = Beaver.Deferred.resolve(t, ctx)
+    loc = Beaver.Deferred.resolve(loc, ctx)
     MLIR.CAPI.mlirBlockAddArgument(block, t, loc)
   end
 
   defp do_add_args!(block, ctx, {t, loc}) do
     t = MLIR.CAPI.mlirTypeParseGet(ctx, MLIR.StringRef.create(t))
+    loc = Beaver.Deferred.resolve(loc, ctx)
     MLIR.CAPI.mlirBlockAddArgument(block, t, loc)
   end
 
@@ -42,7 +46,7 @@ defmodule Beaver.MLIR.Block do
   """
   def add_args!(block, args, opts \\ []) when is_list(args) do
     ctx =
-      opts[:ctx] ||
+      Beaver.Deferred.context(opts) ||
         Enum.find_value(args, fn
           t = %MLIR.Type{} -> MLIR.context(t)
           {t = %MLIR.Type{}, _} -> MLIR.context(t)

--- a/lib/beaver/mlir/context.ex
+++ b/lib/beaver/mlir/context.ex
@@ -101,6 +101,49 @@ defmodule Beaver.MLIR.Context do
     end
   end
 
+  @context_owned_modules [
+    MLIR.AffineExpr,
+    MLIR.AffineMap,
+    MLIR.Attribute,
+    MLIR.Dialect,
+    MLIR.Identifier,
+    MLIR.IntegerSet,
+    MLIR.Location,
+    MLIR.Module,
+    MLIR.Operation,
+    MLIR.Type,
+    MLIR.Value
+  ]
+
+  @doc "Returns whether two handles refer to the same MLIR context."
+  @spec same?(t(), t()) :: boolean()
+  def same?(%__MODULE__{} = left, %__MODULE__{} = right), do: MLIR.equal?(left, right)
+
+  @doc """
+  Verifies that a context-owned MLIR entity belongs to `expected`.
+
+  Context-free values pass through unchanged, which makes this suitable for
+  validating the output of contextual builders at their common boundary.
+  """
+  @spec ensure_same!(term(), t()) :: term()
+  def ensure_same!(%module{} = entity, %__MODULE__{} = expected)
+      when module in @context_owned_modules do
+    if not MLIR.null?(entity) and not same?(MLIR.context(entity), expected) do
+      kind = module |> Module.split() |> List.last() |> Macro.underscore()
+      raise ArgumentError, "#{kind} belongs to a different MLIR context"
+    end
+
+    entity
+  end
+
+  def ensure_same!({:ok, entity}, %__MODULE__{} = expected),
+    do: {:ok, ensure_same!(entity, expected)}
+
+  def ensure_same!(entities, %__MODULE__{} = expected) when is_list(entities),
+    do: Enum.map(entities, &ensure_same!(&1, expected))
+
+  def ensure_same!(entity, %__MODULE__{}), do: entity
+
   defp resolve_thread_pool(_opts, false), do: {nil, nil, nil}
 
   defp resolve_thread_pool(opts, true) do

--- a/lib/beaver/mlir/dialect/builtin.ex
+++ b/lib/beaver/mlir/dialect/builtin.ex
@@ -28,7 +28,7 @@ defmodule Beaver.MLIR.Dialect.Builtin do
       for {name, attr} <- unquote(attrs) do
         name = name |> Beaver.MLIR.StringRef.create()
 
-        attr = Beaver.Deferred.create(attr, ctx)
+        attr = Beaver.Deferred.resolve(attr, ctx)
 
         module
         |> Beaver.MLIR.CAPI.mlirModuleGetOperation()

--- a/lib/beaver/mlir/dialect/dlti.ex
+++ b/lib/beaver/mlir/dialect/dlti.ex
@@ -3,7 +3,7 @@ defmodule Beaver.MLIR.Dialect.DLTI do
   Operations and structured attribute builders for MLIR DLTI.
 
   DLTI attributes are contextual, so all builders follow Beaver's deferred
-  convention: pass `ctx:` for eager creation or pass the returned creator to
+  convention: pass `ctx:` for eager creation or pass the returned deferred value to
   another builder or operation.
   """
 
@@ -101,7 +101,7 @@ defmodule Beaver.MLIR.Dialect.DLTI do
 
   defp put_attribute(operation_or_module, name, attribute) do
     operation = MLIR.Operation.from_module(operation_or_module)
-    attribute = Beaver.Deferred.create(attribute, MLIR.context(operation))
+    attribute = Beaver.Deferred.resolve(attribute, MLIR.context(operation))
     MLIR.Operation.get_and_update(operation, name, fn _ -> {nil, attribute} end)
     operation_or_module
   end
@@ -122,7 +122,7 @@ defmodule Beaver.MLIR.Dialect.DLTI do
 
   defp render_entry(entry, ctx) do
     entry
-    |> Beaver.Deferred.create(ctx)
+    |> Beaver.Deferred.resolve(ctx)
     |> to_string()
   end
 
@@ -135,7 +135,7 @@ defmodule Beaver.MLIR.Dialect.DLTI do
 
   defp render_key(key, ctx) do
     key
-    |> Beaver.Deferred.create(ctx)
+    |> Beaver.Deferred.resolve(ctx)
     |> case do
       %MLIR.Type{} = type ->
         to_string(type)
@@ -159,7 +159,7 @@ defmodule Beaver.MLIR.Dialect.DLTI do
 
   defp render_value(value, ctx) do
     value
-    |> Beaver.Deferred.create(ctx)
+    |> Beaver.Deferred.resolve(ctx)
     |> case do
       %MLIR.Attribute{} = attribute -> to_string(attribute)
       %MLIR.Type{} = type -> type |> MLIR.Attribute.type() |> to_string()

--- a/lib/beaver/mlir/dialect/gpu.ex
+++ b/lib/beaver/mlir/dialect/gpu.ex
@@ -40,7 +40,7 @@ defmodule Beaver.MLIR.Dialect.GPU do
     * `:features` - target features, e.g. `"+ptx80"`
     * `:opt` - optimization level, an integer
 
-  Returns a deferred attribute creator unless `ctx:` is given, following the
+  Returns a deferred attribute value unless `ctx:` is given, following the
   convention of `MLIR.Attribute.get/2`. The resulting attribute can be passed
   to `package_binary!/3` as the target configuration of a `gpu.binary`.
   """
@@ -68,7 +68,7 @@ defmodule Beaver.MLIR.Dialect.GPU do
     * `:opt` - optimization level, an integer (defaults to `2`)
     * `:abi` - ABI version, e.g. `"600"`
 
-  Returns a deferred attribute creator unless `ctx:` is given, following the
+  Returns a deferred attribute value unless `ctx:` is given, following the
   convention of `MLIR.Attribute.get/2`. The resulting attribute can be passed
   to `package_binary!/3` as the target configuration of a `gpu.binary`.
   """

--- a/lib/beaver/mlir/dialect/linalg.ex
+++ b/lib/beaver/mlir/dialect/linalg.ex
@@ -76,13 +76,13 @@ defmodule Beaver.MLIR.Dialect.Linalg do
 
   @doc "Build the array attribute used by `linalg.generic` indexing maps."
   def indexing_maps(maps) when is_list(maps) do
-    fn ctx ->
+    Beaver.Deferred.defer(fn ctx ->
       maps
       |> Enum.map(fn map ->
-        map |> Beaver.Deferred.create(ctx) |> MLIR.Attribute.affine_map()
+        map |> Beaver.Deferred.resolve(ctx) |> MLIR.Attribute.affine_map()
       end)
       |> MLIR.Attribute.array(ctx: ctx)
-    end
+    end)
   end
 
   @doc "Build and validate Linalg iterator types."
@@ -97,11 +97,11 @@ defmodule Beaver.MLIR.Dialect.Linalg do
         raise ArgumentError, "unsupported Linalg iterator type: #{inspect(invalid)}"
     end
 
-    fn ctx ->
+    Beaver.Deferred.defer(fn ctx ->
       iterators
       |> Enum.map(&MLIR.Attribute.get("#linalg.iterator_type<#{&1}>", ctx: ctx))
       |> MLIR.Attribute.array(ctx: ctx)
-    end
+    end)
   end
 
   @doc false

--- a/lib/beaver/mlir/dialect/llvm.ex
+++ b/lib/beaver/mlir/dialect/llvm.ex
@@ -234,7 +234,7 @@ defmodule Beaver.MLIR.Dialect.LLVM do
   def global(%Beaver.SSA{arguments: arguments, ctx: ctx} = ssa) do
     opts = Keyword.new(arguments)
     sym_name = Keyword.fetch!(opts, :sym_name)
-    type = opts |> Keyword.fetch!(:type) |> Beaver.Deferred.create(ctx)
+    type = opts |> Keyword.fetch!(:type) |> Beaver.Deferred.resolve(ctx)
     address_space = Keyword.get(opts, :address_space, 0)
 
     arguments = [
@@ -284,7 +284,7 @@ defmodule Beaver.MLIR.Dialect.LLVM do
 
   defp render_type(type, ctx) do
     type
-    |> Beaver.Deferred.create(ctx)
+    |> Beaver.Deferred.resolve(ctx)
     |> case do
       %MLIR.Type{} = type -> to_string(type)
       other -> raise ArgumentError, "expected an MLIR type, got: #{inspect(other)}"

--- a/lib/beaver/mlir/dialect/ptr.ex
+++ b/lib/beaver/mlir/dialect/ptr.ex
@@ -90,7 +90,7 @@ defmodule Beaver.MLIR.Dialect.Ptr do
       end)
 
     Deferred.from_opts(opts, fn ctx ->
-      pointer_type = Deferred.create(pointer_type, ctx)
+      pointer_type = Deferred.resolve(pointer_type, ctx)
       Attribute.get("#{source} : #{MLIR.to_string(pointer_type)}", ctx: ctx)
     end)
   end
@@ -103,5 +103,5 @@ defmodule Beaver.MLIR.Dialect.Ptr do
   defp materialize_memory_space(address_space, ctx) when is_integer(address_space),
     do: llvm_address_space(address_space, ctx: ctx)
 
-  defp materialize_memory_space(memory_space, ctx), do: Deferred.create(memory_space, ctx)
+  defp materialize_memory_space(memory_space, ctx), do: Deferred.resolve(memory_space, ctx)
 end

--- a/lib/beaver/mlir/dialect/vector.ex
+++ b/lib/beaver/mlir/dialect/vector.ex
@@ -30,7 +30,7 @@ defmodule Beaver.MLIR.Dialect.Vector do
   def transfer_read_(%Beaver.SSA{arguments: [base, padding | options], ctx: ctx} = ssa) do
     options = Keyword.new(options)
     indices = Keyword.get(options, :indices, [])
-    map = options |> Keyword.fetch!(:permutation_map) |> Beaver.Deferred.create(ctx)
+    map = options |> Keyword.fetch!(:permutation_map) |> Beaver.Deferred.resolve(ctx)
     bounds = Keyword.get(options, :in_bounds, [])
     mask = Keyword.get(options, :mask)
 

--- a/lib/beaver/mlir/location.ex
+++ b/lib/beaver/mlir/location.ex
@@ -204,8 +204,8 @@ defmodule Beaver.MLIR.Location do
   def of(%MLIR.Operation{} = operation), do: MLIR.Operation.location(operation)
   def of(%MLIR.Value{} = value), do: MLIR.Value.location(value)
 
-  def of(deferred) when is_function(deferred, 1) do
-    fn ctx -> deferred |> Deferred.create(ctx) |> of() end
+  def of(%Deferred{} = deferred) do
+    Deferred.defer(fn ctx -> deferred |> Deferred.resolve(ctx) |> of() end)
   end
 
   def of(other) do
@@ -216,13 +216,9 @@ defmodule Beaver.MLIR.Location do
   @doc "Resolves a location-bearing value in `ctx` and verifies context ownership."
   @spec resolve(source(), MLIR.Context.t()) :: t()
   def resolve(source, %MLIR.Context{} = ctx) do
-    location = source |> Deferred.create(ctx) |> of()
+    location = source |> Deferred.resolve(ctx) |> of()
 
-    unless MLIR.equal?(MLIR.context(location), ctx) do
-      raise ArgumentError, "location belongs to a different MLIR context"
-    end
-
-    location
+    MLIR.Context.ensure_same!(location, ctx)
   end
 
   @doc "Returns the built-in location kind, or `:other` for dialect-defined locations."
@@ -360,13 +356,9 @@ defmodule Beaver.MLIR.Location do
   defp resolve_metadata(nil, _ctx), do: MLIR.Attribute.null()
 
   defp resolve_metadata(metadata, ctx) do
-    case Deferred.create(metadata, ctx) do
+    case Deferred.resolve(metadata, ctx) do
       %MLIR.Attribute{} = attribute ->
-        unless MLIR.equal?(MLIR.context(attribute), ctx) do
-          raise ArgumentError, "location metadata belongs to a different MLIR context"
-        end
-
-        attribute
+        MLIR.Context.ensure_same!(attribute, ctx)
 
       other ->
         raise ArgumentError, "location metadata must be an MLIR attribute, got: #{inspect(other)}"
@@ -374,7 +366,7 @@ defmodule Beaver.MLIR.Location do
   end
 
   defp infer_context(opts, sources) do
-    case opts[:ctx] || Enum.find_value(sources, &context_of/1) do
+    case Deferred.context(opts) || Enum.find_value(sources, &context_of/1) do
       nil -> opts
       ctx -> Keyword.put(opts, :ctx, ctx)
     end

--- a/lib/beaver/mlir/module.ex
+++ b/lib/beaver/mlir/module.ex
@@ -32,10 +32,12 @@ defmodule Beaver.MLIR.Module do
 
   def create!(str, opts \\ []) when is_binary(str) do
     res =
-      Beaver.Deferred.from_opts(opts, fn ctx -> Beaver.Deferred.create(create(str, opts), ctx) end)
+      Beaver.Deferred.from_opts(opts, fn ctx ->
+        Beaver.Deferred.resolve(create(str, opts), ctx)
+      end)
 
     case res do
-      f when is_function(f, 1) ->
+      %Beaver.Deferred{} ->
         raise ArgumentError, "calling a bang function to parse module must be eager"
 
       {:error, diagnostics} ->

--- a/lib/beaver/mlir/named_attribute.ex
+++ b/lib/beaver/mlir/named_attribute.ex
@@ -25,12 +25,15 @@ defmodule Beaver.MLIR.NamedAttribute do
     Beaver.Deferred.from_opts(
       opts,
       fn ctx ->
-        mlirNamedAttributeGet(
+        identifier =
           case name do
             %MLIR.Identifier{} -> name
             s -> MLIR.Identifier.get(s, ctx: ctx)
-          end,
-          Beaver.Deferred.create(attr, ctx)
+          end
+
+        mlirNamedAttributeGet(
+          Beaver.Deferred.resolve(identifier, ctx),
+          Beaver.Deferred.resolve(attr, ctx)
         )
       end
     )

--- a/lib/beaver/mlir/operation.ex
+++ b/lib/beaver/mlir/operation.ex
@@ -222,7 +222,7 @@ defmodule Beaver.MLIR.Operation do
         mlirOperationSetAttributeByName(
           operation,
           MLIR.StringRef.create(attribute),
-          Beaver.Deferred.create(new_value, ctx)
+          Beaver.Deferred.resolve(new_value, ctx)
         )
 
       :pop ->

--- a/lib/beaver/mlir/operation/state.ex
+++ b/lib/beaver/mlir/operation/state.ex
@@ -8,11 +8,10 @@ defmodule Beaver.MLIR.Operation.State do
 
   defp prepare(
          %Beaver.Changeset{
-           location: location,
+           location: %MLIR.Location{} = location,
            context: nil
          } = changeset
-       )
-       when not is_nil(location) and not is_function(location) do
+       ) do
     %Beaver.Changeset{changeset | context: MLIR.context(location)}
   end
 
@@ -28,20 +27,20 @@ defmodule Beaver.MLIR.Operation.State do
 
   defp prepare(
          %Beaver.Changeset{
-           location: location,
-           context: context
+           location: %Beaver.Deferred{} = location,
+           context: %MLIR.Context{} = context
          } = changeset
-       )
-       when not is_nil(context) and is_function(location, 1) do
-    %Beaver.Changeset{changeset | location: location.(context)}
+       ) do
+    %Beaver.Changeset{changeset | location: Beaver.Deferred.resolve(location, context)}
   end
 
   defp prepare(
          %Beaver.Changeset{
-           location: %Beaver.MLIR.Location{} = location
+           location: %MLIR.Location{} = location,
+           context: %MLIR.Context{} = context
          } = changeset
        ) do
-    %Beaver.Changeset{changeset | location: location}
+    %Beaver.Changeset{changeset | location: Beaver.Deferred.resolve(location, context)}
   end
 
   defp add_attributes(state, []) do
@@ -116,7 +115,7 @@ defmodule Beaver.MLIR.Operation.State do
 
     array =
       result_types
-      |> Enum.map(&Beaver.Deferred.create(&1, context))
+      |> Enum.map(&Beaver.Deferred.resolve(&1, context))
       |> Enum.map(fn
         t when is_binary(t) ->
           CAPI.mlirTypeParseGet(context, MLIR.StringRef.create(t))

--- a/lib/beaver/mlir/transform.ex
+++ b/lib/beaver/mlir/transform.ex
@@ -186,8 +186,11 @@ defmodule Beaver.MLIR.Transform do
   @doc "Creates a Transform parameter type wrapping an MLIR type."
   def param_type(type) do
     case type do
-      %MLIR.Type{} -> MLIR.CAPI.mlirTransformParamTypeGet(MLIR.context(type), type)
-      deferred when is_function(deferred, 1) -> &param_type(deferred.(&1))
+      %MLIR.Type{} ->
+        MLIR.CAPI.mlirTransformParamTypeGet(MLIR.context(type), type)
+
+      %Beaver.Deferred{} = deferred ->
+        Beaver.Deferred.defer(&param_type(Beaver.Deferred.resolve(deferred, &1)))
     end
   end
 

--- a/lib/beaver/mlir/transform/schedule/dsl.ex
+++ b/lib/beaver/mlir/transform/schedule/dsl.ex
@@ -233,7 +233,9 @@ defmodule Beaver.MLIR.Transform.Schedule.DSL do
        when is_atom(name) and (is_atom(context) or is_nil(context)) do
     type_builder =
       quote do
-        fn context -> Beaver.Deferred.create(unquote(type), context) end
+        Beaver.Deferred.defer(fn context ->
+          Beaver.Deferred.resolve(unquote(type), context)
+        end)
       end
 
     binding =
@@ -393,8 +395,8 @@ defmodule Beaver.MLIR.Transform.Schedule.DSL do
 
   defp knob_attribute!(:unit, context), do: MLIR.Attribute.unit(ctx: context)
 
-  defp knob_attribute!(deferred, context) when is_function(deferred, 1) do
-    case deferred.(context) do
+  defp knob_attribute!(%Beaver.Deferred{} = deferred, context) do
+    case Beaver.Deferred.resolve(deferred, context) do
       %MLIR.Attribute{} = attribute -> knob_attribute!(attribute, context)
       value -> unsupported_knob_option!(value)
     end
@@ -596,7 +598,7 @@ defmodule Beaver.MLIR.Transform.Schedule.DSL do
   def param(type), do: Transform.param_type(type)
 
   defp resolve_type!(type, context, label) do
-    case Beaver.Deferred.create(type, context) do
+    case Beaver.Deferred.resolve(type, context) do
       %MLIR.Type{} = resolved ->
         ensure_same_context!(resolved, context, label)
         resolved

--- a/lib/beaver/mlir/type.ex
+++ b/lib/beaver/mlir/type.ex
@@ -43,11 +43,11 @@ defmodule Beaver.MLIR.Type do
 
     Beaver.Deferred.from_opts(opts, fn ctx ->
       inputs =
-        inputs |> Enum.map(&Beaver.Deferred.create(&1, ctx)) |> Beaver.Native.array(__MODULE__)
+        inputs |> Enum.map(&Beaver.Deferred.resolve(&1, ctx)) |> Beaver.Native.array(__MODULE__)
 
       results =
         results
-        |> Enum.map(&Beaver.Deferred.create(&1, ctx))
+        |> Enum.map(&Beaver.Deferred.resolve(&1, ctx))
         |> Beaver.Native.array(__MODULE__)
 
       mlirFunctionTypeGet(ctx, num_inputs, inputs, num_results, results)
@@ -55,7 +55,7 @@ defmodule Beaver.MLIR.Type do
   end
 
   defp checked_composite_type(ctx, getter, args, opts) do
-    loc = opts[:loc] || MLIR.Location.unknown(ctx: ctx)
+    loc = (opts[:loc] || MLIR.Location.unknown(ctx: ctx)) |> Beaver.Deferred.resolve(ctx)
     {t, diagnostics} = apply(getter, [ctx, loc | args])
 
     if MLIR.null?(t) do
@@ -71,7 +71,7 @@ defmodule Beaver.MLIR.Type do
 
   defp bang_composite_type(cb, args) do
     case apply(cb, args) do
-      f when is_function(f, 1) ->
+      %Beaver.Deferred{} ->
         raise ArgumentError, "calling a bang function to compose a type must be eager"
 
       {:ok, t} ->
@@ -86,11 +86,16 @@ defmodule Beaver.MLIR.Type do
 
   def ranked_tensor(
         shape,
-        f,
+        %Beaver.Deferred{} = deferred,
         opts
+      ) do
+    Beaver.Deferred.from_opts(opts, fn ctx ->
+      ranked_tensor(
+        shape,
+        Beaver.Deferred.resolve(deferred, ctx),
+        Keyword.put(opts, :ctx, ctx)
       )
-      when is_function(f, 1) do
-    &ranked_tensor(shape, f.(&1), opts)
+    end)
   end
 
   def ranked_tensor(
@@ -99,9 +104,9 @@ defmodule Beaver.MLIR.Type do
         opts
       )
       when is_list(shape) do
-    ctx = MLIR.context(element_type)
+    ctx = composite_context(element_type, opts)
     rank = length(shape)
-    encoding = opts[:encoding] || mlirAttributeGetNull()
+    encoding = (opts[:encoding] || mlirAttributeGetNull()) |> Beaver.Deferred.resolve(ctx)
 
     shape =
       shape
@@ -122,13 +127,17 @@ defmodule Beaver.MLIR.Type do
 
   def unranked_tensor(element_type, opts \\ [])
 
-  def unranked_tensor(element_type, opts)
-      when is_function(element_type, 1) do
-    &unranked_tensor(element_type.(&1), opts)
+  def unranked_tensor(%Beaver.Deferred{} = element_type, opts) do
+    Beaver.Deferred.from_opts(opts, fn ctx ->
+      unranked_tensor(
+        Beaver.Deferred.resolve(element_type, ctx),
+        Keyword.put(opts, :ctx, ctx)
+      )
+    end)
   end
 
   def unranked_tensor(%__MODULE__{} = element_type, opts) do
-    ctx = MLIR.context(element_type)
+    ctx = composite_context(element_type, opts)
 
     checked_composite_type(
       ctx,
@@ -144,15 +153,19 @@ defmodule Beaver.MLIR.Type do
 
   def unranked_memref(element_type, opts \\ [])
 
-  def unranked_memref(element_type, opts)
-      when is_function(element_type, 1) do
-    &unranked_memref(element_type.(&1), opts)
+  def unranked_memref(%Beaver.Deferred{} = element_type, opts) do
+    Beaver.Deferred.from_opts(opts, fn ctx ->
+      unranked_memref(
+        Beaver.Deferred.resolve(element_type, ctx),
+        Keyword.put(opts, :ctx, ctx)
+      )
+    end)
   end
 
   def unranked_memref(%__MODULE__{} = element_type, opts) do
-    ctx = MLIR.context(element_type)
+    ctx = composite_context(element_type, opts)
     default_null = mlirAttributeGetNull()
-    memory_space = (opts[:memory_space] || default_null) |> Beaver.Deferred.create(ctx)
+    memory_space = (opts[:memory_space] || default_null) |> Beaver.Deferred.resolve(ctx)
 
     checked_composite_type(
       ctx,
@@ -166,8 +179,8 @@ defmodule Beaver.MLIR.Type do
     bang_composite_type(&unranked_memref/2, [element_type, opts])
   end
 
-  def complex(element_type) when is_function(element_type, 1) do
-    &complex(element_type.(&1))
+  def complex(%Beaver.Deferred{} = element_type) do
+    Beaver.Deferred.defer(&complex(Beaver.Deferred.resolve(element_type, &1)))
   end
 
   def complex(%__MODULE__{} = element_type) do
@@ -180,8 +193,14 @@ defmodule Beaver.MLIR.Type do
         opts \\ [layout: nil, memory_space: nil]
       )
 
-  def memref(shape, element_type, opts) when is_function(element_type, 1) do
-    &memref(shape, element_type.(&1), opts)
+  def memref(shape, %Beaver.Deferred{} = element_type, opts) do
+    Beaver.Deferred.from_opts(opts, fn ctx ->
+      memref(
+        shape,
+        Beaver.Deferred.resolve(element_type, ctx),
+        Keyword.put(opts, :ctx, ctx)
+      )
+    end)
   end
 
   def memref(
@@ -190,7 +209,7 @@ defmodule Beaver.MLIR.Type do
         opts
       )
       when is_list(shape) do
-    ctx = MLIR.context(element_type)
+    ctx = composite_context(element_type, opts)
     rank = length(shape)
 
     shape =
@@ -201,10 +220,10 @@ defmodule Beaver.MLIR.Type do
     default_null = mlirAttributeGetNull()
 
     layout =
-      %MLIR.Attribute{} = (opts[:layout] || default_null) |> Beaver.Deferred.create(ctx)
+      %MLIR.Attribute{} = (opts[:layout] || default_null) |> Beaver.Deferred.resolve(ctx)
 
     memory_space =
-      %MLIR.Attribute{} = (opts[:memory_space] || default_null) |> Beaver.Deferred.create(ctx)
+      %MLIR.Attribute{} = (opts[:memory_space] || default_null) |> Beaver.Deferred.resolve(ctx)
 
     checked_composite_type(
       ctx,
@@ -214,12 +233,12 @@ defmodule Beaver.MLIR.Type do
     )
   end
 
-  def memref!(shape, %__MODULE__{} = element_type, opts \\ []) do
+  def memref!(shape, element_type, opts \\ []) do
     bang_composite_type(&memref/3, [shape, element_type, opts])
   end
 
   @doc """
-  Get a vector type creator.
+  Get a vector type or deferred type value.
 
   ## Examples
       iex> ctx = MLIR.Context.create()
@@ -230,12 +249,18 @@ defmodule Beaver.MLIR.Type do
 
   def vector(shape, element_type, opts \\ [])
 
-  def vector(shape, element_type, opts) when is_function(element_type, 1) do
-    &vector(shape, element_type.(&1), opts)
+  def vector(shape, %Beaver.Deferred{} = element_type, opts) do
+    Beaver.Deferred.from_opts(opts, fn ctx ->
+      vector(
+        shape,
+        Beaver.Deferred.resolve(element_type, ctx),
+        Keyword.put(opts, :ctx, ctx)
+      )
+    end)
   end
 
   def vector(shape, %__MODULE__{} = element_type, opts) when is_list(shape) do
-    ctx = MLIR.context(element_type)
+    ctx = composite_context(element_type, opts)
     rank = length(shape)
     shape = shape |> Beaver.Native.array(Beaver.Native.I64)
 
@@ -247,8 +272,15 @@ defmodule Beaver.MLIR.Type do
     )
   end
 
-  def vector!(shape, %__MODULE__{} = element_type, opts \\ []) do
+  def vector!(shape, element_type, opts \\ []) do
     bang_composite_type(&vector/3, [shape, element_type, opts])
+  end
+
+  defp composite_context(%__MODULE__{} = element_type, opts) do
+    case Beaver.Deferred.context(opts) do
+      nil -> MLIR.context(element_type)
+      %MLIR.Context{} = ctx -> element_type |> Beaver.Deferred.resolve(ctx) |> MLIR.context()
+    end
   end
 
   @doc """
@@ -266,7 +298,7 @@ defmodule Beaver.MLIR.Type do
 
       elements =
         elements
-        |> Enum.map(&Beaver.Deferred.create(&1, ctx))
+        |> Enum.map(&Beaver.Deferred.resolve(&1, ctx))
         |> Beaver.Native.array(__MODULE__)
 
       mlirTupleTypeGet(ctx, num_elements, elements)

--- a/lib/beaver/pattern.ex
+++ b/lib/beaver/pattern.ex
@@ -152,8 +152,12 @@ defmodule Beaver.Pattern do
     value
   end
 
-  def gen_pdl(blk, %Beaver.Changeset{context: context} = changeset, f) when is_function(f, 1) do
-    gen_pdl(blk, changeset, Beaver.Deferred.create(f, context))
+  def gen_pdl(
+        blk,
+        %Beaver.Changeset{context: context} = changeset,
+        %Beaver.Deferred{} = deferred
+      ) do
+    gen_pdl(blk, changeset, Beaver.Deferred.resolve(deferred, context))
   end
 
   def gen_pdl(_, _, element) do

--- a/lib/beaver/sigils.ex
+++ b/lib/beaver/sigils.ex
@@ -1,11 +1,11 @@
 defmodule Beaver.Sigils do
   @moduledoc """
-  Sigils return a function to create MLIR elements by parsing the content.
+  Sigils return explicit `Beaver.Deferred` values that parse MLIR elements in a context.
   """
   alias Beaver.MLIR
 
   @doc """
-  Create a module creator.
+  Create a deferred module value.
   ## Examples
 
       iex> ctx = MLIR.Context.create()
@@ -16,23 +16,21 @@ defmodule Beaver.Sigils do
       ...>     return %res : i32
       ...>   }
       ...> }
-      ...> \""".(ctx) |> MLIR.verify!()
+      ...> \""" |> Beaver.Deferred.resolve(ctx) |> MLIR.verify!()
       iex> MLIR.Context.destroy(ctx)
   """
-  def sigil_m(string, []) do
-    &MLIR.Module.create!(string, ctx: &1)
-  end
+  def sigil_m(string, []), do: Beaver.Deferred.defer(&MLIR.Module.create!(string, ctx: &1))
 
   @doc """
-  Create an attribute creator.
+  Create a deferred attribute value.
 
   Add a modifier to it as a shortcut to annotate the type
   ## Examples
 
       iex> ctx = MLIR.Context.create()
-      iex> MLIR.equal?(Attribute.float(Type.f(32), 0.0).(ctx), ~a{0.0}f32.(ctx))
+      iex> MLIR.equal?(Beaver.Deferred.resolve(Attribute.float(Type.f(32), 0.0), ctx), Beaver.Deferred.resolve(~a{0.0}f32, ctx))
       true
-      iex> ~a{1 : i32}.(ctx) |> MLIR.to_string()
+      iex> ~a{1 : i32} |> Beaver.Deferred.resolve(ctx) |> MLIR.to_string()
       "1 : i32"
       iex> MLIR.Context.destroy(ctx)
   """
@@ -44,19 +42,19 @@ defmodule Beaver.Sigils do
   end
 
   @doc """
-  Create a type creator.
+  Create a deferred type value.
 
   Add a modifier to it as a shortcut to make it a higher order type.
   ## Examples
 
       iex> ctx = MLIR.Context.create()
-      iex> MLIR.equal?(Type.unranked_tensor!(Type.f32(ctx: ctx)), ~t{tensor<*xf32>}.(ctx))
+      iex> MLIR.equal?(Type.unranked_tensor!(Type.f32(ctx: ctx)), Beaver.Deferred.resolve(~t{tensor<*xf32>}, ctx))
       true
       iex> MLIR.equal?(Type.unranked_tensor!(Type.f32(ctx: ctx)), ~t{tensor<*xf32>})
       true
-      iex> MLIR.equal?(Type.complex(Type.f32()).(ctx), ~t<f32>complex.(ctx))
+      iex> MLIR.equal?(Beaver.Deferred.resolve(Type.complex(Type.f32()), ctx), Beaver.Deferred.resolve(~t<f32>complex, ctx))
       true
-      iex> MLIR.equal?(Type.complex(Type.f32()), ~t<f32>complex.(ctx))
+      iex> MLIR.equal?(Type.complex(Type.f32()), Beaver.Deferred.resolve(~t<f32>complex, ctx))
       true
       iex> MLIR.Context.destroy(ctx)
   """

--- a/lib/beaver/slang.ex
+++ b/lib/beaver/slang.ex
@@ -290,10 +290,10 @@ defmodule Beaver.Slang do
   defp source_location(opts, ctx) do
     case opts[:source] do
       %{file: file, line: line} ->
-        Beaver.Deferred.create(MLIR.Location.file(name: file, line: line), ctx)
+        Beaver.Deferred.resolve(MLIR.Location.file(name: file, line: line), ctx)
 
       _ ->
-        Beaver.Deferred.create(MLIR.Location.unknown(), ctx)
+        Beaver.Deferred.resolve(MLIR.Location.unknown(), ctx)
     end
   end
 
@@ -536,7 +536,7 @@ defmodule Beaver.Slang do
           attrs ++
             [
               numberOfBlocks:
-                Beaver.Deferred.create(
+                Beaver.Deferred.resolve(
                   MLIR.Attribute.integer(MLIR.Type.i32(), size),
                   ctx
                 )
@@ -545,7 +545,7 @@ defmodule Beaver.Slang do
       end)
       |> then(fn attrs ->
         if constrained_args? do
-          attrs ++ [constrainedArguments: Beaver.Deferred.create(MLIR.Attribute.unit(), ctx)]
+          attrs ++ [constrainedArguments: Beaver.Deferred.resolve(MLIR.Attribute.unit(), ctx)]
         else
           attrs
         end
@@ -564,7 +564,7 @@ defmodule Beaver.Slang do
 
     %Beaver.SSA{
       arguments: region_args,
-      results: [Beaver.Deferred.create(~t{!irdl.region}, ctx)],
+      results: [Beaver.Deferred.resolve(~t{!irdl.region}, ctx)],
       ip: block,
       ctx: ctx,
       loc: loc,
@@ -703,7 +703,7 @@ defmodule Beaver.Slang do
     Beaver.Deferred.from_opts(opts, fn ctx ->
       params =
         params
-        |> Enum.map(&Beaver.Deferred.create(&1, ctx))
+        |> Enum.map(&Beaver.Deferred.resolve(&1, ctx))
         |> Enum.map(fn
           %MLIR.Type{} = t -> MLIR.Attribute.type(t)
           %MLIR.Attribute{} = a -> a
@@ -908,7 +908,7 @@ defmodule Beaver.Slang do
       mlir ctx: ctx, ip: Beaver.Deferred.fetch_insertion_point(opts) do
         loc = constraint_location(opts, ctx)
 
-        IRDL.base([loc, base_ref: Beaver.Deferred.create(symbol, ctx)]) >>>
+        IRDL.base([loc, base_ref: Beaver.Deferred.resolve(symbol, ctx)]) >>>
           ~t{!irdl.attribute}
       end
     end)
@@ -982,7 +982,7 @@ defmodule Beaver.Slang do
   @doc false
   # This function creates a parametric attribute for a given value. It generates the code for `irdl.parametric` op.
   def create_parametric({:parametric, symbol, values, _}, opts) do
-    base_type = Beaver.Deferred.from_opts(opts, symbol)
+    base_type = symbol
 
     Beaver.Deferred.from_opts(
       opts,

--- a/lib/beaver/ssa.ex
+++ b/lib/beaver/ssa.ex
@@ -42,8 +42,8 @@ defmodule Beaver.SSA do
     %__MODULE__{ssa | arguments: arguments ++ additional_arguments}
   end
 
-  def put_results(%__MODULE__{results: results} = ssa, f) when is_function(f, 1) do
-    %__MODULE__{ssa | results: results ++ [f]}
+  def put_results(%__MODULE__{results: results} = ssa, %Beaver.Deferred{} = deferred) do
+    %__MODULE__{ssa | results: results ++ [deferred]}
   end
 
   def put_results(%__MODULE__{results: results} = ssa, %MLIR.Type{} = single_result) do

--- a/test/capi_test.exs
+++ b/test/capi_test.exs
@@ -117,7 +117,8 @@ defmodule MlirTest do
       %3 = "tosa.transpose"(%1) {perms = array<i32: 2, 0, 1>} : (tensor<2x3x1xi32>) -> (tensor<1x2x3xi32>)
       return
     }
-    """).(ctx)
+    """)
+    |> Beaver.Deferred.resolve(ctx)
   end
 
   test "run a simple pass" do
@@ -186,7 +187,7 @@ defmodule MlirTest do
   end
 
   test "Run pass with patterns", %{ctx: ctx} do
-    {:ok, module} = create_redundant_transpose_module(ctx)
+    module = create_redundant_transpose_module(ctx)
     external = %MLIR.Pass{} = Beaver.Composer.create_pass(TestFuncPass, ctx)
     pm = mlirPassManagerCreate(ctx)
     npm = mlirPassManagerGetNestedUnder(pm, MLIR.StringRef.create("func.func"))
@@ -273,7 +274,8 @@ defmodule MlirTest do
     assert map |> MLIR.to_string() == txt
     assert MLIR.Attribute.affine_map(map) |> MLIR.to_string() == "affine_map<#{txt}>"
 
-    assert MLIR.AffineMap.create(3, 3, [MLIR.AffineMap.dim(0), MLIR.AffineMap.symbol(1)]).(ctx)
+    assert MLIR.AffineMap.create(3, 3, [MLIR.AffineMap.dim(0), MLIR.AffineMap.symbol(1)])
+           |> Beaver.Deferred.resolve(ctx)
            |> MLIR.to_string() == txt
   end
 

--- a/test/cf_test.exs
+++ b/test/cf_test.exs
@@ -28,7 +28,7 @@ defmodule CfTest do
         return(base_lr)
       end
 
-    ir = ~m{#{mlir}}.(ctx)
+    ir = ~m{#{mlir}} |> Beaver.Deferred.resolve(ctx)
 
     f = get_func(ir, "get_lr_with_ctrl_flow")
 

--- a/test/custom_trait_test.exs
+++ b/test/custom_trait_test.exs
@@ -105,6 +105,6 @@ defmodule CustomTraitTest do
 
   defp parse_with(ctx, operation_name) do
     MLIR.Module.create(~s[module { "#{operation_name}"() : () -> () }], ctx: ctx)
-    |> Beaver.Deferred.create(ctx)
+    |> Beaver.Deferred.resolve(ctx)
   end
 end

--- a/test/debug_output_test.exs
+++ b/test/debug_output_test.exs
@@ -11,7 +11,8 @@ defmodule DebugOutputTest do
       %res = arith.addi %arg0, %arg1 : i32
       return %res : i32
     }
-    """.(ctx)
+    """
+    |> Beaver.Deferred.resolve(ctx)
   end
 
   test "op stats", %{ctx: ctx} do

--- a/test/deferred_test.exs
+++ b/test/deferred_test.exs
@@ -1,0 +1,56 @@
+defmodule Beaver.DeferredTest do
+  use Beaver.Case, async: true
+
+  alias Beaver.Deferred
+  alias Beaver.MLIR
+
+  test "builders distinguish deferred values from ordinary callbacks", %{ctx: ctx} do
+    assert %Deferred{} = deferred = MLIR.Type.i32()
+    assert %MLIR.Type{} = Deferred.resolve(deferred, ctx)
+    assert %MLIR.Type{} = MLIR.Type.i32(ctx: ctx)
+    assert %Deferred{} = MLIR.Type.vector([4], MLIR.Type.i32())
+    assert {:ok, %MLIR.Type{}} = MLIR.Type.vector([4], MLIR.Type.i32(), ctx: ctx)
+    assert %MLIR.Type{} = MLIR.Type.vector!([4], MLIR.Type.i32(), ctx: ctx)
+
+    assert_raise ArgumentError,
+                 "bare context resolvers are not deferred values; wrap the function with defer/1",
+                 fn -> Deferred.resolve(fn _context -> :not_an_mlir_builder end, ctx) end
+  end
+
+  test "explicit invalid contexts fail at the builder boundary" do
+    assert_raise ArgumentError, "expected :ctx to be an MLIR context, got: nil", fn ->
+      MLIR.Type.i32(ctx: nil)
+    end
+
+    assert_raise ArgumentError, "expected an MLIR context, got: nil", fn ->
+      Deferred.resolve(MLIR.Type.i32(), nil)
+    end
+  end
+
+  test "resolution rejects eager and nested entities from another context", %{ctx: ctx} do
+    other = MLIR.Context.create()
+
+    try do
+      type = MLIR.Type.i32(ctx: ctx)
+
+      assert_raise ArgumentError, "type belongs to a different MLIR context", fn ->
+        Deferred.resolve(type, other)
+      end
+
+      assert_raise ArgumentError, "type belongs to a different MLIR context", fn ->
+        MLIR.Type.function([type], [], ctx: other)
+      end
+    after
+      MLIR.Context.destroy(other)
+    end
+  end
+
+  test "deferred success and error results have one normalization rule", %{ctx: ctx} do
+    assert :resolved =
+             Deferred.defer(fn _context -> {:ok, :resolved} end) |> Deferred.resolve(ctx)
+
+    assert_raise ArgumentError, "failed", fn ->
+      Deferred.defer(fn _context -> {:error, "failed"} end) |> Deferred.resolve(ctx)
+    end
+  end
+end

--- a/test/e2e_test.exs
+++ b/test/e2e_test.exs
@@ -15,7 +15,8 @@ defmodule E2ETest do
           return %res : i32
         }
       }
-      """.(ctx)
+      """
+      |> Beaver.Deferred.resolve(ctx)
       |> canonicalize
       |> cse
       |> convert_arith_to_llvm()
@@ -37,7 +38,8 @@ defmodule E2ETest do
                          return %res : i32
                        }
                      }
-                     """.(ctx)
+                     """
+                     |> Beaver.Deferred.resolve(ctx)
                      |> MLIR.ExecutionEngine.create!()
                    end
     end

--- a/test/entity_test.exs
+++ b/test/entity_test.exs
@@ -29,15 +29,26 @@ defmodule EntityTest do
       assert MLIR.equal?(Type.i32(opts), Type.i(32, opts))
       assert MLIR.equal?(Type.i64(opts), Type.i(64, opts))
       assert MLIR.equal?(Type.i128(opts), Type.i(128, opts))
-      assert MLIR.equal?(Type.integer(32, opts), ~t{i32}.(ctx))
-      assert MLIR.equal?(Type.integer(64, opts), Type.get("i64").(ctx))
-      assert MLIR.equal?(Type.integer(128, opts), Type.get("i128").(ctx))
-      assert MLIR.equal?(Type.complex(Type.f32()).(ctx), Type.get("complex<f32>").(ctx))
+      assert MLIR.equal?(Type.integer(32, opts), ~t{i32} |> Beaver.Deferred.resolve(ctx))
+      assert MLIR.equal?(Type.integer(64, opts), Type.get("i64") |> Beaver.Deferred.resolve(ctx))
+
+      assert MLIR.equal?(
+               Type.integer(128, opts),
+               Type.get("i128") |> Beaver.Deferred.resolve(ctx)
+             )
+
+      assert MLIR.equal?(
+               Type.complex(Type.f32()) |> Beaver.Deferred.resolve(ctx),
+               Type.get("complex<f32>") |> Beaver.Deferred.resolve(ctx)
+             )
 
       assert Type.unranked_tensor!(Type.complex(Type.f32(ctx: ctx))) |> to_string() ==
                "tensor<*xcomplex<f32>>"
 
-      assert MLIR.equal?(Type.unranked_tensor!(Type.f32(ctx: ctx)), ~t{tensor<*xf32>}.(ctx))
+      assert MLIR.equal?(
+               Type.unranked_tensor!(Type.f32(ctx: ctx)),
+               ~t{tensor<*xf32>} |> Beaver.Deferred.resolve(ctx)
+             )
 
       assert Type.ranked_tensor!([], Type.f32(ctx: ctx)) |> to_string() ==
                "tensor<f32>"
@@ -54,7 +65,10 @@ defmodule EntityTest do
              |> to_string() ==
                "memref<f32>"
 
-      assert MLIR.equal?(Type.none().(ctx), Type.get("none").(ctx))
+      assert MLIR.equal?(
+               Type.none() |> Beaver.Deferred.resolve(ctx),
+               Type.get("none") |> Beaver.Deferred.resolve(ctx)
+             )
     end
   end
 
@@ -63,7 +77,8 @@ defmodule EntityTest do
       Type.function(
         [Type.i32(ctx: ctx), Type.f32(ctx: ctx)],
         [Type.f64(ctx: ctx)]
-      ).(ctx)
+      )
+      |> Beaver.Deferred.resolve(ctx)
 
     assert func_type |> to_string() =~ ~r"i32.+f32.+f64"
     assert 2 = MLIR.FunctionType.num_inputs(func_type)
@@ -91,33 +106,54 @@ defmodule EntityTest do
   end
 
   test "type detection", %{ctx: ctx} do
-    assert Type.tensor?(~t{tensor<*xf32>}.(ctx))
-    assert Type.i(32).(ctx) |> Type.integer?()
-    refute Type.f(32).(ctx) |> Type.integer?()
-    assert Type.f(32).(ctx) |> Type.float?()
+    assert Type.tensor?(~t{tensor<*xf32>} |> Beaver.Deferred.resolve(ctx))
+    assert Type.i(32) |> Beaver.Deferred.resolve(ctx) |> Type.integer?()
+    refute Type.f(32) |> Beaver.Deferred.resolve(ctx) |> Type.integer?()
+    assert Type.f(32) |> Beaver.Deferred.resolve(ctx) |> Type.float?()
     assert Type.memref!([], Type.f32(ctx: ctx)) |> Type.memref?()
   end
 
   describe "attr apis" do
     test "generate", %{ctx: ctx} do
-      assert MLIR.equal?(Attribute.type(Type.f32()).(ctx), Attribute.type(Type.f32()).(ctx))
-      assert MLIR.equal?(Attribute.type(Type.f32()), Attribute.type(Type.f32()).(ctx))
-      assert MLIR.equal?(Attribute.type(Type.f32()).(ctx), Attribute.type(Type.f32()))
+      assert MLIR.equal?(
+               Attribute.type(Type.f32()) |> Beaver.Deferred.resolve(ctx),
+               Attribute.type(Type.f32()) |> Beaver.Deferred.resolve(ctx)
+             )
 
-      assert Attribute.integer(Type.i(32), 1) |> Beaver.Deferred.create(ctx) |> to_string() ==
+      assert MLIR.equal?(
+               Attribute.type(Type.f32()),
+               Attribute.type(Type.f32()) |> Beaver.Deferred.resolve(ctx)
+             )
+
+      assert MLIR.equal?(
+               Attribute.type(Type.f32()) |> Beaver.Deferred.resolve(ctx),
+               Attribute.type(Type.f32())
+             )
+
+      assert Attribute.integer(Type.i(32), 1) |> Beaver.Deferred.resolve(ctx) |> to_string() ==
                "1 : i32"
 
-      assert MLIR.equal?(Attribute.integer(Type.i(32), 0).(ctx), ~a{0}i32.(ctx))
-      assert MLIR.equal?(Attribute.float(Type.f(32), 0.0).(ctx), ~a{0.0}f32.(ctx))
+      assert MLIR.equal?(
+               Attribute.integer(Type.i(32), 0) |> Beaver.Deferred.resolve(ctx),
+               ~a{0}i32 |> Beaver.Deferred.resolve(ctx)
+             )
+
+      assert MLIR.equal?(
+               Attribute.float(Type.f(32), 0.0) |> Beaver.Deferred.resolve(ctx),
+               ~a{0.0}f32 |> Beaver.Deferred.resolve(ctx)
+             )
 
       assert_raise ArgumentError, "incompatible type i32", fn ->
-        Attribute.float(Type.i(32), 0.0).(ctx)
+        Attribute.float(Type.i(32), 0.0) |> Beaver.Deferred.resolve(ctx)
       end
 
-      assert MLIR.equal?(Attribute.integer(Type.index(), 1).(ctx), ~a{1}index.(ctx))
+      assert MLIR.equal?(
+               Attribute.integer(Type.index(), 1) |> Beaver.Deferred.resolve(ctx),
+               ~a{1}index |> Beaver.Deferred.resolve(ctx)
+             )
 
       assert_raise ArgumentError, "incompatible type f32", fn ->
-        Attribute.integer(Type.f32(), 1).(ctx)
+        Attribute.integer(Type.f32(), 1) |> Beaver.Deferred.resolve(ctx)
       end
 
       assert not MLIR.null?(
@@ -126,13 +162,15 @@ defmodule EntityTest do
                    [Type.i(32)],
                    [Type.i(32)]
                  )
-               ).(ctx)
+               )
+               |> Beaver.Deferred.resolve(ctx)
              )
 
       assert Type.function(
                [Type.ranked_tensor!([1, 2, 3, 4], Type.i(32, ctx: ctx))],
                [Type.i(32)]
-             ).(ctx)
+             )
+             |> Beaver.Deferred.resolve(ctx)
              |> to_string() ==
                "(tensor<1x2x3x4xi32>) -> i32"
 
@@ -142,8 +180,9 @@ defmodule EntityTest do
                    [Type.i(32)],
                    [Type.i(32)]
                  )
-               ).(ctx),
-               ~a{(i32) -> (i32)}.(ctx)
+               )
+               |> Beaver.Deferred.resolve(ctx),
+               ~a{(i32) -> (i32)} |> Beaver.Deferred.resolve(ctx)
              )
 
       vec2xi32 = Type.vector!([2], Type.i(32, ctx: ctx))
@@ -151,33 +190,35 @@ defmodule EntityTest do
       i0attr = Attribute.integer(Type.i(32), 0)
 
       assert MLIR.equal?(
-               Attribute.dense_elements([i0attr, i0attr], vec2xi32).(ctx),
-               ~a{dense<0> : vector<2xi32>}.(ctx)
+               Attribute.dense_elements([i0attr, i0attr], vec2xi32)
+               |> Beaver.Deferred.resolve(ctx),
+               ~a{dense<0> : vector<2xi32>} |> Beaver.Deferred.resolve(ctx)
              )
 
       assert MLIR.equal?(
-               Attribute.dense_elements([i0attr], vec2xi32).(ctx),
-               ~a{dense<0> : vector<2xi32>}.(ctx)
+               Attribute.dense_elements([i0attr], vec2xi32) |> Beaver.Deferred.resolve(ctx),
+               ~a{dense<0> : vector<2xi32>} |> Beaver.Deferred.resolve(ctx)
              )
 
       assert MLIR.equal?(
-               Attribute.dense_elements(0, vec2xi32).(ctx),
-               ~a{dense<0> : vector<2xi32>}.(ctx)
+               Attribute.dense_elements(0, vec2xi32) |> Beaver.Deferred.resolve(ctx),
+               ~a{dense<0> : vector<2xi32>} |> Beaver.Deferred.resolve(ctx)
              )
 
       assert MLIR.equal?(
-               Attribute.dense_elements("abcd").(ctx),
-               ~a{dense<[#{?a}, #{?b}, #{?c}, #{?d}]> : tensor<4xi8>}.(ctx)
+               Attribute.dense_elements("abcd") |> Beaver.Deferred.resolve(ctx),
+               ~a{dense<[#{?a}, #{?b}, #{?c}, #{?d}]> : tensor<4xi8>}
+               |> Beaver.Deferred.resolve(ctx)
              )
 
       assert MLIR.equal?(
                MLIR.ODS.operand_segment_sizes([0, 0], ctx: ctx),
-               ~a{array<i32: 0, 0>}.(ctx)
+               ~a{array<i32: 0, 0>} |> Beaver.Deferred.resolve(ctx)
              )
 
       assert MLIR.equal?(
-               MLIR.ODS.operand_segment_sizes([1, 0]).(ctx),
-               ~a{array<i32: 1, 0>}.(ctx)
+               MLIR.ODS.operand_segment_sizes([1, 0]) |> Beaver.Deferred.resolve(ctx),
+               ~a{array<i32: 1, 0>} |> Beaver.Deferred.resolve(ctx)
              )
 
       assert_raise ArgumentError, "number of elements 0 does not match shaped type 3", fn ->
@@ -190,8 +231,8 @@ defmodule EntityTest do
       parallel2 = Attribute.array([parallel, parallel])
 
       assert MLIR.equal?(
-               parallel2.(ctx),
-               ~a{["parallel", "parallel"]}.(ctx)
+               parallel2 |> Beaver.Deferred.resolve(ctx),
+               ~a{["parallel", "parallel"]} |> Beaver.Deferred.resolve(ctx)
              )
     end
 
@@ -238,7 +279,8 @@ defmodule EntityTest do
         Attribute.strided_layout(
           1,
           [1, 2, 3]
-        ).(ctx)
+        )
+        |> Beaver.Deferred.resolve(ctx)
 
       assert not MLIR.null?(strided_attr)
     end

--- a/test/irdl_test.exs
+++ b/test/irdl_test.exs
@@ -30,7 +30,8 @@ defmodule IRDLTest do
           irdl.results(res: %3)
         }
       }
-      """.(ctx)
+      """
+      |> Beaver.Deferred.resolve(ctx)
       |> MLIR.verify!()
 
     assert m
@@ -53,7 +54,7 @@ defmodule IRDLTest do
     CMath.IRExample.gen(ctx)
 
     assert not (CMath.some_attr(Type.f32())
-                |> Beaver.Deferred.create(ctx)
+                |> Beaver.Deferred.resolve(ctx)
                 |> MLIR.null?())
 
     assert not (MLIR.CAPI.mlirContextGetOrLoadDialect(

--- a/test/load_ir_test.exs
+++ b/test/load_ir_test.exs
@@ -8,7 +8,8 @@ defmodule LoadIRTest do
 
     ~m"""
     #{content}
-    """.(ctx)
+    """
+    |> Beaver.Deferred.resolve(ctx)
     |> MLIR.verify!()
   end
 

--- a/test/memref_test.exs
+++ b/test/memref_test.exs
@@ -22,14 +22,14 @@ defmodule MemRefTest do
 
   test "memref layout and memory space", %{ctx: ctx} do
     assert_raise ArgumentError, "only ranked memref has layout", fn ->
-      ~t{memref<*xbf16>}.(ctx) |> MemRef.layout()
+      ~t{memref<*xbf16>} |> Beaver.Deferred.resolve(ctx) |> MemRef.layout()
     end
 
     assert_raise ArgumentError, "only ranked memref has layout", fn ->
       MLIR.Type.index(ctx: ctx) |> MemRef.layout()
     end
 
-    assert memref_type = ~t{memref<128xbf16>}.(ctx)
+    assert memref_type = ~t{memref<128xbf16>} |> Beaver.Deferred.resolve(ctx)
     assert MLIR.ShapedType.static_dim?(memref_type, 0)
     refute MLIR.ShapedType.dynamic_dim?(memref_type, 0)
     assert 128 = MLIR.ShapedType.dim_size(memref_type, 0)
@@ -39,7 +39,7 @@ defmodule MemRefTest do
     assert layout = MemRef.layout(memref_type)
     assert to_string(layout) == "affine_map<(d0) -> (d0)>"
 
-    memref_type = ~t{memref<128x?xbf16>}.(ctx)
+    memref_type = ~t{memref<128x?xbf16>} |> Beaver.Deferred.resolve(ctx)
     assert :dynamic = MLIR.ShapedType.dim_size(memref_type, 1)
     assert 2 = MLIR.ShapedType.rank(memref_type)
     refute MLIR.ShapedType.static?(memref_type)
@@ -51,7 +51,7 @@ defmodule MemRefTest do
   end
 
   test "get strides and offset of a memref type", %{ctx: ctx} do
-    type = ~t{memref<1x2xi32, strided<[?, 1], offset: 0>>}.(ctx)
+    type = ~t{memref<1x2xi32, strided<[?, 1], offset: 0>>} |> Beaver.Deferred.resolve(ctx)
     refute MLIR.null?(type)
     assert {[:dynamic, 1], 0} = MemRef.strides_and_offset(type)
 
@@ -61,41 +61,46 @@ defmodule MemRefTest do
   end
 
   test "affine map of a memref type", %{ctx: ctx} do
-    type = ~t{memref<1x2xi32, affine_map<(d0, d1) -> (d0, d1)>>}.(ctx)
+    type = ~t{memref<1x2xi32, affine_map<(d0, d1) -> (d0, d1)>>} |> Beaver.Deferred.resolve(ctx)
     refute MLIR.null?(type)
     assert affine_map = MemRef.affine_map(type)
     assert to_string(affine_map) == "(d0, d1) -> (d0, d1)"
   end
 
   test "num of elements of a shaped type", %{ctx: ctx} do
-    assert 6 = ~t{memref<2x3xf32>}.(ctx) |> MLIR.ShapedType.num_elements()
-    assert 0 = ~t{memref<0x3xf32>}.(ctx) |> MLIR.ShapedType.num_elements()
+    assert 6 =
+             ~t{memref<2x3xf32>} |> Beaver.Deferred.resolve(ctx) |> MLIR.ShapedType.num_elements()
+
+    assert 0 =
+             ~t{memref<0x3xf32>} |> Beaver.Deferred.resolve(ctx) |> MLIR.ShapedType.num_elements()
 
     assert_raise ArgumentError, "not a shaped type", fn ->
       MLIR.ShapedType.num_elements(MLIR.Type.index(ctx: ctx))
     end
 
     assert_raise ArgumentError, "cannot get element count of dynamic shaped type", fn ->
-      ~t{memref<*xf32>}.(ctx) |> MLIR.ShapedType.num_elements()
+      ~t{memref<*xf32>} |> Beaver.Deferred.resolve(ctx) |> MLIR.ShapedType.num_elements()
     end
   end
 
   test "memref<?xi8>", %{ctx: ctx} do
     import Beaver.Sigils
-    assert memref_type = ~t{memref<?xi8>}.(ctx)
+    assert memref_type = ~t{memref<?xi8>} |> Beaver.Deferred.resolve(ctx)
     assert 1 = MLIR.ShapedType.rank(memref_type)
     assert :dynamic = MLIR.ShapedType.dim_size(memref_type, 0)
     assert MLIR.equal?(MLIR.ShapedType.element_type(memref_type), MLIR.Type.i8(ctx: ctx))
     assert {[1], 0} = MemRef.strides_and_offset(memref_type)
-    assert MLIR.equal?(memref_type, ~t{memref<?xi8>}.(ctx))
+    assert MLIR.equal?(memref_type, ~t{memref<?xi8>} |> Beaver.Deferred.resolve(ctx))
     memref_type_from_api = MLIR.Type.memref!([:dynamic], MLIR.Type.i8(ctx: ctx))
     assert MLIR.equal?(memref_type, memref_type_from_api)
 
-    assert memref_type_strided = ~t{memref<?xi8, strided<[1]>>}.(ctx)
+    assert memref_type_strided = ~t{memref<?xi8, strided<[1]>>} |> Beaver.Deferred.resolve(ctx)
     assert {[1], 0} = MemRef.strides_and_offset(memref_type_strided)
     refute MLIR.equal?(memref_type_strided, memref_type)
 
-    assert memref_type_strided_offset = ~t{memref<?xi8, strided<[1], offset: 0>>}.(ctx)
+    assert memref_type_strided_offset =
+             ~t{memref<?xi8, strided<[1], offset: 0>>} |> Beaver.Deferred.resolve(ctx)
+
     assert {[1], 0} = MemRef.strides_and_offset(memref_type_strided_offset)
     assert MLIR.equal?(memref_type_strided_offset, memref_type_strided)
     refute MLIR.equal?(memref_type_strided_offset, memref_type)
@@ -107,7 +112,7 @@ defmodule MemRefTest do
 
     assert MLIR.equal?(memref_type_strided_offset, memref_type_strided_offset_from_api)
 
-    memref_type_strided = ~t{memref<16xi8, strided<[2]>>}.(ctx)
+    memref_type_strided = ~t{memref<16xi8, strided<[2]>>} |> Beaver.Deferred.resolve(ctx)
     assert 16 = memref_type_strided |> MLIR.ShapedType.num_elements()
   end
 end

--- a/test/op_test.exs
+++ b/test/op_test.exs
@@ -7,7 +7,8 @@ defmodule OpTest do
     const =
       ~m"""
       %0 = arith.constant dense<42> : vector<4xi32>
-      """.(ctx)
+      """
+      |> Beaver.Deferred.resolve(ctx)
       |> MLIR.verify!()
       |> MLIR.Module.body()
       |> Beaver.Walker.operations()
@@ -23,7 +24,10 @@ defmodule OpTest do
 
     # check deferred attribute
     old_attr = const[:value]
-    {attr, op} = get_and_update_in(const[:value], &{&1, ~a{#{attr_str2}}.(ctx)})
+
+    {attr, op} =
+      get_and_update_in(const[:value], &{&1, ~a{#{attr_str2}} |> Beaver.Deferred.resolve(ctx)})
+
     assert MLIR.equal?(attr, old_attr)
     assert MLIR.equal?(op, const)
     assert const |> MLIR.to_string() =~ attr_str2

--- a/test/pdl_test.exs
+++ b/test/pdl_test.exs
@@ -210,7 +210,8 @@ defmodule PDLTest do
             return %0 : tensor<2x3xf32>
           }
         }
-        """.(ctx)
+        """
+        |> Beaver.Deferred.resolve(ctx)
         |> Beaver.Composer.append(unquote(p))
         |> canonicalize
         |> Beaver.Composer.run!()

--- a/test/slang_complete_test.exs
+++ b/test/slang_complete_test.exs
@@ -43,10 +43,10 @@ defmodule SlangCompleteTest do
     assert CompleteSlang |> then(&Beaver.Slang.load(ctx, &1)) |> MLIR.LogicalResult.success?()
     assert MLIR.Context.terminator?(ctx, "complete_slang.yield")
 
-    type = CompleteSlang.box(MLIR.Type.i32()) |> Beaver.Deferred.create(ctx)
+    type = CompleteSlang.box(MLIR.Type.i32()) |> Beaver.Deferred.resolve(ctx)
 
     attribute =
-      CompleteSlang.direction(MLIR.Attribute.string("left")) |> Beaver.Deferred.create(ctx)
+      CompleteSlang.direction(MLIR.Attribute.string("left")) |> Beaver.Deferred.resolve(ctx)
 
     refute MLIR.null?(type)
     refute MLIR.null?(attribute)

--- a/test/support/cmath_ir.ex
+++ b/test/support/cmath_ir.ex
@@ -51,7 +51,8 @@ defmodule CMath.IRExample do
       %conorm = "cmath.norm"(%pq) : (!cmath.complex<f32>) -> f32
       return %conorm : f32
     }
-    """.(ctx)
+    """
+    |> Beaver.Deferred.resolve(ctx)
     |> MLIR.verify!()
   end
 end

--- a/test/transform_schedule_dsl_test.exs
+++ b/test/transform_schedule_dsl_test.exs
@@ -87,7 +87,9 @@ defmodule Beaver.MLIR.Transform.Schedule.DSLTest do
 
         _attribute =
           knob("attribute", [
-            fn context -> MLIR.Attribute.integer(MLIR.Type.i32(ctx: context), 42) end
+            Beaver.Deferred.defer(fn context ->
+              MLIR.Attribute.integer(MLIR.Type.i32(ctx: context), 42)
+            end)
           ])
       end
     end


### PR DESCRIPTION
## What

- replace anonymous arity-one deferred builders with an explicit `Beaver.Deferred` value
- centralize eager/deferred resolution and context validation in `Deferred.resolve/2`
- enforce same-context ownership for types, attributes, values, locations, blocks, and operation changesets
- make composite type builders honor an explicit `ctx:` consistently
- remove `Deferred.create/2` without a compatibility shim and update docs/tests/call sites

## Why

Bare functions served two incompatible conventions: ordinary callbacks and context-bound IR builders. Context inference was also spread across individual APIs, so explicit `ctx: nil`, eager cross-context entities, and nested composite builders behaved inconsistently. This makes the boundary explicit and gives all MLIR construction paths the same ownership checks.

## Impact

This is intentionally breaking: downstream code must use `%Beaver.Deferred{}` and `Beaver.Deferred.resolve/2`; `Deferred.create/2` is removed. Batata is migrated in a stacked PR.

## Verification

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix test` — 425 passed, 30 excluded
- `mix docs` — passed with existing ExDoc warnings
- `mix credo --strict` — existing baseline findings only
- `mix dialyzer --format short` — emitted warning set is identical to `main`
