### PR TITLE
ci: build the Triton prebuilt BEFORE opening the pin PR

### DIFF
--- a/.github/workflows/track-upstream.yml
+++ b/.github/workflows/track-upstream.yml
@@ -43,34 +43,73 @@ jobs:
             | sort -k2 | tail -1 | cut -f1)"
           echo "asset=$asset" >> "$GITHUB_OUTPUT"
 
+      - name: Check Triton-pinned LLVM availability
+        id: llvm
+        run: |
+          ref="${{ steps.triton.outputs.sha }}"
+          info="$(curl -fsS "https://raw.githubusercontent.com/triton-lang/triton/${ref}/cmake/llvm-info.json" \
+            || curl -fsS "https://raw.githubusercontent.com/triton-lang/triton/${ref}/cmake/llvm-build-info.json")"
+          hash="$(echo "$info" | jq -r '.llvm_hash // empty')"
+          build="$(echo "$info" | jq -r '.build_number // empty')"
+          if [[ -z "$hash" || "$build" == "null" || -z "$build" ]]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "No LLVM info for ${ref}" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          url="https://oaitriton.blob.core.windows.net/public/llvm-builds/llvm-${hash:0:8}-ubuntu-x64-${build}.tar.gz"
+          code="$(curl -s -o /dev/null -w '%{http_code}' -I "$url")"
+          echo "llvm_url=$url" >> "$GITHUB_OUTPUT"
+          echo "llvm_code=$code" >> "$GITHUB_OUTPUT"
+          echo "available=$([ "$code" = "200" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "Triton ${ref} LLVM: ${url} -> HTTP ${code}" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Read current pins
         id: current
         run: |
           echo "triton=$(jq -r .triton_ref triton.json)" >> "$GITHUB_OUTPUT"
           echo "eudsl=$(jq -r .llvm_eudsl_latest upstream-pins.json)" >> "$GITHUB_OUTPUT"
 
-      - name: Open pin-update PR
-        if: steps.triton.outputs.sha != steps.current.outputs.triton || steps.eudsl.outputs.asset != steps.current.outputs.eudsl
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Update pins, build prebuilt, open PR
+        # Open a PR when the eudsl asset moved, or when the triton pin moved
+        # AND its Triton-pinned LLVM is actually downloadable (OpenAI's LLVM
+        # builds lag Triton main). The elixir CI downloads
+        # triton-prebuilt-<ref>, so the prebuilt must be built and released
+        # BEFORE the pin PR's CI runs; dispatch the build on the pin branch
+        # and wait for it to finish, then open the PR.
+        if: (steps.eudsl.outputs.asset != steps.current.outputs.eudsl) || (steps.triton.outputs.sha != steps.current.outputs.triton && steps.llvm.outputs.available == 'true')
         run: |
+          set -euo pipefail
           sha="${{ steps.triton.outputs.sha }}"
           asset="${{ steps.eudsl.outputs.asset }}"
+          triton_changed="false"
+          if [ "$sha" != "${{ steps.current.outputs.triton }}" ]; then
+            triton_changed="true"
+          fi
           branch="agent/upstream-pins-${sha:0:12}"
 
           git switch -c "$branch"
-          jq --arg ref "$sha" '.triton_ref = $ref' triton.json > triton.json.tmp \
-            && mv triton.json.tmp triton.json
-          jq --arg ref "$sha" --arg asset "$asset" \
-            '.triton_ref = $ref | .llvm_eudsl_latest = $asset' upstream-pins.json \
+          if [ "$triton_changed" = "true" ]; then
+            jq --arg ref "$sha" '.triton_ref = $ref' triton.json > triton.json.tmp \
+              && mv triton.json.tmp triton.json
+          fi
+          jq --arg asset "$asset" '.llvm_eudsl_latest = $asset' upstream-pins.json \
             > upstream-pins.json.tmp && mv upstream-pins.json.tmp upstream-pins.json
 
           git add triton.json upstream-pins.json
           git -c user.name="beaver-upstream-tracker" \
               -c user.email="actions@github.com" \
               commit -m "chore: bump triton pin to ${sha:0:12}" \
