### PR TITLE
Add map fetch term operation

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -152,6 +152,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.list_cons", &convert_term_list_cons/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.map", &convert_term_map/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.map_put", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.map_fetch", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.mapset_from_list", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.mapset_member", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.mapset_put", &convert_term_read/3, version: "1.0")
@@ -212,6 +213,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
   @term_intrinsics %{
     list_cons: "ex.term.list_cons",
     map_put: "ex.term.map_put",
+    map_fetch: "ex.term.map_fetch",
     self: "ex.term.self",
     send: "ex.term.send",
     receive: "ex.term.receive",
@@ -944,6 +946,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.float_lit"), do: @term_intrinsics.float_lit
   defp read_intrinsic("ex.string_to_float"), do: @term_intrinsics.string_to_float
   defp read_intrinsic("ex.map_put"), do: @term_intrinsics.map_put
+  defp read_intrinsic("ex.map_fetch"), do: @term_intrinsics.map_fetch
   defp read_intrinsic("ex.mapset_from_list"), do: @term_intrinsics.mapset_from_list
   defp read_intrinsic("ex.mapset_member"), do: @term_intrinsics.mapset_member
   defp read_intrinsic("ex.mapset_put"), do: @term_intrinsics.mapset_put
@@ -1488,6 +1491,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
               "ex.term.binary_slice",
               "ex.term.binary_utf8_get",
               "ex.term.binary_utf8_width",
+              "ex.term.map_fetch",
               "ex.term.mapset_member",
               "ex.term.mapset_put",
               "ex.term.stream_take",

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -430,6 +430,9 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop map_put(map = base(dyn()), key = base(dyn()), value = base(dyn())),
     results: [result: base(dyn())]
 
+  defop map_fetch(map = base(dyn()), key = base(dyn())),
+    results: [result: base(dyn())]
+
   defop mapset_from_list(list = base(dyn())),
     results: [result: base(dyn())]
 

--- a/lib/beaver/wasm/term_abi.ex
+++ b/lib/beaver/wasm/term_abi.ex
@@ -123,6 +123,7 @@ defmodule Beaver.Wasm.TermABI do
     "ex.term.tuple_get" => %{params: [:i64, :i64], result: :i64},
     "ex.term.tuple_length" => %{params: [:i64], result: :i64},
     "ex.term.map_from_list" => %{params: [:i64], result: :i64},
+    "ex.term.map_fetch" => %{params: [:i64, :i64], result: :i64},
     "ex.term.map_put" => %{params: [:i64, :i64, :i64], result: :i64},
     "ex.term.map_length" => %{params: [:i64], result: :i64},
     "ex.term.mapset_from_list" => %{params: [:i64], result: :i64},

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -565,6 +565,7 @@ defmodule ExConversionTest do
             %4 = "ex.list"(%2, %3) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
             %5 = "ex.map"(%2, %3) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
             %6 = "ex.map_put"(%5, %2, %3) : (!ex.dyn, !ex.dyn, !ex.dyn) -> !ex.dyn
+            %13 = "ex.map_fetch"(%6, %2) : (!ex.dyn, !ex.dyn) -> !ex.dyn
             %7 = "ex.binary"(%2, %3) {operandSegmentSizes = array<i32: 2>} : (!ex.dyn, !ex.dyn) -> !ex.dyn
             %8 = "ex.binary_from_list"(%4) : (!ex.dyn) -> !ex.dyn
             %12 = "ex.iodata_to_binary"(%4) : (!ex.dyn) -> !ex.dyn
@@ -584,6 +585,7 @@ defmodule ExConversionTest do
     assert rendered =~ "ex.term.list_cons"
     assert rendered =~ "ex.term.map_from_list"
     assert rendered =~ "ex.term.map_put"
+    assert rendered =~ "ex.term.map_fetch"
     assert rendered =~ "ex.term.binary_from_list"
     assert rendered =~ "ex.term.iodata_to_binary"
     assert rendered =~ "ex.term.float_lit"

--- a/test/wasm_term_abi_test.exs
+++ b/test/wasm_term_abi_test.exs
@@ -31,6 +31,8 @@ defmodule WasmTermABITest do
     assert TermABI.entry("ex.term.list_cons").params == [:i64, :i64]
     assert TermABI.entry("ex.term.list_cons").result == :i64
     assert TermABI.entry("ex.term.map_put").params == [:i64, :i64, :i64]
+    assert TermABI.entry("ex.term.map_fetch").params == [:i64, :i64]
+    assert TermABI.entry("ex.term.map_fetch").result == :i64
     assert TermABI.entry("ex.term.iodata_to_binary").params == [:i64]
     assert TermABI.entry("ex.term.float_lit").params == [:i64]
     assert TermABI.entry("ex.term.is_float").params == [:i64]


### PR DESCRIPTION
## Summary

- add `ex.map_fetch` and lower it to `ex.term.map_fetch`
- declare the two-argument Wasm term ABI
- cover conversion and ABI manifest behavior

## Why

Batata map-pattern lowering needs a lookup primitive whose runtime result can distinguish a missing key from a present key whose value is `nil`. The runtime will encode that distinction in the returned dynamic term.

## Validation

- `mix format --check-formatted ...`
- focused tests are delegated to CI because this host has no `llvm-config`