### PR TITLE
Add bounded inspect format intrinsics

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -210,9 +210,11 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.binary_utf8_width", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.binary_utf8_length", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.string_printable", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.binary_quote", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.binary_encode16", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.binary_decode16", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.int_to_string", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.int_to_hex", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.string_to_int", &convert_term_read/3, version: "1.0")
   end
 
@@ -339,9 +341,11 @@ defmodule Beaver.MLIR.Conversion.Ex do
     binary_utf8_width: "ex.term.binary_utf8_width",
     binary_utf8_length: "ex.term.binary_utf8_length",
     string_printable: "ex.term.string_printable",
+    binary_quote: "ex.term.binary_quote",
     binary_encode16: "ex.term.binary_encode16",
     binary_decode16: "ex.term.binary_decode16",
     int_to_string: "ex.term.int_to_string",
+    int_to_hex: "ex.term.int_to_hex",
     string_to_int: "ex.term.string_to_int"
   }
 
@@ -1064,9 +1068,11 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.binary_utf8_width"), do: @term_intrinsics.binary_utf8_width
   defp read_intrinsic("ex.binary_utf8_length"), do: @term_intrinsics.binary_utf8_length
   defp read_intrinsic("ex.string_printable"), do: @term_intrinsics.string_printable
+  defp read_intrinsic("ex.binary_quote"), do: @term_intrinsics.binary_quote
   defp read_intrinsic("ex.binary_encode16"), do: @term_intrinsics.binary_encode16
   defp read_intrinsic("ex.binary_decode16"), do: @term_intrinsics.binary_decode16
   defp read_intrinsic("ex.int_to_string"), do: @term_intrinsics.int_to_string
+  defp read_intrinsic("ex.int_to_hex"), do: @term_intrinsics.int_to_hex
   defp read_intrinsic("ex.string_to_int"), do: @term_intrinsics.string_to_int
 
   defp insertion_point(operation, rewriter) do

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -614,6 +614,9 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop string_printable(binary = base(dyn())),
     results: [result: ^integer_like]
 
+  defop binary_quote(binary = base(dyn())),
+    results: [result: base(dyn())]
+
   defop binary_encode16(binary = base(dyn())),
     results: [result: base(dyn())]
 
@@ -621,6 +624,9 @@ defmodule Beaver.MLIR.Dialect.Ex do
     results: [result: base(dyn())]
 
   defop int_to_string(word = base(dyn())),
+    results: [result: base(dyn())]
+
+  defop int_to_hex(word = base(dyn())),
     results: [result: base(dyn())]
 
   defop string_to_int(binary = base(dyn())),

--- a/lib/beaver/wasm/term_abi.ex
+++ b/lib/beaver/wasm/term_abi.ex
@@ -143,9 +143,11 @@ defmodule Beaver.Wasm.TermABI do
     "ex.term.binary_utf8_width" => %{params: [:i64, :i64], result: :i64},
     "ex.term.binary_utf8_length" => %{params: [:i64], result: :i64},
     "ex.term.string_printable" => %{params: [:i64], result: :i64},
+    "ex.term.binary_quote" => %{params: [:i64], result: :i64},
     "ex.term.binary_encode16" => %{params: [:i64], result: :i64},
     "ex.term.binary_decode16" => %{params: [:i64], result: :i64},
     "ex.term.int_to_string" => %{params: [:i64], result: :i64},
+    "ex.term.int_to_hex" => %{params: [:i64], result: :i64},
     "ex.term.string_to_int" => %{params: [:i64], result: :i64},
     # file IO
     "ex.term.file_read" => %{params: [:i64], result: :i64},

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -637,6 +637,8 @@ defmodule ExConversionTest do
             %10 = "ex.list_tail"(%5) : (!ex.dyn) -> !ex.dyn
             %11 = "ex.term_eq"(%7, %2) : (!ex.dyn, !ex.dyn) -> i64
             %12 = "ex.string_printable"(%2) : (!ex.dyn) -> i64
+            %13 = "ex.binary_quote"(%2) : (!ex.dyn) -> !ex.dyn
+            %14 = "ex.int_to_hex"(%2) : (!ex.dyn) -> !ex.dyn
             "ex.return"(%12) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
           }) {sym_name = "main"} : () -> ()
         }
@@ -654,6 +656,8 @@ defmodule ExConversionTest do
     assert rendered =~ "ex.term.list_tail"
     assert rendered =~ "ex.term.eq"
     assert rendered =~ "ex.term.string_printable"
+    assert rendered =~ "ex.term.binary_quote"
+    assert rendered =~ "ex.term.int_to_hex"
   end
 
   test "converts binary read ops to Zig runtime ABI calls", %{ctx: ctx} do

--- a/test/wasm_term_abi_test.exs
+++ b/test/wasm_term_abi_test.exs
@@ -39,6 +39,10 @@ defmodule WasmTermABITest do
     assert TermABI.entry("ex.term.string_to_float").params == [:i64]
     assert TermABI.entry("ex.term.string_printable").params == [:i64]
     assert TermABI.entry("ex.term.string_printable").result == :i64
+    assert TermABI.entry("ex.term.binary_quote").params == [:i64]
+    assert TermABI.entry("ex.term.binary_quote").result == :i64
+    assert TermABI.entry("ex.term.int_to_hex").params == [:i64]
+    assert TermABI.entry("ex.term.int_to_hex").result == :i64
     assert TermABI.entry("ex.term.send").params == [:i64, :i64]
     assert TermABI.entry("ex.term.runtime_create").params == []
     assert TermABI.entry("ex.term.runtime_enter").params == [:i64]


### PR DESCRIPTION
## Summary

- declare narrow `ex.binary_quote` and `ex.int_to_hex` operations
- lower them to the term runtime ABI
- expose matching Wasm import signatures
- cover conversion and ABI lookup

These primitives support bounded formatting without introducing Elixir Inspect protocol semantics into Beaver.

## Verification

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix test test/ex_conversion_test.exs test/wasm_term_abi_test.exs --warnings-as-errors` (32 passed)
- `mix credo --strict` (repository baseline only: 5 refactoring, 79 readability, 188 design findings)