### PR TITLE
Adopt Kinda comptime NIF adapters

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .kinda = .{
-            .url = "https://codeload.github.com/beaver-lodge/kinda/tar.gz/aa43cd03d266b43068b707e7a6aeae112ad49ad3",
-            .hash = "kinda-0.11.0-dev-ghcZCR2HAQBuQB_sPYBrSY7yKHmguKExLjE7AKim1bhU",
+            .url = "https://codeload.github.com/beaver-lodge/kinda/tar.gz/cb5a5021b1f7538ace89936f0449b4ef827c5a71",
+            .hash = "kinda-0.11.0-dev-ghcZCX7JAQAUTfcKNw06HoJbiMbw9KDcDh7oBvIECuzu",
         },
     },
     .paths = .{""},

--- a/kinda.ref
+++ b/kinda.ref
@@ -5,4 +5,4 @@
 # line, probes the revision on beaver-lodge/kinda, and falls back to the Hex
 # release when it is unavailable. Delete this file once the fixes land in a
 # Hex release.
-aa43cd03d266b43068b707e7a6aeae112ad49ad3
+cb5a5021b1f7538ace89936f0449b4ef827c5a71

--- a/native/src/action_tracing.zig
+++ b/native/src/action_tracing.zig
@@ -29,8 +29,6 @@ extern fn mlirBeaverActionTracingDrain(
 
 extern fn mlirBeaverActionTracingDetach(tracing: MlirBeaverActionTracing) void;
 
-var tracing_state_type: beam.resource_type = undefined;
-
 const TracingState = struct {
     tracing: MlirBeaverActionTracing,
 };
@@ -42,6 +40,12 @@ fn destroyTracingState(_: beam.env, object: ?*anyopaque) callconv(.c) void {
         state.tracing = .{ .ptr = null };
     }
 }
