### PR TITLE
add runtime binary builder operation

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -158,6 +158,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.file_read", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.file_read_lines", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.binary", &convert_term_binary/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.binary_from_list", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.is_integer", &convert_term_predicate/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.is_atom", &convert_term_predicate/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.is_binary", &convert_term_predicate/3, version: "1.0")
@@ -1017,6 +1018,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.processes_runnable"), do: @term_intrinsics.processes_runnable
   defp read_intrinsic("ex.process_result"), do: @term_intrinsics.process_result
   defp read_intrinsic("ex.binary_length"), do: @term_intrinsics.binary_length
+  defp read_intrinsic("ex.binary_from_list"), do: @term_intrinsics.binary_from_list
   defp read_intrinsic("ex.binary_get"), do: @term_intrinsics.binary_get
   defp read_intrinsic("ex.binary_slice"), do: @term_intrinsics.binary_slice
   defp read_intrinsic("ex.binary_utf8_get"), do: @term_intrinsics.binary_utf8_get

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -448,6 +448,9 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop binary(segments = variadic(base(dyn()))),
     results: [result: base(dyn())]
 
+  defop binary_from_list(bytes = base(dyn())),
+    results: [result: base(dyn())]
+
   defop is_integer(value = ^any_value),
     results: [result: ^integer_like]
 

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -566,8 +566,9 @@ defmodule ExConversionTest do
             %5 = "ex.map"(%2, %3) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
             %6 = "ex.map_put"(%5, %2, %3) : (!ex.dyn, !ex.dyn, !ex.dyn) -> !ex.dyn
             %7 = "ex.binary"(%2, %3) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
-            %8 = "ex.is_list"(%4) : (!ex.dyn) -> i64
-            "ex.return"(%8) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+            %8 = "ex.binary_from_list"(%4) : (!ex.dyn) -> !ex.dyn
+            %9 = "ex.is_list"(%4) : (!ex.dyn) -> i64
+            "ex.return"(%9) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
           }) {sym_name = "main"} : () -> ()
         }
         """,


### PR DESCRIPTION
Adds `ex.binary_from_list` as the minimal runtime binary-builder operation over a dynamic byte list.

This is stacked on the map-put PR to keep the Beaver sequence explicit.

Checks: `mix test test/ex_conversion_test.exs --seed 0`.