### PR TITLE
Fix exception reason accessor type

### DIFF
--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -191,7 +191,7 @@ defmodule Beaver.MLIR.Dialect.Ex do
     results: [result: ^integer_like]
 
   defop result_exception_reason(handle = ^integer_like),
-    results: [result: base(dyn())]
+    results: [result: ^integer_like]
 
   defop result_term_kind(handle = ^integer_like, word = ^integer_like),
     results: [result: ^integer_like]


### PR DESCRIPTION
## Summary

Declare `ex.result_exception_reason` as the integer word returned by its host accessor wrapper.

## Root cause

The operation was declared as `!ex.dyn`, while Batata result accessors expose ABI words as `i64`. This made every module containing the accessor fail MLIR verification.

## Validation

The failure was reproduced through Batata JIT tests; Beaver CI covers dialect verification on all supported platforms.