-              -m "Latest triton-lang/triton main: ${sha}. Latest llvm/eudsl asset: ${asset}. Merging this PR triggers the Build Triton prebuilt workflow (push to main with triton.json) to publish the prebuilt for the new pin."
+              -m "Latest triton-lang/triton main: ${sha}. Latest llvm/eudsl asset: ${asset}."
           git push origin "$branch"
+
+          if [ "$triton_changed" = "true" ]; then
+            gh workflow run triton-prebuilt.yml --repo beaver-lodge/beaver --ref "$branch"
+            sleep 10
+            run_id="$(gh run list --repo beaver-lodge/beaver --workflow triton-prebuilt.yml \
+              --branch "$branch" --limit 1 --json databaseId --jq '.[0].databaseId')"
+            echo "Building triton-prebuilt release (run ${run_id})..."
+            gh run watch "$run_id" --repo beaver-lodge/beaver --exit-status --interval 30
+          fi
 
           printf '%s\n' \
             "Tracks the latest OpenAI LLVM (llvm/eudsl) release and the latest Triton pin." \
@@ -78,7 +117,7 @@ jobs:
             "- triton_ref: ${sha}" \
             "- llvm/eudsl latest asset: ${asset}" \
             "" \
-            "Merging triggers \`Build Triton prebuilt\` (push to main with \`triton.json\`) to publish the prebuilt for the new pin." \
+            "The \`triton-prebuilt-${sha:0:12}\` release was built from this branch before opening the PR, so the Elixir CI can download it. Merging also triggers \`Build Triton prebuilt\` (push to main with \`triton.json\`), which is idempotent." \
             > /tmp/pr_body.md
 
           gh pr create --repo beaver-lodge/beaver \

--- a/.github/workflows/track-upstream.yml
+++ b/.github/workflows/track-upstream.yml
@@ -87,6 +87,9 @@ jobs:
           fi
           branch="agent/upstream-pins-${sha:0:12}"
 
+          # Always rebuild the pin branch from current main; if the branch
+          # already exists remotely (a previous tracker run), the force-push
+          # replaces it and any open PR updates to the new head.
           git switch -c "$branch"
           if [ "$triton_changed" = "true" ]; then
             jq --arg ref "$sha" '.triton_ref = $ref' triton.json > triton.json.tmp \
@@ -100,7 +103,7 @@ jobs:
               -c user.email="actions@github.com" \
               commit -m "chore: bump triton pin to ${sha:0:12}" \
               -m "Latest triton-lang/triton main: ${sha}. Latest llvm/eudsl asset: ${asset}."
-          git push origin "$branch"
+          git push --force origin "$branch"
 
           if [ "$triton_changed" = "true" ]; then
             gh workflow run triton-prebuilt.yml --repo beaver-lodge/beaver --ref "$branch"
@@ -120,8 +123,15 @@ jobs:
             "The \`triton-prebuilt-${sha:0:12}\` release was built from this branch before opening the PR, so the Elixir CI can download it. Merging also triggers \`Build Triton prebuilt\` (push to main with \`triton.json\`), which is idempotent." \
             > /tmp/pr_body.md
 
-          gh pr create --repo beaver-lodge/beaver \
-            --base main \
-            --head "$branch" \
-            --title "chore: bump triton pin to ${sha:0:12}" \
-            --body-file /tmp/pr_body.md
+          existing="$(gh pr list --repo beaver-lodge/beaver --head "$branch" \
+            --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            echo "PR #${existing} already exists for ${branch}; branch updated"
+            gh pr edit "$existing" --repo beaver-lodge/beaver --body-file /tmp/pr_body.md
+          else
+            gh pr create --repo beaver-lodge/beaver \
+              --base main \
+              --head "$branch" \
+              --title "chore: bump triton pin to ${sha:0:12}" \
+              --body-file /tmp/pr_body.md
+          fi

