### PR TITLE
ci: set GH_TOKEN at job level in track-upstream.yml

### DIFF
--- a/.github/workflows/track-upstream.yml
+++ b/.github/workflows/track-upstream.yml
@@ -18,7 +18,12 @@ jobs:
   track:
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ github.token }}
+      # The repo blocks Actions-created PRs by default (createPullRequest).
+      # Either set the UPSTREAM_PINS_TOKEN fine-grained PAT (contents: write,
+      # pull requests: write on this repo), or enable Settings > Actions >
+      # General > Workflow permissions > "Allow GitHub Actions to create and
+      # approve pull requests".
+      GH_TOKEN: ${{ secrets.UPSTREAM_PINS_TOKEN || github.token }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/track-upstream.yml
+++ b/.github/workflows/track-upstream.yml
@@ -17,6 +17,8 @@ concurrency:
 jobs:
   track:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The `Track upstream pins` workflow fails on the `Resolve latest Triton main` step:

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
```

Only the PR-creation step had `GH_TOKEN: ${{ github.token }}`. Move it to the job-level `env` so all steps (including the resolve steps) use the workflow token.