### PR TITLE
Declare boxed float term ABI

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -159,7 +159,10 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.file_read_lines", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.binary", &convert_term_binary/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.binary_from_list", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.float_lit", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.string_to_float", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.is_integer", &convert_term_predicate/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.is_float", &convert_term_predicate/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.is_atom", &convert_term_predicate/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.is_binary", &convert_term_predicate/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.is_list", &convert_term_predicate/3, version: "1.0")
@@ -286,7 +289,10 @@ defmodule Beaver.MLIR.Conversion.Ex do
     file_read: "ex.term.file_read",
     file_read_lines: "ex.term.file_read_lines",
     binary_from_list: "ex.term.binary_from_list",
+    float_lit: "ex.term.float_lit",
+    string_to_float: "ex.term.string_to_float",
     is_integer: "ex.term.is_integer",
+    is_float: "ex.term.is_float",
     is_atom: "ex.term.is_atom",
     is_binary: "ex.term.is_binary",
     is_list: "ex.term.is_list",
@@ -916,6 +922,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
   end
 
   defp predicate_intrinsic("ex.is_integer"), do: @term_intrinsics.is_integer
+  defp predicate_intrinsic("ex.is_float"), do: @term_intrinsics.is_float
   defp predicate_intrinsic("ex.is_atom"), do: @term_intrinsics.is_atom
   defp predicate_intrinsic("ex.is_binary"), do: @term_intrinsics.is_binary
   defp predicate_intrinsic("ex.is_list"), do: @term_intrinsics.is_list
@@ -932,6 +939,8 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.tuple_get"), do: @term_intrinsics.tuple_get
   defp read_intrinsic("ex.tuple_length"), do: @term_intrinsics.tuple_length
   defp read_intrinsic("ex.map_length"), do: @term_intrinsics.map_length
+  defp read_intrinsic("ex.float_lit"), do: @term_intrinsics.float_lit
+  defp read_intrinsic("ex.string_to_float"), do: @term_intrinsics.string_to_float
   defp read_intrinsic("ex.map_put"), do: @term_intrinsics.map_put
   defp read_intrinsic("ex.mapset_from_list"), do: @term_intrinsics.mapset_from_list
   defp read_intrinsic("ex.mapset_member"), do: @term_intrinsics.mapset_member

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -451,7 +451,16 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop binary_from_list(bytes = base(dyn())),
     results: [result: base(dyn())]
 
+  defop float_lit(bits = ^integer_like),
+    results: [result: base(dyn())]
+
+  defop string_to_float(binary = base(dyn())),
+    results: [result: base(dyn())]
+
   defop is_integer(value = ^any_value),
+    results: [result: ^integer_like]
+
+  defop is_float(value = ^any_value),
     results: [result: ^integer_like]
 
   defop is_atom(value = ^any_value),

--- a/lib/beaver/wasm/term_abi.ex
+++ b/lib/beaver/wasm/term_abi.ex
@@ -108,6 +108,7 @@ defmodule Beaver.Wasm.TermABI do
     "ex.term.to_int" => %{params: [:i64], result: :i64},
     "ex.term.eq" => %{params: [:i64, :i64], result: :i64},
     "ex.term.is_integer" => %{params: [:i64], result: :i64},
+    "ex.term.is_float" => %{params: [:i64], result: :i64},
     "ex.term.is_atom" => %{params: [:i64], result: :i64},
     "ex.term.is_binary" => %{params: [:i64], result: :i64},
     "ex.term.is_list" => %{params: [:i64], result: :i64},
@@ -129,6 +130,8 @@ defmodule Beaver.Wasm.TermABI do
     "ex.term.mapset_put" => %{params: [:i64, :i64], result: :i64},
     # binary
     "ex.term.binary_from_list" => %{params: [:i64], result: :i64},
+    "ex.term.float_lit" => %{params: [:i64], result: :i64},
+    "ex.term.string_to_float" => %{params: [:i64], result: :i64},
     "ex.term.binary_length" => %{params: [:i64], result: :i64},
     "ex.term.binary_get" => %{params: [:i64, :i64], result: :i64},
     "ex.term.binary_slice" => %{params: [:i64, :i64], result: :i64},

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -567,8 +567,10 @@ defmodule ExConversionTest do
             %6 = "ex.map_put"(%5, %2, %3) : (!ex.dyn, !ex.dyn, !ex.dyn) -> !ex.dyn
             %7 = "ex.binary"(%2, %3) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
             %8 = "ex.binary_from_list"(%4) : (!ex.dyn) -> !ex.dyn
-            %9 = "ex.is_list"(%4) : (!ex.dyn) -> i64
-            "ex.return"(%9) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+            %9 = "ex.float_lit"(%0) : (i64) -> !ex.dyn
+            %10 = "ex.string_to_float"(%7) : (!ex.dyn) -> !ex.dyn
+            %11 = "ex.is_list"(%4) : (!ex.dyn) -> i64
+            "ex.return"(%11) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
           }) {sym_name = "main"} : () -> ()
         }
         """,
@@ -582,6 +584,8 @@ defmodule ExConversionTest do
     assert rendered =~ "ex.term.map_from_list"
     assert rendered =~ "ex.term.map_put"
     assert rendered =~ "ex.term.binary_from_list"
+    assert rendered =~ "ex.term.float_lit"
+    assert rendered =~ "ex.term.string_to_float"
     assert rendered =~ "ex.term.is_list"
   end
 

--- a/test/wasm_term_abi_test.exs
+++ b/test/wasm_term_abi_test.exs
@@ -31,6 +31,9 @@ defmodule WasmTermABITest do
     assert TermABI.entry("ex.term.list_cons").params == [:i64, :i64]
     assert TermABI.entry("ex.term.list_cons").result == :i64
     assert TermABI.entry("ex.term.map_put").params == [:i64, :i64, :i64]
+    assert TermABI.entry("ex.term.float_lit").params == [:i64]
+    assert TermABI.entry("ex.term.is_float").params == [:i64]
+    assert TermABI.entry("ex.term.string_to_float").params == [:i64]
     assert TermABI.entry("ex.term.send").params == [:i64, :i64]
     assert TermABI.entry("ex.term.runtime_create").params == []
     assert TermABI.entry("ex.term.runtime_enter").params == [:i64]


### PR DESCRIPTION
## Summary

- declare boxed float literals, float predicates, and string-to-float operations in the `ex` dialect
- lower the operations to stable `ex.term.*` runtime symbols
- expose matching Wasm term ABI entries

## Validation

- `BEAVER_KINDA_PATH=/home/jackal/oss/kinda-main LLVM_CONFIG_PATH=/home/jackal/oss/beaver/priv/llvm-prebuilt/bin/llvm-config mix test test/ex_dialect_test.exs test/ex_conversion_test.exs test/wasm_term_abi_test.exs` (43 passed)

## Stack

1. this PR
2. batata-lang/batata `agent/float-runtime`
3. batata-lang/batata `agent/jason-float-corpus`