### PR TITLE
ex: add host result lifecycle operations

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -90,6 +90,13 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.runtime_enter", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.runtime_leave", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.runtime_destroy", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.result_create", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.result_destroy", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.result_root_kind", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.result_root_word", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.result_term_kind", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.result_term_length", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.result_term_get", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.process_table_reset", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.cont_save", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.receive_cont_save", &convert_term_read/3, version: "1.0")
@@ -199,6 +206,13 @@ defmodule Beaver.MLIR.Conversion.Ex do
     runtime_enter: "ex.term.runtime_enter",
     runtime_leave: "ex.term.runtime_leave",
     runtime_destroy: "ex.term.runtime_destroy",
+    result_create: "ex.term.result_create",
+    result_destroy: "ex.term.result_destroy",
+    result_root_kind: "ex.term.result_root_kind",
+    result_root_word: "ex.term.result_root_word",
+    result_term_kind: "ex.term.result_term_kind",
+    result_term_length: "ex.term.result_term_length",
+    result_term_get: "ex.term.result_term_get",
     process_table_reset: "ex.term.process_table_reset",
     cont_save: "ex.term.cont_save",
     receive_cont_save: "ex.term.receive_cont_save",
@@ -935,6 +949,13 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.runtime_enter"), do: @term_intrinsics.runtime_enter
   defp read_intrinsic("ex.runtime_leave"), do: @term_intrinsics.runtime_leave
   defp read_intrinsic("ex.runtime_destroy"), do: @term_intrinsics.runtime_destroy
+  defp read_intrinsic("ex.result_create"), do: @term_intrinsics.result_create
+  defp read_intrinsic("ex.result_destroy"), do: @term_intrinsics.result_destroy
+  defp read_intrinsic("ex.result_root_kind"), do: @term_intrinsics.result_root_kind
+  defp read_intrinsic("ex.result_root_word"), do: @term_intrinsics.result_root_word
+  defp read_intrinsic("ex.result_term_kind"), do: @term_intrinsics.result_term_kind
+  defp read_intrinsic("ex.result_term_length"), do: @term_intrinsics.result_term_length
+  defp read_intrinsic("ex.result_term_get"), do: @term_intrinsics.result_term_get
   defp read_intrinsic("ex.process_table_reset"), do: @term_intrinsics.process_table_reset
   defp read_intrinsic("ex.cont_save"), do: @term_intrinsics.cont_save
   defp read_intrinsic("ex.receive_cont_save"), do: @term_intrinsics.receive_cont_save
