### PR TITLE
add dynamic map put operation

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -151,6 +151,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.list", &convert_term_list/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.list_cons", &convert_term_list_cons/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.map", &convert_term_map/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.map_put", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.mapset_from_list", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.mapset_member", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.mapset_put", &convert_term_read/3, version: "1.0")
@@ -205,6 +206,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
   # `native/term_runtime.zig` exports exactly these C symbols.
   @term_intrinsics %{
     list_cons: "ex.term.list_cons",
+    map_put: "ex.term.map_put",
     self: "ex.term.self",
     send: "ex.term.send",
     receive: "ex.term.receive",
@@ -929,6 +931,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.tuple_get"), do: @term_intrinsics.tuple_get
   defp read_intrinsic("ex.tuple_length"), do: @term_intrinsics.tuple_length
   defp read_intrinsic("ex.map_length"), do: @term_intrinsics.map_length
+  defp read_intrinsic("ex.map_put"), do: @term_intrinsics.map_put
   defp read_intrinsic("ex.mapset_from_list"), do: @term_intrinsics.mapset_from_list
   defp read_intrinsic("ex.mapset_member"), do: @term_intrinsics.mapset_member
   defp read_intrinsic("ex.mapset_put"), do: @term_intrinsics.mapset_put
@@ -1178,6 +1181,10 @@ defmodule Beaver.MLIR.Conversion.Ex do
 
   defp intrinsic_function_type("ex.term.list_cons", _ctx) do
     MLIR.Type.function([MLIR.Type.i64(), MLIR.Type.i64()], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.map_put", _ctx) do
+    MLIR.Type.function([MLIR.Type.i64(), MLIR.Type.i64(), MLIR.Type.i64()], [MLIR.Type.i64()])
   end
 
   defp intrinsic_function_type("ex.term.self", _ctx) do

--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -158,6 +158,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.file_read", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.file_read_lines", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.binary", &convert_term_binary/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.binary_from_list", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.is_integer", &convert_term_predicate/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.is_atom", &convert_term_predicate/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.is_binary", &convert_term_predicate/3, version: "1.0")
@@ -1017,6 +1018,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.processes_runnable"), do: @term_intrinsics.processes_runnable
   defp read_intrinsic("ex.process_result"), do: @term_intrinsics.process_result
   defp read_intrinsic("ex.binary_length"), do: @term_intrinsics.binary_length
+  defp read_intrinsic("ex.binary_from_list"), do: @term_intrinsics.binary_from_list
   defp read_intrinsic("ex.binary_get"), do: @term_intrinsics.binary_get
   defp read_intrinsic("ex.binary_slice"), do: @term_intrinsics.binary_slice
   defp read_intrinsic("ex.binary_utf8_get"), do: @term_intrinsics.binary_utf8_get

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -448,6 +448,9 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop binary(segments = variadic(base(dyn()))),
     results: [result: base(dyn())]
 
+  defop binary_from_list(bytes = base(dyn())),
+    results: [result: base(dyn())]
+
   defop is_integer(value = ^any_value),
     results: [result: ^integer_like]
 

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -427,6 +427,9 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop map(entries = variadic(base(dyn()))),
     results: [result: base(dyn())]
 
+  defop map_put(map = base(dyn()), key = base(dyn()), value = base(dyn())),
+    results: [result: base(dyn())]
+
   defop mapset_from_list(list = base(dyn())),
     results: [result: base(dyn())]
 

--- a/lib/beaver/wasm/term_abi.ex
+++ b/lib/beaver/wasm/term_abi.ex
@@ -122,6 +122,7 @@ defmodule Beaver.Wasm.TermABI do
     "ex.term.tuple_get" => %{params: [:i64, :i64], result: :i64},
     "ex.term.tuple_length" => %{params: [:i64], result: :i64},
     "ex.term.map_from_list" => %{params: [:i64], result: :i64},
+    "ex.term.map_put" => %{params: [:i64, :i64, :i64], result: :i64},
     "ex.term.map_length" => %{params: [:i64], result: :i64},
     "ex.term.mapset_from_list" => %{params: [:i64], result: :i64},
     "ex.term.mapset_member" => %{params: [:i64, :i64], result: :i64},

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -566,8 +566,9 @@ defmodule ExConversionTest do
             %5 = "ex.map"(%2, %3) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
             %6 = "ex.map_put"(%5, %2, %3) : (!ex.dyn, !ex.dyn, !ex.dyn) -> !ex.dyn
             %7 = "ex.binary"(%2, %3) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
-            %8 = "ex.is_list"(%4) : (!ex.dyn) -> i64
-            "ex.return"(%8) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+            %8 = "ex.binary_from_list"(%4) : (!ex.dyn) -> !ex.dyn
+            %9 = "ex.is_list"(%4) : (!ex.dyn) -> i64
+            "ex.return"(%9) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
           }) {sym_name = "main"} : () -> ()
         }
         """,

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -564,9 +564,10 @@ defmodule ExConversionTest do
             %3 = "ex.box"(%1) : (i64) -> !ex.dyn
             %4 = "ex.list"(%2, %3) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
             %5 = "ex.map"(%2, %3) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
-            %6 = "ex.binary"(%2, %3) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
-            %7 = "ex.is_list"(%4) : (!ex.dyn) -> i64
-            "ex.return"(%7) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+            %6 = "ex.map_put"(%5, %2, %3) : (!ex.dyn, !ex.dyn, !ex.dyn) -> !ex.dyn
+            %7 = "ex.binary"(%2, %3) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
+            %8 = "ex.is_list"(%4) : (!ex.dyn) -> i64
+            "ex.return"(%8) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
           }) {sym_name = "main"} : () -> ()
         }
         """,
@@ -578,6 +579,7 @@ defmodule ExConversionTest do
     rendered = MLIR.to_string(module, generic: true)
     assert rendered =~ "ex.term.list_cons"
     assert rendered =~ "ex.term.map_from_list"
+    assert rendered =~ "ex.term.map_put"
     assert rendered =~ "ex.term.binary_from_list"
     assert rendered =~ "ex.term.is_list"
   end

--- a/test/wasm_term_abi_test.exs
+++ b/test/wasm_term_abi_test.exs
@@ -30,6 +30,7 @@ defmodule WasmTermABITest do
   test "declares term signatures" do
     assert TermABI.entry("ex.term.list_cons").params == [:i64, :i64]
     assert TermABI.entry("ex.term.list_cons").result == :i64
+    assert TermABI.entry("ex.term.map_put").params == [:i64, :i64, :i64]
     assert TermABI.entry("ex.term.send").params == [:i64, :i64]
     assert TermABI.entry("ex.term.runtime_create").params == []
     assert TermABI.entry("ex.term.runtime_enter").params == [:i64]


### PR DESCRIPTION
Adds the minimal `ex.map_put` dialect operation and lowers it to the existing term-runtime ABI boundary.

Includes conversion and WebAssembly ABI coverage.

Checks: `mix test test/ex_conversion_test.exs test/wasm_term_abi_test.exs --seed 0`.