### PR TITLE
Add typed EX raise operation

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -94,6 +94,12 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.result_destroy", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.result_root_kind", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.result_root_word", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.result_exception_kind", &convert_term_read/3,
+      version: "1.0"
+    )
+    |> Plan.add_conversion_pattern("ex.result_exception_reason", &convert_term_read/3,
+      version: "1.0"
+    )
     |> Plan.add_conversion_pattern("ex.result_term_kind", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.result_term_length", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.result_term_get", &convert_term_read/3, version: "1.0")
@@ -144,6 +150,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.yield_mark", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.try", &convert_try/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.throw", &convert_throw/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.raise", &convert_raise/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.catch_value", &convert_catch_value/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.make_fun", &convert_make_fun/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.apply", &convert_apply/3, version: "1.0")
@@ -227,6 +234,8 @@ defmodule Beaver.MLIR.Conversion.Ex do
     result_destroy: "ex.term.result_destroy",
     result_root_kind: "ex.term.result_root_kind",
     result_root_word: "ex.term.result_root_word",
+    result_exception_kind: "ex.term.result_exception_kind",
+    result_exception_reason: "ex.term.result_exception_reason",
     result_term_kind: "ex.term.result_term_kind",
     result_term_length: "ex.term.result_term_length",
     result_term_get: "ex.term.result_term_get",
@@ -280,6 +289,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     try_push: "ex.term.try_push",
     try_pop: "ex.term.try_pop",
     throw: "ex.term.throw",
+    raise: "ex.term.raise",
     catch_value: "ex.term.catch_value",
     make_fun: "ex.term.make_fun",
     fun_idx: "ex.term.fun_idx",
@@ -832,6 +842,16 @@ defmodule Beaver.MLIR.Conversion.Ex do
     )
   end
 
+  defp convert_raise(operation, [reason, kind], rewriter) do
+    base = insertion_point(operation, rewriter)
+
+    replace_with(
+      rewriter,
+      operation,
+      emit_runtime_call(operation, rewriter, base, @term_intrinsics.raise, [reason, kind])
+    )
+  end
+
   defp convert_catch_value(operation, [], rewriter) do
     base = insertion_point(operation, rewriter)
 
@@ -987,6 +1007,8 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.result_destroy"), do: @term_intrinsics.result_destroy
   defp read_intrinsic("ex.result_root_kind"), do: @term_intrinsics.result_root_kind
   defp read_intrinsic("ex.result_root_word"), do: @term_intrinsics.result_root_word
+  defp read_intrinsic("ex.result_exception_kind"), do: @term_intrinsics.result_exception_kind
+  defp read_intrinsic("ex.result_exception_reason"), do: @term_intrinsics.result_exception_reason
   defp read_intrinsic("ex.result_term_kind"), do: @term_intrinsics.result_term_kind
   defp read_intrinsic("ex.result_term_length"), do: @term_intrinsics.result_term_length
   defp read_intrinsic("ex.result_term_get"), do: @term_intrinsics.result_term_get
@@ -1252,7 +1274,9 @@ defmodule Beaver.MLIR.Conversion.Ex do
        when symbol in [
               "ex.term.result_destroy",
               "ex.term.result_root_kind",
-              "ex.term.result_root_word"
+              "ex.term.result_root_word",
+              "ex.term.result_exception_kind",
+              "ex.term.result_exception_reason"
             ] do
     MLIR.Type.function([MLIR.Type.i64()], [MLIR.Type.i64()])
   end
@@ -1418,6 +1442,10 @@ defmodule Beaver.MLIR.Conversion.Ex do
 
   defp intrinsic_function_type("ex.term.catch_value", _ctx) do
     MLIR.Type.function([], [MLIR.Type.i64()])
+  end
+
+  defp intrinsic_function_type("ex.term.raise", _ctx) do
+    MLIR.Type.function([MLIR.Type.i64(), MLIR.Type.i64()], [MLIR.Type.i64()])
   end
 
   defp intrinsic_function_type("ex.term.make_fun", _ctx) do

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -187,6 +187,12 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop result_root_word(handle = ^integer_like),
     results: [result: ^integer_like]
 
+  defop result_exception_kind(handle = ^integer_like),
+    results: [result: ^integer_like]
+
+  defop result_exception_reason(handle = ^integer_like),
+    results: [result: base(dyn())]
+
   defop result_term_kind(handle = ^integer_like, word = ^integer_like),
     results: [result: ^integer_like]
 
@@ -385,6 +391,12 @@ defmodule Beaver.MLIR.Dialect.Ex do
     regions: [:any, :any]
 
   defop throw(value = base(dyn())),
+    results: [result: base(dyn())]
+
+  # Raises a typed runtime exception. Unlike `throw`, this bypasses user catch
+  # regions; `kind` is a runtime-defined integer discriminator and `reason`
+  # carries the exception payload.
+  defop raise(reason = base(dyn()), kind = ^integer_like),
     results: [result: base(dyn())]
 
   defop catch_value(),

