### PR TITLE
Declare the EX iodata flatten term ABI

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -159,6 +159,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.file_read_lines", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.binary", &convert_term_binary/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.binary_from_list", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.iodata_to_binary", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.float_lit", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.string_to_float", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.is_integer", &convert_term_predicate/3, version: "1.0")
@@ -289,6 +290,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     file_read: "ex.term.file_read",
     file_read_lines: "ex.term.file_read_lines",
     binary_from_list: "ex.term.binary_from_list",
+    iodata_to_binary: "ex.term.iodata_to_binary",
     float_lit: "ex.term.float_lit",
     string_to_float: "ex.term.string_to_float",
     is_integer: "ex.term.is_integer",
@@ -1028,6 +1030,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.process_result"), do: @term_intrinsics.process_result
   defp read_intrinsic("ex.binary_length"), do: @term_intrinsics.binary_length
   defp read_intrinsic("ex.binary_from_list"), do: @term_intrinsics.binary_from_list
+  defp read_intrinsic("ex.iodata_to_binary"), do: @term_intrinsics.iodata_to_binary
   defp read_intrinsic("ex.binary_get"), do: @term_intrinsics.binary_get
   defp read_intrinsic("ex.binary_slice"), do: @term_intrinsics.binary_slice
   defp read_intrinsic("ex.binary_utf8_get"), do: @term_intrinsics.binary_utf8_get

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -451,6 +451,9 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop binary_from_list(bytes = base(dyn())),
     results: [result: base(dyn())]
 
+  defop iodata_to_binary(iodata = base(dyn())),
+    results: [result: base(dyn())]
+
   defop float_lit(bits = ^integer_like),
     results: [result: base(dyn())]
 

--- a/lib/beaver/wasm/term_abi.ex
+++ b/lib/beaver/wasm/term_abi.ex
@@ -130,6 +130,7 @@ defmodule Beaver.Wasm.TermABI do
     "ex.term.mapset_put" => %{params: [:i64, :i64], result: :i64},
     # binary
     "ex.term.binary_from_list" => %{params: [:i64], result: :i64},
+    "ex.term.iodata_to_binary" => %{params: [:i64], result: :i64},
     "ex.term.float_lit" => %{params: [:i64], result: :i64},
     "ex.term.string_to_float" => %{params: [:i64], result: :i64},
     "ex.term.binary_length" => %{params: [:i64], result: :i64},

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -567,6 +567,7 @@ defmodule ExConversionTest do
             %6 = "ex.map_put"(%5, %2, %3) : (!ex.dyn, !ex.dyn, !ex.dyn) -> !ex.dyn
             %7 = "ex.binary"(%2, %3) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
             %8 = "ex.binary_from_list"(%4) : (!ex.dyn) -> !ex.dyn
+            %12 = "ex.iodata_to_binary"(%4) : (!ex.dyn) -> !ex.dyn
             %9 = "ex.float_lit"(%0) : (i64) -> !ex.dyn
             %10 = "ex.string_to_float"(%7) : (!ex.dyn) -> !ex.dyn
             %11 = "ex.is_list"(%4) : (!ex.dyn) -> i64
@@ -584,6 +585,7 @@ defmodule ExConversionTest do
     assert rendered =~ "ex.term.map_from_list"
     assert rendered =~ "ex.term.map_put"
     assert rendered =~ "ex.term.binary_from_list"
+    assert rendered =~ "ex.term.iodata_to_binary"
     assert rendered =~ "ex.term.float_lit"
     assert rendered =~ "ex.term.string_to_float"
     assert rendered =~ "ex.term.is_list"

--- a/test/wasm_term_abi_test.exs
+++ b/test/wasm_term_abi_test.exs
@@ -31,6 +31,7 @@ defmodule WasmTermABITest do
     assert TermABI.entry("ex.term.list_cons").params == [:i64, :i64]
     assert TermABI.entry("ex.term.list_cons").result == :i64
     assert TermABI.entry("ex.term.map_put").params == [:i64, :i64, :i64]
+    assert TermABI.entry("ex.term.iodata_to_binary").params == [:i64]
     assert TermABI.entry("ex.term.float_lit").params == [:i64]
     assert TermABI.entry("ex.term.is_float").params == [:i64]
     assert TermABI.entry("ex.term.string_to_float").params == [:i64]


### PR DESCRIPTION
## Summary

- declare ex.iodata_to_binary in the EX dialect
- register its conversion contract and runtime symbol
- publish the matching WASM term ABI signature

This is the Beaver half of the Jason encoder execution probe and supports the binary/iodata capability tracked in Forgejo beaver#54.

## Validation

- BEAVER_KINDA_PATH=/home/jackal/oss/kinda-main LLVM_CONFIG_PATH=/home/jackal/oss/beaver/priv/llvm-prebuilt/bin/llvm-config mix test test/ex_dialect_test.exs test/ex_conversion_test.exs test/wasm_term_abi_test.exs
- mix format --check-formatted
- git diff --check