### PR TITLE
ex: add explicit runtime lifecycle operations

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -86,6 +86,10 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.receive", &convert_receive/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.mailbox_clear", &convert_mailbox_clear/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.spawn", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.runtime_create", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.runtime_enter", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.runtime_leave", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.runtime_destroy", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.process_table_reset", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.cont_save", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.receive_cont_save", &convert_term_read/3, version: "1.0")
@@ -183,6 +187,10 @@ defmodule Beaver.MLIR.Conversion.Ex do
     receive: "ex.term.receive",
     mailbox_clear: "ex.term.mailbox_clear",
     spawn: "ex.term.spawn",
+    runtime_create: "ex.term.runtime_create",
+    runtime_enter: "ex.term.runtime_enter",
+    runtime_leave: "ex.term.runtime_leave",
+    runtime_destroy: "ex.term.runtime_destroy",
     process_table_reset: "ex.term.process_table_reset",
     cont_save: "ex.term.cont_save",
     receive_cont_save: "ex.term.receive_cont_save",
@@ -907,6 +915,10 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.clock_init"), do: @term_intrinsics.clock_init
   defp read_intrinsic("ex.yield_mark"), do: @term_intrinsics.yield_mark
   defp read_intrinsic("ex.spawn"), do: @term_intrinsics.spawn
+  defp read_intrinsic("ex.runtime_create"), do: @term_intrinsics.runtime_create
+  defp read_intrinsic("ex.runtime_enter"), do: @term_intrinsics.runtime_enter
+  defp read_intrinsic("ex.runtime_leave"), do: @term_intrinsics.runtime_leave
+  defp read_intrinsic("ex.runtime_destroy"), do: @term_intrinsics.runtime_destroy
   defp read_intrinsic("ex.process_table_reset"), do: @term_intrinsics.process_table_reset
   defp read_intrinsic("ex.cont_save"), do: @term_intrinsics.cont_save
   defp read_intrinsic("ex.receive_cont_save"), do: @term_intrinsics.receive_cont_save
@@ -1120,6 +1132,22 @@ defmodule Beaver.MLIR.Conversion.Ex do
   end
 
   defp intrinsic_function_type("ex.term.spawn", _ctx) do
