### PR TITLE
Add string printable term intrinsic

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -209,6 +209,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.binary_utf8_get", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.binary_utf8_width", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.binary_utf8_length", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.string_printable", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.binary_encode16", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.binary_decode16", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.int_to_string", &convert_term_read/3, version: "1.0")
@@ -337,6 +338,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     binary_utf8_get: "ex.term.binary_utf8_get",
     binary_utf8_width: "ex.term.binary_utf8_width",
     binary_utf8_length: "ex.term.binary_utf8_length",
+    string_printable: "ex.term.string_printable",
     binary_encode16: "ex.term.binary_encode16",
     binary_decode16: "ex.term.binary_decode16",
     int_to_string: "ex.term.int_to_string",
@@ -1061,6 +1063,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.binary_utf8_get"), do: @term_intrinsics.binary_utf8_get
   defp read_intrinsic("ex.binary_utf8_width"), do: @term_intrinsics.binary_utf8_width
   defp read_intrinsic("ex.binary_utf8_length"), do: @term_intrinsics.binary_utf8_length
+  defp read_intrinsic("ex.string_printable"), do: @term_intrinsics.string_printable
   defp read_intrinsic("ex.binary_encode16"), do: @term_intrinsics.binary_encode16
   defp read_intrinsic("ex.binary_decode16"), do: @term_intrinsics.binary_decode16
   defp read_intrinsic("ex.int_to_string"), do: @term_intrinsics.int_to_string

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -611,6 +611,9 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop binary_utf8_length(binary = base(dyn())),
     results: [result: ^integer_like]
 
+  defop string_printable(binary = base(dyn())),
+    results: [result: ^integer_like]
+
   defop binary_encode16(binary = base(dyn())),
     results: [result: base(dyn())]
 

--- a/lib/beaver/wasm/term_abi.ex
+++ b/lib/beaver/wasm/term_abi.ex
@@ -142,6 +142,7 @@ defmodule Beaver.Wasm.TermABI do
     "ex.term.binary_utf8_get" => %{params: [:i64, :i64], result: :i64},
     "ex.term.binary_utf8_width" => %{params: [:i64, :i64], result: :i64},
     "ex.term.binary_utf8_length" => %{params: [:i64], result: :i64},
+    "ex.term.string_printable" => %{params: [:i64], result: :i64},
     "ex.term.binary_encode16" => %{params: [:i64], result: :i64},
     "ex.term.binary_decode16" => %{params: [:i64], result: :i64},
     "ex.term.int_to_string" => %{params: [:i64], result: :i64},

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -636,7 +636,8 @@ defmodule ExConversionTest do
             %9 = "ex.list_head"(%5) : (!ex.dyn) -> !ex.dyn
             %10 = "ex.list_tail"(%5) : (!ex.dyn) -> !ex.dyn
             %11 = "ex.term_eq"(%7, %2) : (!ex.dyn, !ex.dyn) -> i64
-            "ex.return"(%11) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+            %12 = "ex.string_printable"(%2) : (!ex.dyn) -> i64
+            "ex.return"(%12) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
           }) {sym_name = "main"} : () -> ()
         }
         """,
@@ -652,6 +653,7 @@ defmodule ExConversionTest do
     assert rendered =~ "ex.term.list_head"
     assert rendered =~ "ex.term.list_tail"
     assert rendered =~ "ex.term.eq"
+    assert rendered =~ "ex.term.string_printable"
   end
 
   test "converts binary read ops to Zig runtime ABI calls", %{ctx: ctx} do

--- a/test/wasm_term_abi_test.exs
+++ b/test/wasm_term_abi_test.exs
@@ -37,6 +37,8 @@ defmodule WasmTermABITest do
     assert TermABI.entry("ex.term.float_lit").params == [:i64]
     assert TermABI.entry("ex.term.is_float").params == [:i64]
     assert TermABI.entry("ex.term.string_to_float").params == [:i64]
+    assert TermABI.entry("ex.term.string_printable").params == [:i64]
+    assert TermABI.entry("ex.term.string_printable").result == :i64
     assert TermABI.entry("ex.term.send").params == [:i64, :i64]
     assert TermABI.entry("ex.term.runtime_create").params == []
     assert TermABI.entry("ex.term.runtime_enter").params == [:i64]


### PR DESCRIPTION
## Summary
- declare `ex.string_printable` in the Ex dialect
- lower it to the `ex.term.string_printable` runtime intrinsic
- expose the intrinsic through the Wasm term ABI manifest

This is the compiler-side prerequisite for Batata to implement exact `String.printable?/1` semantics in its term runtime.

## Verification
- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix test test/ex_conversion_test.exs test/wasm_term_abi_test.exs --warnings-as-errors` (32 tests)
- `mix credo --strict` reports only the repository existing baseline findings; changed files introduce no new finding