+
+const TracingStateResource = kinda.RawResourceType(
+    TracingState,
+    "Beaver.MLIR.ActionTracing",
+    destroyTracingState,
+);
 
 fn makeStringRef(env: beam.env, term: beam.term) !mlir_capi.StringRef.T {
     const bin = try beam.get_binary(env, term);
@@ -55,16 +59,17 @@ pub fn action_tracing_attach(env: beam.env, _: c_int, args: [*c]const beam.term)
     const skip_json = try makeStringRef(env, args[3]);
     const limit_json = try makeStringRef(env, args[4]);
 
-    const memory = e.enif_alloc_resource(tracing_state_type, @sizeOf(TracingState)) orelse
+    const state = TracingStateResource.alloc() catch
         return error.FailedToAllocateActionTracingState;
-    errdefer e.enif_release_resource(memory);
-    const state: *TracingState = @ptrCast(@alignCast(memory));
+    errdefer TracingStateResource.release(state);
 
     state.tracing =
         mlirBeaverActionTracingAttach(context, filter_json, location_json, skip_json, limit_json);
     if (state.tracing.ptr == null) return error.FailedToAttachActionTracing;
 
-    return e.enif_make_resource(env, state);
+    const term = e.enif_make_resource(env, state);
+    TracingStateResource.release(state);
+    return term;
 }
 
 fn drainCollector(data: [*c]const u8, user_data: ?*anyopaque) callconv(.c) void {
@@ -73,10 +78,8 @@ fn drainCollector(data: [*c]const u8, user_data: ?*anyopaque) callconv(.c) void 
 }
 
 pub fn action_tracing_drain(env: beam.env, _: c_int, args: [*c]const beam.term) !beam.term {
-    var object: ?*anyopaque = null;
-    if (e.enif_get_resource(env, args[0], tracing_state_type, @ptrCast(&object)) == 0)
+    const state = TracingStateResource.fetch(env, args[0]) catch
         return error.InvalidActionTracingState;
-    const state: *TracingState = @ptrCast(@alignCast(object.?));
 
     var buffer = std.array_list.Managed(u8).init(beam.allocator);
     defer buffer.deinit();
@@ -86,10 +89,8 @@ pub fn action_tracing_drain(env: beam.env, _: c_int, args: [*c]const beam.term) 
 }
 
 pub fn action_tracing_detach(env: beam.env, _: c_int, args: [*c]const beam.term) !beam.term {
-    var object: ?*anyopaque = null;
-    if (e.enif_get_resource(env, args[0], tracing_state_type, @ptrCast(&object)) == 0)
+    const state = TracingStateResource.fetch(env, args[0]) catch
         return error.InvalidActionTracingState;
-    const state: *TracingState = @ptrCast(@alignCast(object.?));
     if (state.tracing.ptr != null) {
         mlirBeaverActionTracingDetach(state.tracing);
         state.tracing = .{ .ptr = null };
@@ -98,16 +99,7 @@ pub fn action_tracing_detach(env: beam.env, _: c_int, args: [*c]const beam.term)
 }
 
 pub fn open(environment: beam.env) void {
-    tracing_state_type = e.enif_open_resource_type(
-        environment,
-        null,
-        "Beaver.MLIR.ActionTracing",
-        destroyTracingState,
-        e.ERL_NIF_RT_CREATE | e.ERL_NIF_RT_TAKEOVER,
-        null,
-    );
-    if (tracing_state_type == null)
-        @panic("failed to open action tracing state resource");
+    TracingStateResource.open(environment);
 }
 
 pub const nifs = .{

--- a/native/src/callback_bridge.zig
+++ b/native/src/callback_bridge.zig
@@ -14,12 +14,6 @@ const TransformDispatcher = kinda.callback_runtime.Dispatcher(.{ "apply", "allow
 const PatternDescriptorDispatcher = kinda.callback_runtime.Dispatcher(.{ "populate_patterns", "populate_patterns_with_state" });
 const DynamicTraitDispatcher = kinda.callback_runtime.Dispatcher(.{ "verify", "verify_regions" });
 
-var speculatability_state_type: beam.resource_type = undefined;
-var memory_effects_state_type: beam.resource_type = undefined;
-var transform_state_type: beam.resource_type = undefined;
-var pattern_descriptor_state_type: beam.resource_type = undefined;
-var dynamic_trait_state_type: beam.resource_type = undefined;
-
 fn notifyReleased(recipient: beam.pid) void {
     const environment = e.enif_alloc_env() orelse return;
     defer e.enif_free_env(environment);
@@ -364,6 +358,32 @@ const DynamicTraitState = struct {
     }
 };
 
+const SpeculatabilityStateResource = kinda.RawResourceType(
+    SpeculatabilityState,
+    "Beaver.MLIR.ConditionallySpeculatable.FallbackState",
+    destroyState(SpeculatabilityState),
+);
+const MemoryEffectsStateResource = kinda.RawResourceType(
+    MemoryEffectsState,
+    "Beaver.MLIR.MemoryEffects.FallbackState",
+    destroyState(MemoryEffectsState),
+);
+const TransformStateResource = kinda.RawResourceType(
+    TransformState,
+    "Beaver.MLIR.TransformOpInterface.FallbackState",
+    destroyState(TransformState),
+);
+const PatternDescriptorStateResource = kinda.RawResourceType(
+    PatternDescriptorState,
+    "Beaver.MLIR.PatternDescriptorOpInterface.FallbackState",
+    destroyState(PatternDescriptorState),
+);
+const DynamicTraitStateResource = kinda.RawResourceType(
+    DynamicTraitState,
+    "Beaver.MLIR.Trait.DynamicState",
+    destroyState(DynamicTraitState),
+);
+
 fn destroyState(comptime State: type) fn (beam.env, ?*anyopaque) callconv(.c) void {
     return struct {
         fn destroy(_: beam.env, object: ?*anyopaque) callconv(.c) void {
@@ -379,12 +399,10 @@ fn destroyState(comptime State: type) fn (beam.env, ?*anyopaque) callconv(.c) vo
 fn allocateState(
     comptime State: type,
     comptime Dispatcher: type,
-    resource_type: beam.resource_type,
+    comptime Resource: type,
     dispatcher: *Dispatcher,
 ) !*State {
-    const memory = e.enif_alloc_resource(resource_type, @sizeOf(State)) orelse
-        return error.FailedToAllocateExternalInterfaceState;
-    const state: *State = @ptrCast(@alignCast(memory));
+    const state = Resource.alloc() catch return error.FailedToAllocateExternalInterfaceState;
     state.* = .{ .dispatcher = dispatcher };
     return state;
 }
@@ -401,8 +419,8 @@ fn attachSpeculatabilityFallback(environment: beam.env, _: c_int, args: [*c]cons
     var dispatcher_owned = true;
     errdefer if (dispatcher_owned) dispatcher.deinit();
     dispatcher.setCallback("get_speculatability", args[2]);
-    const state = try allocateState(SpeculatabilityState, SpeculatabilityDispatcher, speculatability_state_type, dispatcher);
-    errdefer e.enif_release_resource(state);
+    const state = try allocateState(SpeculatabilityState, SpeculatabilityDispatcher, SpeculatabilityStateResource, dispatcher);
+    errdefer SpeculatabilityStateResource.release(state);
     dispatcher_owned = false;
     c.mlirConditionallySpeculatableOpInterfaceAttachFallbackModel(
         context,
@@ -430,8 +448,8 @@ fn attachMemoryEffectsFallback(environment: beam.env, _: c_int, args: [*c]const 
     var dispatcher_owned = true;
     errdefer if (dispatcher_owned) dispatcher.deinit();
     dispatcher.setCallback("get_effects", args[2]);
-    const state = try allocateState(MemoryEffectsState, MemoryEffectsDispatcher, memory_effects_state_type, dispatcher);
-    errdefer e.enif_release_resource(state);
+    const state = try allocateState(MemoryEffectsState, MemoryEffectsDispatcher, MemoryEffectsStateResource, dispatcher);
+    errdefer MemoryEffectsStateResource.release(state);
     dispatcher_owned = false;
     c.mlirMemoryEffectsOpInterfaceAttachFallbackModel(
         context,
@@ -461,8 +479,8 @@ fn attachTransformFallback(environment: beam.env, _: c_int, args: [*c]const beam
     dispatcher.setCallback("apply", args[2]);
     if (!beam.is_nil2(environment, args[3]))
         dispatcher.setCallback("allows_repeated_handle_operands", args[3]);
-    const state = try allocateState(TransformState, TransformDispatcher, transform_state_type, dispatcher);
-    errdefer e.enif_release_resource(state);
+    const state = try allocateState(TransformState, TransformDispatcher, TransformStateResource, dispatcher);
+    errdefer TransformStateResource.release(state);
     dispatcher_owned = false;
     c.mlirTransformOpInterfaceAttachFallbackModel(
         context,
@@ -493,8 +511,8 @@ fn attachPatternDescriptorFallback(environment: beam.env, _: c_int, args: [*c]co
     dispatcher.setCallback("populate_patterns", args[2]);
     if (!beam.is_nil2(environment, args[3]))
         dispatcher.setCallback("populate_patterns_with_state", args[3]);
-    const state = try allocateState(PatternDescriptorState, PatternDescriptorDispatcher, pattern_descriptor_state_type, dispatcher);
-    errdefer e.enif_release_resource(state);
+    const state = try allocateState(PatternDescriptorState, PatternDescriptorDispatcher, PatternDescriptorStateResource, dispatcher);
+    errdefer PatternDescriptorStateResource.release(state);
     dispatcher_owned = false;
     c.mlirPatternDescriptorOpInterfaceAttachFallbackModel(
         context,
@@ -532,10 +550,10 @@ fn attachDynamicTrait(environment: beam.env, _: c_int, args: [*c]const beam.term
     const state = try allocateState(
         DynamicTraitState,
         DynamicTraitDispatcher,
-        dynamic_trait_state_type,
+        DynamicTraitStateResource,
         dispatcher,
     );
-    errdefer if (dispatcher_owned) e.enif_release_resource(state);
+    errdefer if (dispatcher_owned) DynamicTraitStateResource.release(state);
     dispatcher_owned = false;
 
     // Add the BEAM-term reference before handing the allocation reference to
@@ -624,25 +642,22 @@ fn AsyncDiagnosticsNIF(comptime name: []const u8) type {
 
 fn releaseStateTerm(
     comptime State: type,
+    comptime Resource: type,
     environment: beam.env,
-    resource_type: beam.resource_type,
     term: beam.term,
 ) bool {
-    var object: ?*anyopaque = null;
-    if (e.enif_get_resource(environment, term, resource_type, @ptrCast(&object)) == 0)
-        return false;
-    const state: *State = @ptrCast(@alignCast(object orelse return false));
+    const state: *State = Resource.fetch(environment, term) catch return false;
     releaseModel(State, state);
     return true;
 }
 
 fn releaseExternalInterface(environment: beam.env, _: c_int, args: [*c]const beam.term) !beam.term {
     const released =
-        releaseStateTerm(SpeculatabilityState, environment, speculatability_state_type, args[0]) or
-        releaseStateTerm(MemoryEffectsState, environment, memory_effects_state_type, args[0]) or
-        releaseStateTerm(TransformState, environment, transform_state_type, args[0]) or
-        releaseStateTerm(PatternDescriptorState, environment, pattern_descriptor_state_type, args[0]) or
-        releaseStateTerm(DynamicTraitState, environment, dynamic_trait_state_type, args[0]);
+        releaseStateTerm(SpeculatabilityState, SpeculatabilityStateResource, environment, args[0]) or
+        releaseStateTerm(MemoryEffectsState, MemoryEffectsStateResource, environment, args[0]) or
+        releaseStateTerm(TransformState, TransformStateResource, environment, args[0]) or
+        releaseStateTerm(PatternDescriptorState, PatternDescriptorStateResource, environment, args[0]) or
+        releaseStateTerm(DynamicTraitState, DynamicTraitStateResource, environment, args[0]);
     if (!released) return error.InvalidExternalInterfaceState;
     return beam.make_ok(environment);
 }
@@ -725,49 +740,12 @@ fn transformStateParams(environment: beam.env, _: c_int, args: [*c]const beam.te
     );
 }
 
-fn openResourceType(
-    environment: beam.env,
-    comptime name: [*c]const u8,
-    destructor: e.ErlNifResourceDtor,
-) beam.resource_type {
-    const resource_type = e.enif_open_resource_type(
-        environment,
-        null,
-        name,
-        destructor,
-        e.ERL_NIF_RT_CREATE | e.ERL_NIF_RT_TAKEOVER,
-        null,
-    );
-    if (resource_type == null) @panic("failed to open external interface state resource");
-    return resource_type;
-}
-
 pub fn open(environment: beam.env) void {
-    speculatability_state_type = openResourceType(
-        environment,
-        "Beaver.MLIR.ConditionallySpeculatable.FallbackState",
-        destroyState(SpeculatabilityState),
-    );
-    memory_effects_state_type = openResourceType(
-        environment,
-        "Beaver.MLIR.MemoryEffects.FallbackState",
-        destroyState(MemoryEffectsState),
-    );
-    transform_state_type = openResourceType(
-        environment,
-        "Beaver.MLIR.TransformOpInterface.FallbackState",
-        destroyState(TransformState),
-    );
-    pattern_descriptor_state_type = openResourceType(
-        environment,
-        "Beaver.MLIR.PatternDescriptorOpInterface.FallbackState",
-        destroyState(PatternDescriptorState),
-    );
-    dynamic_trait_state_type = openResourceType(
-        environment,
-        "Beaver.MLIR.Trait.DynamicState",
-        destroyState(DynamicTraitState),
-    );
+    SpeculatabilityStateResource.open(environment);
+    MemoryEffectsStateResource.open(environment);
+    TransformStateResource.open(environment);
+    PatternDescriptorStateResource.open(environment);
+    DynamicTraitStateResource.open(environment);
 }
 
 pub const nifs = .{

--- a/native/src/conversion.zig
+++ b/native/src/conversion.zig
@@ -21,9 +21,6 @@ const PatternDispatcher = kinda.callback_runtime.Dispatcher(.{
     "conversion_pattern_1_to_n",
 });
 
-var target_registration_type: beam.resource_type = undefined;
-var type_converter_registration_type: beam.resource_type = undefined;
-
 fn handleSlice(
     comptime Kind: type,
     environment: beam.env,
@@ -186,22 +183,27 @@ fn destroyTargetRegistration(_: beam.env, object: ?*anyopaque) callconv(.c) void
     _ = registration.close();
 }
 
+const TargetRegistrationResource = kinda.RawResourceType(
+    TargetRegistration,
+    "Beaver.MLIR.ConversionTarget.Registration",
+    destroyTargetRegistration,
+);
+
 fn fetchTargetRegistration(environment: beam.env, term: beam.term) !*TargetRegistration {
-    return beam.fetch_resource_ptr(*TargetRegistration, environment, target_registration_type, term);
+    return TargetRegistrationResource.fetch(environment, term);
 }
 
 fn createTarget(environment: beam.env, _: c_int, args: [*c]const beam.term) !beam.term {
     const context = try mlir_capi.Context.resource.fetch(environment, args[0]);
-    const memory = e.enif_alloc_resource(target_registration_type, @sizeOf(TargetRegistration)) orelse
+    const registration = TargetRegistrationResource.alloc() catch
         return error.FailedToAllocateConversionTargetRegistration;
-    const registration: *TargetRegistration = @ptrCast(@alignCast(memory));
     registration.* = .{
         .target = c.mlirConversionTargetCreate(context),
         .context = context,
         .callbacks = std.array_list.Managed(*LegalityState).init(std.heap.smp_allocator),
     };
-    const registration_term = e.enif_make_resource(environment, memory);
-    e.enif_release_resource(memory);
+    const registration_term = e.enif_make_resource(environment, registration);
+    TargetRegistrationResource.release(registration);
     var terms = [_]beam.term{
         beam.make_atom(environment, "managed_conversion_target"),
         try mlir_capi.ConversionTarget.resource.make_kind(environment, registration.target),
@@ -549,20 +551,25 @@ fn destroyTypeConverterRegistration(_: beam.env, object: ?*anyopaque) callconv(.
     _ = registration.close();
 }
 
+const TypeConverterRegistrationResource = kinda.RawResourceType(
+    TypeConverterRegistration,
+    "Beaver.MLIR.TypeConverter.Registration",
+    destroyTypeConverterRegistration,
+);
+
 fn fetchTypeConverterRegistration(environment: beam.env, term: beam.term) !*TypeConverterRegistration {
-    return beam.fetch_resource_ptr(*TypeConverterRegistration, environment, type_converter_registration_type, term);
+    return TypeConverterRegistrationResource.fetch(environment, term);
 }
 
 fn createTypeConverter(environment: beam.env, _: c_int, _: [*c]const beam.term) !beam.term {
-    const memory = e.enif_alloc_resource(type_converter_registration_type, @sizeOf(TypeConverterRegistration)) orelse
+    const registration = TypeConverterRegistrationResource.alloc() catch
         return error.FailedToAllocateTypeConverterRegistration;
-    const registration: *TypeConverterRegistration = @ptrCast(@alignCast(memory));
     registration.* = .{
         .converter = c.mlirTypeConverterCreate(),
         .callbacks = std.array_list.Managed(*TypeCallbackState).init(std.heap.smp_allocator),
     };
-    const registration_term = e.enif_make_resource(environment, memory);
-    e.enif_release_resource(memory);
+    const registration_term = e.enif_make_resource(environment, registration);
+    TypeConverterRegistrationResource.release(registration);
     var terms = [_]beam.term{
         beam.make_atom(environment, "managed_type_converter"),
         try mlir_capi.TypeConverter.resource.make_kind(environment, registration.converter),
@@ -987,25 +994,8 @@ fn applyConversionAsync(environment: beam.env, _: c_int, args: [*c]const beam.te
 }
 
 pub fn open(environment: beam.env) void {
-    target_registration_type = e.enif_open_resource_type(
-        environment,
-        null,
-        "Beaver.MLIR.ConversionTarget.Registration",
-        destroyTargetRegistration,
-        e.ERL_NIF_RT_CREATE | e.ERL_NIF_RT_TAKEOVER,
-        null,
-    );
-    if (target_registration_type == null) @panic("failed to open conversion target registration resource");
-
-    type_converter_registration_type = e.enif_open_resource_type(
-        environment,
-        null,
-        "Beaver.MLIR.TypeConverter.Registration",
-        destroyTypeConverterRegistration,
-        e.ERL_NIF_RT_CREATE | e.ERL_NIF_RT_TAKEOVER,
-        null,
-    );
-    if (type_converter_registration_type == null) @panic("failed to open type converter registration resource");
+    TargetRegistrationResource.open(environment);
+    TypeConverterRegistrationResource.open(environment);
 }
 
 pub const nifs = .{

--- a/native/src/main.zig
+++ b/native/src/main.zig
@@ -79,44 +79,16 @@ export fn nif_upgrade(
 
 export fn nif_unload(_: beam.env, _: ?*anyopaque) void {}
 
-var entry: e.ErlNifEntry = undefined;
-
-fn nif_init_impl() *const e.ErlNifEntry {
-    const nifs = assembleNifs();
-    entry = e.ErlNifEntry{
-        .major = 2,
-        .minor = 16,
-        .name = mlir_capi.root_module,
-        .num_of_funcs = @intCast(nifs.len),
-        .funcs = nifs.ptr,
-        .load = nif_load,
-        .reload = null,
-        .upgrade = nif_upgrade,
-        .unload = nif_unload,
-        .vm_variant = "beam.vanilla",
-        .options = 1,
-        .sizeof_ErlNifResourceTypeInit = @sizeOf(e.ErlNifResourceTypeInit),
-        .min_erts = "erts-13.0",
-    };
-    return &entry;
-}
-
-fn nif_init_windows(callbacks: *const e.TWinDynNifCallbacks) callconv(.c) *const e.ErlNifEntry {
-    // Windows NIFs receive the emulator's enif_* function table through
-    // nif_init instead of exported symbols; copy it into the global that the
-    // windows_enif wrappers read.
-    e.WinDynNifCallbacks = callbacks.*;
-    return nif_init_impl();
-}
-
-fn nif_init_unix() callconv(.c) *const e.ErlNifEntry {
-    return nif_init_impl();
-}
+const entry_exports = kinda.DynamicEntryExports(.{
+    .name = mlir_capi.root_module,
+    .nifs_provider = assembleNifs,
+    .windows_callbacks_target = if (builtin.os.tag == .windows) &e.WinDynNifCallbacks else null,
+    .load = nif_load,
+    .upgrade = nif_upgrade,
+    .unload = nif_unload,
+    .min_erts = "erts-13.0",
+});
 
 comptime {
-    if (builtin.os.tag == .windows) {
-        @export(&nif_init_windows, .{ .name = "nif_init" });
-    } else {
-        @export(&nif_init_unix, .{ .name = "nif_init" });
-    }
+    _ = entry_exports;
 }

--- a/native/src/mlir_capi.zig
+++ b/native/src/mlir_capi.zig
@@ -159,7 +159,7 @@ pub const resourceSlots = blk: {
         tuple = tuple ++ &k.slots;
     }
     const reply_token_slots = [_]kinda.ResourceSlot{
-        .{ .name = kinda.callback_runtime.ReplyToken.resource_name, .t = &kinda.callback_runtime.ReplyToken.resource_type, .dtor = beam.destroy_do_nothing },
+        .{ .name = kinda.callback_runtime.ReplyToken.resource_name, .t = &kinda.callback_runtime.ReplyToken.resource.resource_type, .dtor = beam.destroy_do_nothing },
     };
     tuple = tuple ++ &reply_token_slots;
     break :blk tuple;


### PR DESCRIPTION
## Summary

- replace Beaver native entry boilerplate with Kinda DynamicEntryExports
- route Windows callbacks into Beaver shared enif shim for partitioned DLLs
- replace seven manually managed resource types with Kinda RawResourceType
- keep ReplyToken resource-slot synchronization on the new typed handle
- pin both Mix CI pairing and Zig package resolution to the paired Kinda revision

## Validation

- `zig fmt --check native build.zig`
- `mix format --check-formatted`
- `mix credo`
- test-environment `mix compile --force --warnings-as-errors`
- `mix test --warnings-as-errors --exclude vulkan --exclude todo` (431 passed, 5 skipped, 21 excluded)

Depends on merged Kinda PRs beaver-lodge/kinda#125 and beaver-lodge/kinda#126, plus beaver-lodge/kinda#128.