--- a/.github/workflows/track-upstream.yml
+++ b/.github/workflows/track-upstream.yml
@@ -24,6 +24,12 @@ jobs:
       # General > Workflow permissions > "Allow GitHub Actions to create and
       # approve pull requests".
       GH_TOKEN: ${{ secrets.UPSTREAM_PINS_TOKEN || github.token }}
+    outputs:
+      triton_sha: ${{ steps.triton.outputs.sha }}
+      eudsl_asset: ${{ steps.eudsl.outputs.asset }}
+      current_triton: ${{ steps.current.outputs.triton }}
+      eudsl_current: ${{ steps.current.outputs.eudsl }}
+      llvm_available: ${{ steps.llvm.outputs.available }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -51,7 +57,7 @@ jobs:
             || curl -fsS "https://raw.githubusercontent.com/triton-lang/triton/${ref}/cmake/llvm-build-info.json")"
           hash="$(echo "$info" | jq -r '.llvm_hash // empty')"
           build="$(echo "$info" | jq -r '.build_number // empty')"
-          if [[ -z "$hash" || "$build" == "null" || -z "$build" ]]; then
+          if [[ -z "$hash" || -z "$build" || "$build" == "null" ]]; then
             echo "available=false" >> "$GITHUB_OUTPUT"
             echo "No LLVM info for ${ref}" >> "$GITHUB_STEP_SUMMARY"
             exit 0
@@ -59,7 +65,6 @@ jobs:
           url="https://oaitriton.blob.core.windows.net/public/llvm-builds/llvm-${hash:0:8}-ubuntu-x64-${build}.tar.gz"
           code="$(curl -s -o /dev/null -w '%{http_code}' -I "$url")"
           echo "llvm_url=$url" >> "$GITHUB_OUTPUT"
-          echo "llvm_code=$code" >> "$GITHUB_OUTPUT"
           echo "available=$([ "$code" = "200" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "Triton ${ref} LLVM: ${url} -> HTTP ${code}" >> "$GITHUB_STEP_SUMMARY"
 
@@ -69,27 +74,16 @@ jobs:
           echo "triton=$(jq -r .triton_ref triton.json)" >> "$GITHUB_OUTPUT"
           echo "eudsl=$(jq -r .llvm_eudsl_latest upstream-pins.json)" >> "$GITHUB_OUTPUT"
 
-      - name: Update pins, build prebuilt, open PR
-        # Open a PR when the eudsl asset moved, or when the triton pin moved
-        # AND its Triton-pinned LLVM is actually downloadable (OpenAI's LLVM
-        # builds lag Triton main). The elixir CI downloads
-        # triton-prebuilt-<ref>, so the prebuilt must be built and released
-        # BEFORE the pin PR's CI runs; dispatch the build on the pin branch
-        # and wait for it to finish, then open the PR.
+      - name: Create/update pin branch
         if: (steps.eudsl.outputs.asset != steps.current.outputs.eudsl) || (steps.triton.outputs.sha != steps.current.outputs.triton && steps.llvm.outputs.available == 'true')
         run: |
           set -euo pipefail
           sha="${{ steps.triton.outputs.sha }}"
           asset="${{ steps.eudsl.outputs.asset }}"
           triton_changed="false"
-          if [ "$sha" != "${{ steps.current.outputs.triton }}" ]; then
-            triton_changed="true"
-          fi
+          [ "$sha" != "${{ steps.current.outputs.triton }}" ] && triton_changed="true"
           branch="agent/upstream-pins-${sha:0:12}"
 
-          # Always rebuild the pin branch from current main; if the branch
-          # already exists remotely (a previous tracker run), the force-push
-          # replaces it and any open PR updates to the new head.
           git switch -c "$branch"
           if [ "$triton_changed" = "true" ]; then
             jq --arg ref "$sha" '.triton_ref = $ref' triton.json > triton.json.tmp \
@@ -105,14 +99,35 @@ jobs:
               -m "Latest triton-lang/triton main: ${sha}. Latest llvm/eudsl asset: ${asset}."
           git push --force origin "$branch"
 
