### PR TITLE
native: share one resource slot registry across partitions

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -70,11 +70,11 @@ jobs:
       - name: Read Triton version
         if: matrix.llvm == 'triton'
         run: echo "TRITON_REF=$(jq -er '.triton_ref' triton.json)" >> "$GITHUB_ENV"
-      # Kinda 0.11.0 on Hex predates the LLP64 integer conversion fix, so the
-      # Windows lane uses the paired revision pinned in kinda.ref until a
-      # release containing beaver-lodge/kinda#68 is published.
+      # Kinda 0.11.0 on Hex predates the LLP64 integer conversion fix and the
+      # ResourceSlot registry API, so every lane uses the paired revision
+      # pinned in kinda.ref until a release containing beaver-lodge/kinda#68
+      # and beaver-lodge/kinda#87 is published.
       - name: Check out paired Kinda
-        if: runner.os == 'Windows'
         run: |
           ref="$(awk 'NF && $1 !~ /^#/ {print $1; exit}' kinda.ref 2>/dev/null || true)"
           if [ -n "$ref" ]; then

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -46,12 +46,9 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: ["ubuntu-22.04"]
-        otp: ["25.0", "27.3"]
+        otp: ["27.3"]
         elixir: ["1.18.0", "1.20.3"]
         llvm: ["eudsl"]
-        exclude:
-          - otp: "25.0"
-            elixir: "1.20.3"
         include:
           - runs-on: "ubuntu-22.04"
             otp: "28.4"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,12 +52,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         name: Check-out beaver
-      # Kinda 0.11.0 on Hex predates the LLP64 integer conversion and Windows
-      # synchronization fixes, so the Windows lane uses the paired revision
-      # pinned in kinda.ref until a release containing beaver-lodge/kinda#66
-      # and #68 is published.
+      # Kinda 0.11.0 on Hex predates the LLP64 integer conversion, Windows
+      # synchronization fixes, and the ResourceSlot registry API, so every
+      # lane uses the paired revision pinned in kinda.ref until a release
+      # containing beaver-lodge/kinda#66, #68 and #87 is published.
       - name: Check out paired Kinda