+    MLIR.Type.function([MLIR.Type.i64()], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.runtime_create", _ctx) do
+    MLIR.Type.function([], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.runtime_enter", _ctx) do
+    MLIR.Type.function([MLIR.Type.i64()], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.runtime_leave", _ctx) do
+    MLIR.Type.function([], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.runtime_destroy", _ctx) do
     MLIR.Type.function([MLIR.Type.i64()], [MLIR.Type.i64()])
   end
 

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -146,6 +146,21 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop spawn(fun = optional(base(dyn()))),
     results: [result: base(dyn())]
 
+  # Explicit runtime-instance lifecycle. Hosts use these operations to give
+  # each execution its own native state instead of relying on the
+  # compatibility runtime associated with the invoking OS thread.
+  defop runtime_create(),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
+  defop runtime_enter(handle = all_of([base("!builtin.integer"), any()])),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
+  defop runtime_leave(),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
+  defop runtime_destroy(handle = all_of([base("!builtin.integer"), any()])),
+    results: [result: all_of([base("!builtin.integer"), any()])]
+
   # Resets the runtime process table to a single fresh initial process with
   # the given capacity; the scheduler driver calls this at program start.
   defop process_table_reset(cap = all_of([base("!builtin.integer"), any()])),

--- a/lib/beaver/wasm/term_abi.ex
+++ b/lib/beaver/wasm/term_abi.ex
@@ -53,6 +53,11 @@ defmodule Beaver.Wasm.TermABI do
     "ex.term.native_time" => %{params: [], result: :i64},
     "ex.term.unique_integer" => %{params: [:i64], result: :i64},
     "ex.term.mailbox_clear" => %{params: [], result: :i64},
+    # explicit execution-instance lifecycle
+    "ex.term.runtime_create" => %{params: [], result: :i64},
+    "ex.term.runtime_enter" => %{params: [:i64], result: :i64},
+    "ex.term.runtime_leave" => %{params: [], result: :i64},
+    "ex.term.runtime_destroy" => %{params: [:i64], result: :i64},
     # process table / scheduler driver
     "ex.term.spawn" => %{params: [:i64], result: :i64},
     "ex.term.process_table_reset" => %{params: [:i64], result: :i64},

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -690,33 +690,37 @@ defmodule ExConversionTest do
             %2 = "ex.lit"() {value = 2 : i64} : () -> i64
             %3 = "ex.box"(%0) : (i64) -> !ex.dyn
             %4 = "ex.spawn"(%3) : (!ex.dyn) -> !ex.dyn
-            %5 = "ex.process_table_reset"(%1) : (i64) -> i64
-            %6 = "ex.cont_save"(%1, %2, %0) : (i64, i64, i64) -> i64
-            %7 = "ex.receive_cont_save"(%1, %2, %0) : (i64, i64, i64) -> i64
-            %8 = "ex.cont_pending"() : () -> i64
-            %9 = "ex.cont_active"() : () -> i64
-            %10 = "ex.cont_clear"() : () -> i64
-            %11 = "ex.cont_load_arg"() : () -> i64
-            %12 = "ex.cont_load_acc"() : () -> i64
-            %13 = "ex.cont_load_cursor"() : () -> i64
-            %14 = "ex.schedule_next"() : () -> i64
-            %15 = "ex.mailbox_len"() : () -> i64
-            %16 = "ex.mailbox_peek"(%0) : (i64) -> !ex.dyn
-            %17 = "ex.mailbox_remove"(%0) : (i64) -> i64
-            %18 = "ex.nil_word"() : () -> !ex.dyn
-            %19 = "ex.monotonic_time"() : () -> i64
-            %20 = "ex.receive_start"() : () -> i64
-            %21 = "ex.receive_start_set"(%0) : (i64) -> i64
-            %22 = "ex.native_time"() : () -> i64
-            %23 = "ex.unique_integer"(%0) : (i64) -> i64
-            %24 = "ex.current_entry"() : () -> i64
-            %25 = "ex.process_done"(%0) : (i64) -> i64
-            %26 = "ex.processes_runnable"() : () -> i64
-            %27 = "ex.process_result"(%4) : (!ex.dyn) -> i64
-            %28 = "ex.func_addr"() {sym_name = "actor_step"} : () -> ((i64) -> i64)
-            %29 = "ex.worker_run"(%1, %28) : (i64, (i64) -> i64) -> i64
-            %30 = "ex.process_wait"(%0) : (i64) -> i64
-            "ex.return"(%29) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+            %5 = "ex.runtime_create"() : () -> i64
+            %6 = "ex.runtime_enter"(%5) : (i64) -> i64
+            %runtime_leave = "ex.runtime_leave"() : () -> i64
+            %runtime_destroy = "ex.runtime_destroy"(%5) : (i64) -> i64
+            %7 = "ex.process_table_reset"(%1) : (i64) -> i64
+            %8 = "ex.cont_save"(%1, %2, %0) : (i64, i64, i64) -> i64
+            %9 = "ex.receive_cont_save"(%1, %2, %0) : (i64, i64, i64) -> i64
+            %10 = "ex.cont_pending"() : () -> i64
+            %11 = "ex.cont_active"() : () -> i64
+            %12 = "ex.cont_clear"() : () -> i64
+            %13 = "ex.cont_load_arg"() : () -> i64
+            %14 = "ex.cont_load_acc"() : () -> i64
+            %15 = "ex.cont_load_cursor"() : () -> i64
+            %16 = "ex.schedule_next"() : () -> i64
+            %17 = "ex.mailbox_len"() : () -> i64
+            %18 = "ex.mailbox_peek"(%0) : (i64) -> !ex.dyn
+            %19 = "ex.mailbox_remove"(%0) : (i64) -> i64
+            %20 = "ex.nil_word"() : () -> !ex.dyn
+            %21 = "ex.monotonic_time"() : () -> i64
+            %22 = "ex.receive_start"() : () -> i64
+            %23 = "ex.receive_start_set"(%0) : (i64) -> i64
+            %24 = "ex.native_time"() : () -> i64
+            %25 = "ex.unique_integer"(%0) : (i64) -> i64
+            %26 = "ex.current_entry"() : () -> i64
+            %27 = "ex.process_done"(%0) : (i64) -> i64
+            %28 = "ex.processes_runnable"() : () -> i64
+            %29 = "ex.process_result"(%4) : (!ex.dyn) -> i64
+            %30 = "ex.func_addr"() {sym_name = "actor_step"} : () -> ((i64) -> i64)
+            %31 = "ex.worker_run"(%1, %30) : (i64, (i64) -> i64) -> i64
+            %32 = "ex.process_wait"(%0) : (i64) -> i64
+            "ex.return"(%31) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
           }) {sym_name = "main"} : () -> ()
         }
         """,
@@ -727,6 +731,10 @@ defmodule ExConversionTest do
 
     rendered = MLIR.to_string(module, generic: true)
     assert rendered =~ "ex.term.spawn"
+    assert rendered =~ "ex.term.runtime_create"
+    assert rendered =~ "ex.term.runtime_enter"
+    assert rendered =~ "ex.term.runtime_leave"
+    assert rendered =~ "ex.term.runtime_destroy"
     assert rendered =~ "ex.term.process_table_reset"
     assert rendered =~ "ex.term.cont_save"
     assert rendered =~ "ex.term.receive_cont_save"

--- a/test/wasm_term_abi_test.exs
+++ b/test/wasm_term_abi_test.exs
@@ -31,6 +31,10 @@ defmodule WasmTermABITest do
     assert TermABI.entry("ex.term.list_cons").params == [:i64, :i64]
     assert TermABI.entry("ex.term.list_cons").result == :i64
     assert TermABI.entry("ex.term.send").params == [:i64, :i64]
+    assert TermABI.entry("ex.term.runtime_create").params == []
+    assert TermABI.entry("ex.term.runtime_enter").params == [:i64]
+    assert TermABI.entry("ex.term.runtime_leave").params == []
+    assert TermABI.entry("ex.term.runtime_destroy").params == [:i64]
     assert TermABI.entry("ex.term.clock_tick").params == [:i64]
     assert TermABI.entry("ex.term.stream_filter").params == [:i64, :i64]
     assert TermABI.entry("ex.term.enumerable_reduce_c").params == [:i64, :i64, :i64, :i64]


### PR DESCRIPTION
## Summary

- add generic `ex.runtime_*` lifecycle operations
- lower them to the existing native term-runtime ABI
- expose the lifecycle entries through the WebAssembly ABI manifest

This is the lower layer for Batata execution-session isolation. Batata will create one runtime per execution and explicitly enter/leave it around generated code.

## Validation

- `mix format --check-formatted`
- `mix test` (429 passed, 5 skipped, 21 excluded)