-          if [ "$triton_changed" = "true" ]; then
-            gh workflow run triton-prebuilt.yml --repo beaver-lodge/beaver --ref "$branch"
-            sleep 10
-            run_id="$(gh run list --repo beaver-lodge/beaver --workflow triton-prebuilt.yml \
-              --branch "$branch" --limit 1 --json databaseId --jq '.[0].databaseId')"
-            echo "Building triton-prebuilt release (run ${run_id})..."
-            gh run watch "$run_id" --repo beaver-lodge/beaver --exit-status --interval 30
-          fi
+  build-prebuilt:
+    needs: track
+    # The pin PR's Elixir CI downloads triton-prebuilt-<ref>, so the prebuilt
+    # must be released BEFORE opening the PR. Only build when the triton pin
+    # moved and its LLVM is actually published (OpenAI's LLVM builds lag
+    # Triton main).
+    if: needs.track.outputs.triton_sha != needs.track.outputs.current_triton && needs.track.outputs.llvm_available == 'true'
+    uses: ./.github/workflows/triton-prebuilt.yml
+    with:
+      triton_ref: ${{ needs.track.outputs.triton_sha }}
+    secrets: inherit
+
+  open-pr:
+    needs: [track, build-prebuilt]
+    if: always() && (needs.track.outputs.eudsl_asset != needs.track.outputs.eudsl_current || (needs.track.outputs.triton_sha != needs.track.outputs.current_triton && needs.track.outputs.llvm_available == 'true')) && (needs.build-prebuilt.result == 'success' || needs.build-prebuilt.result == 'skipped')
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.UPSTREAM_PINS_TOKEN || github.token }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Open or update pin PR
+        run: |
+          set -euo pipefail
+          sha="${{ needs.track.outputs.triton_sha }}"
+          asset="${{ needs.track.outputs.eudsl_asset }}"
+          branch="agent/upstream-pins-${sha:0:12}"
 
           printf '%s\n' \
             "Tracks the latest OpenAI LLVM (llvm/eudsl) release and the latest Triton pin." \

--- a/.github/workflows/triton-prebuilt.yml
+++ b/.github/workflows/triton-prebuilt.yml
@@ -2,6 +2,12 @@ name: Build Triton prebuilt
 
 on:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      triton_ref:
+        description: "Triton commit ref to build; defaults to triton.json"
+        type: string
+        required: false
   push:
     branches:
       - main
@@ -36,7 +42,11 @@ jobs:
       - name: Read Triton version
         id: triton-version
         run: |
-          ref="$(jq -er '.triton_ref' triton.json)"
+          if [ -n "${{ inputs.triton_ref }}" ]; then
+            ref="${{ inputs.triton_ref }}"
+          else
+            ref="$(jq -er '.triton_ref' triton.json)"
+          fi
           echo "TRITON_REF=$ref" >> "$GITHUB_ENV"
           echo "ref=$ref" >> "$GITHUB_OUTPUT"
 

--- a/upstream-pins.json
+++ b/upstream-pins.json
@@ -1,4 +1,3 @@
 {
-  "triton_ref": "882eb72e1858bfd588fafa4677b86ce00e9da872",
   "llvm_eudsl_latest": "mlir_manylinux_x86_64_20260809+9813315f2.tar.gz"
 }


### PR DESCRIPTION
The pin PR's Elixir CI downloads `triton-prebuilt-<ref>` from a release; the previous design opened the PR first, so the release did not exist and the triton CI job failed with `release not found` (chicken-and-egg between the pin PR and the prebuilt build).

The tracker now:
1. checks the Triton-pinned LLVM archive is downloadable (OpenAI's LLVM builds lag Triton main; skip pins whose LLVM is not published);
2. pushes the pin branch, dispatches `Build Triton prebuilt` on it, waits for the build;
3. only then opens the pin PR, whose CI can download the release.

Also drops the redundant `triton_ref` from `upstream-pins.json` (`triton.json` is the single source of truth).