--- a/lib/beaver/wasm/term_abi.ex
+++ b/lib/beaver/wasm/term_abi.ex
@@ -63,6 +63,8 @@ defmodule Beaver.Wasm.TermABI do
     "ex.term.result_destroy" => %{params: [:i64], result: :i64},
     "ex.term.result_root_kind" => %{params: [:i64], result: :i64},
     "ex.term.result_root_word" => %{params: [:i64], result: :i64},
+    "ex.term.result_exception_kind" => %{params: [:i64], result: :i64},
+    "ex.term.result_exception_reason" => %{params: [:i64], result: :i64},
     "ex.term.result_term_kind" => %{params: [:i64, :i64], result: :i64},
     "ex.term.result_term_length" => %{params: [:i64, :i64], result: :i64},
     "ex.term.result_term_get" => %{params: [:i64, :i64, :i64], result: :i64},
@@ -172,6 +174,7 @@ defmodule Beaver.Wasm.TermABI do
     "ex.term.try_push" => %{params: [:ptr], result: :i64},
     "ex.term.try_pop" => %{params: [], result: :i64},
     "ex.term.throw" => %{params: [:i64], result: :void},
+    "ex.term.raise" => %{params: [:i64, :i64], result: :void},
     "ex.term.catch_value" => %{params: [], result: :i64}
   }
 

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -551,6 +551,30 @@ defmodule ExConversionTest do
     assert rendered =~ "arith.shli"
   end
 
+  test "converts typed raises to a distinct runtime ABI call", %{ctx: ctx} do
+    module =
+      term_module!(
+        ~S"""
+        module {
+          "ex.func"() ({
+          ^bb0:
+            %0 = "ex.lit"() {value = 7 : i64} : () -> i64
+            %1 = "ex.box"(%0) : (i64) -> !ex.dyn
+            %2 = "ex.raise"(%1, %0) : (!ex.dyn, i64) -> !ex.dyn
+            "ex.return"(%2) {operandSegmentSizes = array<i32: 1>} : (!ex.dyn) -> ()
+          }) {sym_name = "main"} : () -> ()
+        }
+        """,
+        ctx
+      )
+
+    assert {:ok, _module, []} = Plan.run(Ex.plan(), module)
+
+    rendered = MLIR.to_string(module, generic: true)
+    assert rendered =~ "ex.term.raise"
+    refute rendered =~ "ex.term.throw"
+  end
+
   test "converts list, map and binary construction to runtime ABI calls", %{ctx: ctx} do
     module =
       term_module!(

--- a/test/wasm_term_abi_test.exs
+++ b/test/wasm_term_abi_test.exs
@@ -42,6 +42,8 @@ defmodule WasmTermABITest do
     assert TermABI.entry("ex.term.runtime_enter").params == [:i64]
     assert TermABI.entry("ex.term.runtime_leave").params == []
     assert TermABI.entry("ex.term.runtime_destroy").params == [:i64]
+    assert TermABI.entry("ex.term.result_exception_kind").params == [:i64]
+    assert TermABI.entry("ex.term.result_exception_reason").params == [:i64]
     assert TermABI.entry("ex.term.export").params == [:i64, :i64]
     assert TermABI.entry("ex.term.import").params == [:i64, :i64]
     assert TermABI.entry("ex.term.handle_destroy").params == [:i64]
@@ -54,6 +56,8 @@ defmodule WasmTermABITest do
     assert TermABI.entry("ex.term.try_push").params == [:ptr]
     assert TermABI.entry("ex.term.throw").params == [:i64]
     assert TermABI.entry("ex.term.throw").result == :void
+    assert TermABI.entry("ex.term.raise").params == [:i64, :i64]
+    assert TermABI.entry("ex.term.raise").result == :void
     assert TermABI.entry("ex.term.make_fun").params == [:i64, :i64, :i64, :i64, :i64, :i64]
   end
 
@@ -63,5 +67,6 @@ defmodule WasmTermABITest do
     assert rendered =~ "## ex.term.* wasm host imports"
     assert rendered =~ "| `ex.term.list_cons` | `ex_term` | `(i64, i64) -> i64` |"
     assert rendered =~ "| `ex.term.throw` | `ex_term` | `(i64) -> noreturn` |"
+    assert rendered =~ "| `ex.term.raise` | `ex_term` | `(i64, i64) -> noreturn` |"
   end
 end


### PR DESCRIPTION
## Summary

- add a typed `ex.raise` operation distinct from `ex.throw`
- lower it to the dedicated `ex.term.raise(reason, kind)` runtime contract
- declare and test the Wasm host ABI

## Why

Runtime exceptions must bypass user `catch` frames. Encoding exception kinds inside ordinary thrown terms would be forgeable and would give explicit `throw/1` the wrong semantics.

## Validation

- `mix format --check-formatted`
- focused tests are covered by CI; local native compilation was blocked because this machine has no `llvm-config`