-        if: runner.os == 'Windows'
         run: |
           ref="$(awk 'NF && $1 !~ /^#/ {print $1; exit}' kinda.ref 2>/dev/null || true)"
           if [ -n "$ref" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,13 +305,26 @@ jobs:
         with:
           repository: beaver-lodge/beaver
           path: beaver
+      - name: Check out paired Kinda
+        run: |
+          ref="$(awk 'NF && $1 !~ /^#/ {print $1; exit}' beaver/kinda.ref 2>/dev/null || true)"
+          if [ -n "$ref" ]; then
+            git clone https://github.com/beaver-lodge/kinda.git kinda
+            if git -C kinda cat-file -e "$ref^{commit}" 2>/dev/null; then
+              git -C kinda checkout "$ref"
+            else
+              echo "warning: paired kinda ref $ref unavailable, using Hex release" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          else
+            echo "no paired kinda ref, using Hex release" >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Strip dev suffix
         working-directory: beaver
         run: sed -i 's/-dev//g' mix.exs
       - name: Build ARM
         continue-on-error: true
         if: ${{ matrix.image.platform == 'linux/arm64/v8' && github.event_name != 'pull_request' }}
-        run: docker run --platform ${{ matrix.image.platform }} -v $PWD:/src -w /src/beaver ${{ vars.DOCKERHUB_USERNAME }}/beaver-livebook-${{ matrix.image.suffix }}:latest bash scripts/build-for-publish.sh
+        run: docker run --platform ${{ matrix.image.platform }} -v $PWD:/src -w /src/beaver -e BEAVER_KINDA_PATH=/src/kinda ${{ vars.DOCKERHUB_USERNAME }}/beaver-livebook-${{ matrix.image.suffix }}:latest bash scripts/build-for-publish.sh
       - name: Publish archives and packages
         uses: softprops/action-gh-release@v3
         if: ${{ github.event_name != 'pull_request' && github.repository == 'beaver-lodge/beaver' && matrix.image.platform == 'linux/arm64/v8' }}
@@ -328,7 +341,7 @@ jobs:
           tag_name: ${{ github.ref_name }}
       - name: Build x86
         if: ${{ matrix.image.platform == 'linux/amd64' }}
-        run: docker run -v $PWD:/src -w /src/beaver ${{ vars.DOCKERHUB_USERNAME }}/beaver-livebook-${{ matrix.image.suffix }}:latest bash scripts/build-for-publish.sh
+        run: docker run -v $PWD:/src -w /src/beaver -e BEAVER_KINDA_PATH=/src/kinda ${{ vars.DOCKERHUB_USERNAME }}/beaver-livebook-${{ matrix.image.suffix }}:latest bash scripts/build-for-publish.sh
 
   hex_publish:
     name: Publish to Hex.pm

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .kinda = .{
-            .url = "https://codeload.github.com/beaver-lodge/kinda/tar.gz/81a51065952cb644b10cb60dacc4370ec653c9ed",
-            .hash = "kinda-0.11.0-dev-ghcZCXRrAQBdY2vX_BioJ5dH2ot1dpV1d4HstzY1z7ti",
+            .url = "https://codeload.github.com/beaver-lodge/kinda/tar.gz/5d34fb21c5a6f66490447cd296c898a9825f1232",
+            .hash = "kinda-0.11.0-dev-ghcZCR2HAQBuQB_sPYBrSY7yKHmguKExLjE7AKim1bhU",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,7 +5,7 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .kinda = .{
-            .url = "https://codeload.github.com/beaver-lodge/kinda/tar.gz/5d34fb21c5a6f66490447cd296c898a9825f1232",
+            .url = "https://codeload.github.com/beaver-lodge/kinda/tar.gz/aa43cd03d266b43068b707e7a6aeae112ad49ad3",
             .hash = "kinda-0.11.0-dev-ghcZCR2HAQBuQB_sPYBrSY7yKHmguKExLjE7AKim1bhU",
         },
     },

--- a/kinda.ref
+++ b/kinda.ref
@@ -5,4 +5,4 @@
 # line, probes the revision on beaver-lodge/kinda, and falls back to the Hex
 # release when it is unavailable. Delete this file once the fixes land in a
 # Hex release.
-5d34fb21c5a6f66490447cd296c898a9825f1232
+aa43cd03d266b43068b707e7a6aeae112ad49ad3

--- a/kinda.ref
+++ b/kinda.ref
@@ -5,4 +5,4 @@
 # line, probes the revision on beaver-lodge/kinda, and falls back to the Hex
 # release when it is unavailable. Delete this file once the fixes land in a
 # Hex release.
-81a51065952cb644b10cb60dacc4370ec653c9ed
+5d34fb21c5a6f66490447cd296c898a9825f1232

--- a/native/src/core.zig
+++ b/native/src/core.zig
@@ -62,31 +62,11 @@ pub fn register_all_passes() void {
 /// the same resource types: opening the same name twice within one load
 /// creates distinct resource types, so handles must be shared explicitly.
 export fn core_resource_type_by_name(name: [*:0]const u8) ?*anyopaque {
-    inline for (mlir_capi.allKinds) |k| {
-        if (std.mem.eql(u8, std.mem.span(name), k.resource.name)) {
-            return @ptrCast(k.resource.t);
+    const name_slice = std.mem.span(name);
+    inline for (mlir_capi.resourceSlots) |slot| {
+        if (std.mem.eql(u8, name_slice, slot.name)) {
+            return @ptrCast(slot.t.*);
         }
-        if (std.mem.eql(u8, std.mem.span(name), k.Ptr.resource.name)) {
-            return @ptrCast(k.Ptr.resource.t);
-        }
-        if (std.mem.eql(u8, std.mem.span(name), k.Array.resource.name)) {
-            return @ptrCast(k.Array.resource.t);
-        }
-    }
-    if (std.mem.eql(u8, std.mem.span(name), kinda.Internal.OpaquePtr.resource.name)) {
-        return @ptrCast(kinda.Internal.OpaquePtr.resource.t);
-    }
-    if (std.mem.eql(u8, std.mem.span(name), kinda.Internal.OpaqueArray.resource.name)) {
-        return @ptrCast(kinda.Internal.OpaqueArray.resource.t);
-    }
-    if (std.mem.eql(u8, std.mem.span(name), kinda.Internal.USize.resource.name)) {
-        return @ptrCast(kinda.Internal.USize.resource.t);
-    }
-    if (std.mem.eql(u8, std.mem.span(name), kinda.Internal.OpaqueStruct.resource.name)) {
-        return @ptrCast(kinda.Internal.OpaqueStruct.resource.t);
-    }
-    if (std.mem.eql(u8, std.mem.span(name), kinda.callback_runtime.ReplyToken.resource_name)) {
-        return @ptrCast(kinda.callback_runtime.ReplyToken.resource_type);
     }
     return null;
 }

--- a/native/src/mlir_capi.zig
+++ b/native/src/mlir_capi.zig
@@ -132,15 +132,46 @@ pub const TransformOptions = MLIRKind("TransformOptions");
 pub const LLVMThreadPool = MLIRKind2("MlirLlvmThreadPool", "LLVMThreadPool");
 pub const OperationState = MLIRKind2("MlirOperationState", "Operation.State");
 pub const allKinds = .{ Pass, LogicalResult, StringRef, Context, Location, ISize, Attribute, OpaquePtr, ShapedTypeComponentsCallback, TypeID, TypesCallback, Bool, Operation, IntegerSet, AffineExpr, StringCallback, DialectHandle, CInt, AffineMap, SparseTensorLevelType, F64, Type, I32, I64, CUInt, DialectRegistry, DiagnosticHandlerID, DiagnosticHandler, DiagnosticHandlerDeleteUserData, Diagnostic, DiagnosticSeverity, F32, U64, U32, U16, I16, U8, I8, USize, UnmanagedDenseResourceElementsAttrGetDeleteCallback, OpaqueArray, StringArray, NamedAttribute, PassManager, RewritePattern, RewritePatternSet, RewritePatternCallbacks, ConversionTarget, ConversionPattern, ConversionPatternRewriter, TypeConverter, ConversionConfig, Region, Module, ExecutionEngine, GenericCallback, ExternalPassConstruct, ExternalPassRun, Identifier, OperationState, SymbolTable, Value, Block, Dialect, ExternalPass, ExternalPassCallbacks, OpPassManager, AffineMapCompressUnusedSymbolsPopulateResult, SymbolTableWalkSymbolTablesCallback, OpOperand, AsmState, OperationWalkCallback, WalkOrder, BytecodeWriterConfig, OpPrintingFlags, LLVMRawFdOStream, LLVMThreadPool, TypeIDAllocator, DynamicOpTrait, DynamicOpTraitCallbacks, DynamicTypeDefinition, DynamicAttrDefinition, MemoryEffectInstancesList, MemoryEffectsOpInterfaceCallbacks, TransformResults, TransformRewriter, TransformState, TransformOpInterfaceCallbacks, PatternDescriptorOpInterfaceCallbacks, TransformOptions, RewriterBase, FrozenRewritePatternSet, PDLPatternModule, GreedyRewriteDriverConfig, string_ref.Printer.ResourceKind, LinalgContractionDimensions, LinalgConvolutionDimensions, PDLValue, PDLResultList, PDLRewriteFunction, PatternRewriter, ConditionallySpeculatableOpInterfaceCallbacks, DominanceInfo, IRMapping, MemoryEffect, MemoryEffectInstance, OpOperandReplaceFilterCallback, PostDominanceInfo, RewriterBaseInsertPoint, SideEffectResource, TypeConverter1ToNConversionCallback, TypeConverter1ToNTargetMaterializationCallback, TypeConverterConversionResults, TypeConverterSourceMaterializationCallback, TypeConverterTargetMaterializationCallback };
+
+/// Kinds that share ERTS resource types with another kind. The alias target
+/// opens the slot; the alias kind only copies the handle so terms made through
+/// either name fetch the same native data.
+const kindAliases = .{
+    .{ OpaquePtr, kinda.Internal.OpaquePtr },
+    .{ OpaqueArray, kinda.Internal.OpaqueArray },
+    .{ USize, kinda.Internal.USize },
+    .{ DiagnosticHandlerID, U64 },
+    .{ SparseTensorLevelType, U64 },
+};
+
+/// Every resource slot opened by this module, in a stable name order, plus
+/// the shared internal kinds and the callback reply token. The core partition
+/// publishes these handles by name for the leaf partitions; each partition
+/// builds its own registry instance because comptime values do not cross DSO
+/// boundaries, but the slot names and order are identical.
+pub const resourceSlots = blk: {
+    const internal_kinds = .{ kinda.Internal.OpaquePtr, kinda.Internal.OpaqueArray, kinda.Internal.USize, kinda.Internal.OpaqueStruct };
+    var tuple: []const kinda.ResourceSlot = &.{};
+    for (allKinds) |k| {
+        tuple = tuple ++ &k.slots;
+    }
+    for (internal_kinds) |k| {
+        tuple = tuple ++ &k.slots;
+    }
+    const reply_token_slots = [_]kinda.ResourceSlot{
+        .{ .name = kinda.callback_runtime.ReplyToken.resource_name, .t = &kinda.callback_runtime.ReplyToken.resource_type, .dtor = beam.destroy_do_nothing },
+    };
+    tuple = tuple ++ &reply_token_slots;
+    break :blk tuple;
+};
+
 pub fn open_all(env: beam.env) void {
     inline for (allKinds) |k| {
         k.open_all(env);
     }
-    kinda.aliasKind(OpaquePtr, kinda.Internal.OpaquePtr);
-    kinda.aliasKind(OpaqueArray, kinda.Internal.OpaqueArray);
-    kinda.aliasKind(USize, kinda.Internal.USize);
-    kinda.aliasKind(DiagnosticHandlerID, U64);
-    kinda.aliasKind(SparseTensorLevelType, U64);
+    inline for (kindAliases) |pair| {
+        kinda.aliasKind(pair[0], pair[1]);
+    }
 }
 
 const EntriesT = [allKinds.len * kinda.numOfNIFsPerKind]e.ErlNifFunc;

--- a/native/src/resource_sync.zig
+++ b/native/src/resource_sync.zig
@@ -6,28 +6,13 @@ const mlir_capi = @import("mlir_capi.zig");
 
 extern fn core_resource_type_by_name(name: [*:0]const u8) ?*anyopaque;
 
-fn lookup(name: [*:0]const u8) ?*e.ErlNifResourceType {
-    const handle = core_resource_type_by_name(name) orelse return null;
-    return @ptrCast(handle);
-}
-
-fn syncKind(comptime k: type) void {
-    k.resource.t = lookup(k.resource.name);
-    k.Ptr.resource.t = lookup(k.Ptr.resource.name);
-    k.Array.resource.t = lookup(k.Array.resource.name);
-}
-
 /// Copies the resource type handles opened by the core partition into this
 /// partition's kind instances. Resource type handles cannot be reopened during
 /// the same NIF load, so every partition that fetches or creates kind terms
 /// must share the core-opened handles this way.
 pub fn syncResourceTypes() void {
-    inline for (mlir_capi.allKinds) |k| {
-        syncKind(k);
+    inline for (mlir_capi.resourceSlots) |slot| {
+        const handle: ?*e.ErlNifResourceType = @ptrCast(core_resource_type_by_name(@ptrCast(slot.name.ptr)));
+        slot.t.* = handle;
     }
-    syncKind(kinda.Internal.OpaquePtr);
-    syncKind(kinda.Internal.OpaqueArray);
-    syncKind(kinda.Internal.USize);
-    syncKind(kinda.Internal.OpaqueStruct);
-    kinda.callback_runtime.ReplyToken.resource_type = lookup(kinda.callback_runtime.ReplyToken.resource_name);
 }


### PR DESCRIPTION
## 背景

beaver 的 NIF 加载入口（`nif_load`）把 MLIR C API 分片成多个 DSO（core / conversion / callback_bridge / rewrite_pattern / cuda）。每个 kind 有 3 个 ERTS resource slot（value / Ptr / Array），跨 partition 共享 resource type handle 时不能重复 `enif_open_resource_type`（会创建不同 resource type），所以 core 通过 `core_resource_type_by_name` 按名字发布 handle，leaf partition 通过 `syncResourceTypes` 拉取。

现状是三份手写遍历：

- `core.zig` 的 `core_resource_type_by_name`：逐个 `allKinds` + Internal 类型 + ReplyToken 手写字符串比较；
- `resource_sync.zig` 的 `syncResourceTypes`：手写同一批 kind 的同步；
- `mlir_capi.zig` 的 `open_all`：5 处手写 `aliasKind` 调用。

## 改动

依赖 [kinda 5d34fb2](https://github.com/beaver-lodge/kinda/commit/5d34fb2)（`ResourceKind` 暴露统一的 `slots` 数组，open/alias 都遍历槽位）。

- `mlir_capi.zig`：新增 `resourceSlots` comptime 注册表（所有 kind 的 3 槽位 + Internal 4 个 kind + callback ReplyToken），alias 收敛为 `kindAliases` 表；
- `core.zig`：`core_resource_type_by_name` 遍历注册表；
- `resource_sync.zig`：`syncResourceTypes` 遍历同一注册表；
- `build.zig.zon` / `kinda.ref`：kinda pin 更新到 5d34fb2。

## 验证

- `zig build`（beaver_native 全部分片编译通过）；
- `mix test`：431 passed（含 resource 密集的 op/memref/pattern/transform 模块），5 skipped，21 excluded（triton/cuda 相关）。

## 后续

注册表目前是线性 comptime 遍历（~200 槽位），加载时一次性执行；如果未来槽位数进一步膨胀，可以换排序+二分，但当前量级没必要。