### PR TITLE
ci: fix track-upstream.yml YAML (multiline quoted string)

### DIFF
--- a/.github/workflows/track-upstream.yml
+++ b/.github/workflows/track-upstream.yml
@@ -65,13 +65,17 @@ jobs:
               -m "Latest triton-lang/triton main: ${sha}. Latest llvm/eudsl asset: ${asset}. Merging this PR triggers the Build Triton prebuilt workflow (push to main with triton.json) to publish the prebuilt for the new pin."
           git push origin "$branch"
 
+          printf '%s\n' \
+            "Tracks the latest OpenAI LLVM (llvm/eudsl) release and the latest Triton pin." \
+            "" \
+            "- triton_ref: ${sha}" \
+            "- llvm/eudsl latest asset: ${asset}" \
+            "" \
+            "Merging triggers \`Build Triton prebuilt\` (push to main with \`triton.json\`) to publish the prebuilt for the new pin." \
+            > /tmp/pr_body.md
+
           gh pr create --repo beaver-lodge/beaver \
             --base main \
             --head "$branch" \
             --title "chore: bump triton pin to ${sha:0:12}" \
-            --body "Tracks the latest OpenAI LLVM (llvm/eudsl) release and the latest Triton pin.
-
-- triton_ref: ${sha}
-- llvm/eudsl latest asset: ${asset}
-
-Merging triggers \`Build Triton prebuilt\` (push to main with \`triton.json\`) to publish the prebuilt for the new pin."
+            --body-file /tmp/pr_body.md


### PR DESCRIPTION
The merged #627 carried the original workflow file whose PR-body was a multi-line double-quoted YAML string, which GitHub cannot parse (the inner '- triton_ref:' lines become list items and the workflow reports 'workflow file issue' on push).

Fix: build the PR body with printf into a file and pass `--body-file`. Validated with a YAML parser.