@@ -1173,6 +1194,28 @@ defmodule Beaver.MLIR.Conversion.Ex do
 
   defp intrinsic_function_type("ex.term.runtime_destroy", _ctx) do
     MLIR.Type.function([MLIR.Type.i64()], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.result_create", _ctx) do
+    MLIR.Type.function(List.duplicate(MLIR.Type.i64(), 2), [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type(symbol, _ctx)
+       when symbol in [
+              "ex.term.result_destroy",
+              "ex.term.result_root_kind",
+              "ex.term.result_root_word"
+            ] do
+    MLIR.Type.function([MLIR.Type.i64()], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type(symbol, _ctx)
+       when symbol in ["ex.term.result_term_kind", "ex.term.result_term_length"] do
+    MLIR.Type.function(List.duplicate(MLIR.Type.i64(), 2), [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.result_term_get", _ctx) do
+    MLIR.Type.function(List.duplicate(MLIR.Type.i64(), 3), [MLIR.Type.i64()])
   end
 
   defp intrinsic_function_type("ex.term.process_table_reset", _ctx) do

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -171,6 +171,35 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop runtime_destroy(handle = ^integer_like),
     results: [result: ^integer_like]
 
+  # Host-result lifecycle. A result handle keeps the producing runtime alive
+  # while the host materializes an arena-backed term, then releases both
+  # together. Inspection always carries the handle so runtimes can reject
+  # stale or foreign words instead of dereferencing arbitrary tagged i64s.
+  defop result_create(runtime = ^integer_like, word = ^integer_like),
+    results: [result: ^integer_like]
+
+  defop result_destroy(handle = ^integer_like),
+    results: [result: ^integer_like]
+
+  defop result_root_kind(handle = ^integer_like),
+    results: [result: ^integer_like]
+
+  defop result_root_word(handle = ^integer_like),
+    results: [result: ^integer_like]
+
+  defop result_term_kind(handle = ^integer_like, word = ^integer_like),
+    results: [result: ^integer_like]
+
+  defop result_term_length(handle = ^integer_like, word = ^integer_like),
+    results: [result: ^integer_like]
+
+  defop result_term_get(
+          handle = ^integer_like,
+          word = ^integer_like,
+          index = ^integer_like
+        ),
+        results: [result: ^integer_like]
+
   # Resets the runtime process table to a single fresh initial process with
   # the given capacity; the scheduler driver calls this at program start.
   defop process_table_reset(cap = ^integer_like),

--- a/lib/beaver/wasm/term_abi.ex
+++ b/lib/beaver/wasm/term_abi.ex
@@ -58,6 +58,14 @@ defmodule Beaver.Wasm.TermABI do
     "ex.term.runtime_enter" => %{params: [:i64], result: :i64},
     "ex.term.runtime_leave" => %{params: [], result: :i64},
     "ex.term.runtime_destroy" => %{params: [:i64], result: :i64},
+    # host result ownership / materialization
+    "ex.term.result_create" => %{params: [:i64, :i64], result: :i64},
+    "ex.term.result_destroy" => %{params: [:i64], result: :i64},
+    "ex.term.result_root_kind" => %{params: [:i64], result: :i64},
+    "ex.term.result_root_word" => %{params: [:i64], result: :i64},
+    "ex.term.result_term_kind" => %{params: [:i64, :i64], result: :i64},
+    "ex.term.result_term_length" => %{params: [:i64, :i64], result: :i64},
+    "ex.term.result_term_get" => %{params: [:i64, :i64, :i64], result: :i64},
     # process table / scheduler driver
     "ex.term.spawn" => %{params: [:i64], result: :i64},
     "ex.term.process_table_reset" => %{params: [:i64], result: :i64},

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -694,6 +694,13 @@ defmodule ExConversionTest do
             %6 = "ex.runtime_enter"(%5) : (i64) -> i64
             %runtime_leave = "ex.runtime_leave"() : () -> i64
             %runtime_destroy = "ex.runtime_destroy"(%5) : (i64) -> i64
+            %result_handle = "ex.result_create"(%5, %0) : (i64, i64) -> i64
+            %result_kind = "ex.result_root_kind"(%result_handle) : (i64) -> i64
+            %result_word = "ex.result_root_word"(%result_handle) : (i64) -> i64
+            %term_kind = "ex.result_term_kind"(%result_handle, %result_word) : (i64, i64) -> i64
+            %term_len = "ex.result_term_length"(%result_handle, %result_word) : (i64, i64) -> i64
+            %term_item = "ex.result_term_get"(%result_handle, %result_word, %0) : (i64, i64, i64) -> i64
+            %result_destroy = "ex.result_destroy"(%result_handle) : (i64) -> i64
             %7 = "ex.process_table_reset"(%1) : (i64) -> i64
             %8 = "ex.cont_save"(%1, %2, %0) : (i64, i64, i64) -> i64
             %9 = "ex.receive_cont_save"(%1, %2, %0) : (i64, i64, i64) -> i64
@@ -735,6 +742,17 @@ defmodule ExConversionTest do
     assert rendered =~ "ex.term.runtime_enter"
     assert rendered =~ "ex.term.runtime_leave"
     assert rendered =~ "ex.term.runtime_destroy"
+    assert rendered =~ "ex.term.result_create"
+    assert rendered =~ "ex.term.result_destroy"
+    assert rendered =~ "ex.term.result_root_kind"
+    assert rendered =~ "ex.term.result_root_word"
+    assert rendered =~ "ex.term.result_term_kind"
+    assert rendered =~ "ex.term.result_term_length"
+    assert rendered =~ "ex.term.result_term_get"
+
+    assert rendered =~
+             ~s|"func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "ex.term.result_term_get"|
+
     assert rendered =~ "ex.term.process_table_reset"
     assert rendered =~ "ex.term.cont_save"
     assert rendered =~ "ex.term.receive_cont_save"


### PR DESCRIPTION
## What changed

- add `ex.result_*` operations for host-owned result lifecycles
- lower the operations to an explicit `ex.term.result_*` runtime ABI
- publish matching WASM host signatures
- cover every operation in the ex conversion test

## Why

Batata currently destroys its runtime arena before a heap-backed `main` result
crosses the JIT/AOT boundary. These operations let the runtime return an opaque
result handle, keep the producing runtime alive during materialization, reject
foreign words, and release the handle and runtime together.

This is the Beaver base of the stacked implementation for Forgejo
`tsai/beaver#57`; the Batata runtime implementation follows in the next PR.

## Validation

- `mix format --check-formatted ...`
- `mix test test/ex_conversion_test.exs test/wasm_term_abi_test.exs` (31 passed)
