### PR TITLE
ci: scheduled tracker for OpenAI LLVM + Triton pin, auto-build prebuilt

### DIFF
--- a/.github/workflows/track-upstream.yml
+++ b/.github/workflows/track-upstream.yml
@@ -1,0 +1,77 @@
+name: Track upstream pins
+
+on:
+  schedule:
+    # 04:30 UTC daily, ahead of "Check Upstream" (05:00).
+    - cron: "30 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: track-upstream
+  cancel-in-progress: true
+
+jobs:
+  track:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Resolve latest Triton main
+        id: triton
+        run: |
+          sha="$(gh api repos/triton-lang/triton/commits/main --jq .sha)"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve latest llvm/eudsl asset
+        id: eudsl
+        run: |
+          asset="$(gh api 'repos/llvm/eudsl/releases/tags/llvm' --paginate \
+            --jq '.assets[] | select(.name | startswith("mlir_manylinux_x86_64_") and endswith(".tar.gz")) | [.name, .updated_at] | @tsv' \
+            | sort -k2 | tail -1 | cut -f1)"
+          echo "asset=$asset" >> "$GITHUB_OUTPUT"
+
+      - name: Read current pins
+        id: current
+        run: |
+          echo "triton=$(jq -r .triton_ref triton.json)" >> "$GITHUB_OUTPUT"
+          echo "eudsl=$(jq -r .llvm_eudsl_latest upstream-pins.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Open pin-update PR
+        if: steps.triton.outputs.sha != steps.current.outputs.triton || steps.eudsl.outputs.asset != steps.current.outputs.eudsl
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          sha="${{ steps.triton.outputs.sha }}"
+          asset="${{ steps.eudsl.outputs.asset }}"
+          branch="agent/upstream-pins-${sha:0:12}"
+
+          git switch -c "$branch"
+          jq --arg ref "$sha" '.triton_ref = $ref' triton.json > triton.json.tmp \
+            && mv triton.json.tmp triton.json
+          jq --arg ref "$sha" --arg asset "$asset" \
+            '.triton_ref = $ref | .llvm_eudsl_latest = $asset' upstream-pins.json \
+            > upstream-pins.json.tmp && mv upstream-pins.json.tmp upstream-pins.json
+
+          git add triton.json upstream-pins.json
+          git -c user.name="beaver-upstream-tracker" \
+              -c user.email="actions@github.com" \
+              commit -m "chore: bump triton pin to ${sha:0:12}" \
+              -m "Latest triton-lang/triton main: ${sha}. Latest llvm/eudsl asset: ${asset}. Merging this PR triggers the Build Triton prebuilt workflow (push to main with triton.json) to publish the prebuilt for the new pin."
+          git push origin "$branch"
+
+          gh pr create --repo beaver-lodge/beaver \
+            --base main \
+            --head "$branch" \
+            --title "chore: bump triton pin to ${sha:0:12}" \
+            --body "Tracks the latest OpenAI LLVM (llvm/eudsl) release and the latest Triton pin.
+
+- triton_ref: ${sha}
+- llvm/eudsl latest asset: ${asset}
+
+Merging triggers \`Build Triton prebuilt\` (push to main with \`triton.json\`) to publish the prebuilt for the new pin."

--- a/.github/workflows/triton-prebuilt.yml
+++ b/.github/workflows/triton-prebuilt.yml
@@ -2,6 +2,11 @@ name: Build Triton prebuilt
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - triton.json
 
 permissions:
   contents: write

--- a/upstream-pins.json
+++ b/upstream-pins.json
@@ -1,0 +1,4 @@
+{
+  "triton_ref": "882eb72e1858bfd588fafa4677b86ce00e9da872",
+  "llvm_eudsl_latest": "mlir_manylinux_x86_64_20260809+9813315f2.tar.gz"
+}


### PR DESCRIPTION
Adds a daily scheduled workflow that tracks the latest upstream pins and opens a pin-update PR; merging it auto-triggers the Triton prebuilt build.

## What

1. **`track-upstream.yml`** (daily 04:30 UTC + manual dispatch): resolves the latest `triton-lang/triton` main commit and the newest `llvm/eudsl` release asset under the `llvm` tag; when either differs from `upstream-pins.json`, opens a PR on `agent/upstream-pins-<sha>` updating `triton.json` and `upstream-pins.json`.
2. **`triton-prebuilt.yml`**: added `push: branches: [main], paths: [triton.json]` — merging the pin PR triggers the existing build and publishes the prebuilt release for the new pin (`triton-prebuilt-<ref>`).
3. **`upstream-pins.json`** (new): records the current `triton_ref` and `llvm_eudsl_latest` for change detection.

## Notes

- The Triton prebuilt build uses the Triton-pinned LLVM (resolved from the triton commit's `cmake/llvm-info.json`), so the eudsl asset is informational for the default (non-triton) install path; both are tracked per the request.
- Merging the pin PR runs the normal Elixir CI plus the prebuilt build.