### PR TITLE
Add loose term equality intrinsic

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -203,6 +203,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     |> Plan.add_conversion_pattern("ex.list_get", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.list_length", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.term_eq", &convert_term_read/3, version: "1.0")
+    |> Plan.add_conversion_pattern("ex.term_eq_loose", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.binary_length", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.binary_get", &convert_term_read/3, version: "1.0")
     |> Plan.add_conversion_pattern("ex.binary_slice", &convert_term_read/3, version: "1.0")
@@ -334,6 +335,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
     list_get: "ex.term.list_get",
     list_length: "ex.term.list_length",
     term_eq: "ex.term.eq",
+    term_eq_loose: "ex.term.eq_loose",
     binary_length: "ex.term.binary_length",
     binary_get: "ex.term.binary_get",
     binary_slice: "ex.term.binary_slice",
@@ -1001,6 +1003,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
   defp read_intrinsic("ex.list_get"), do: @term_intrinsics.list_get
   defp read_intrinsic("ex.list_length"), do: @term_intrinsics.list_length
   defp read_intrinsic("ex.term_eq"), do: @term_intrinsics.term_eq
+  defp read_intrinsic("ex.term_eq_loose"), do: @term_intrinsics.term_eq_loose
   defp read_intrinsic("ex.reduction_tick"), do: @term_intrinsics.reduction_tick
   defp read_intrinsic("ex.clock_init"), do: @term_intrinsics.clock_init
   defp read_intrinsic("ex.yield_mark"), do: @term_intrinsics.yield_mark

--- a/lib/beaver/mlir/dialect/ex.ex
+++ b/lib/beaver/mlir/dialect/ex.ex
@@ -590,6 +590,9 @@ defmodule Beaver.MLIR.Dialect.Ex do
   defop term_eq(left = base(dyn()), right = base(dyn())),
     results: [result: ^integer_like]
 
+  defop term_eq_loose(left = base(dyn()), right = base(dyn())),
+    results: [result: ^integer_like]
+
   defop binary_length(binary = base(dyn())),
     results: [result: ^integer_like]
 

--- a/lib/beaver/wasm/term_abi.ex
+++ b/lib/beaver/wasm/term_abi.ex
@@ -109,6 +109,7 @@ defmodule Beaver.Wasm.TermABI do
     # term construction / inspection
     "ex.term.to_int" => %{params: [:i64], result: :i64},
     "ex.term.eq" => %{params: [:i64, :i64], result: :i64},
+    "ex.term.eq_loose" => %{params: [:i64, :i64], result: :i64},
     "ex.term.is_integer" => %{params: [:i64], result: :i64},
     "ex.term.is_float" => %{params: [:i64], result: :i64},
     "ex.term.is_atom" => %{params: [:i64], result: :i64},

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -636,10 +636,11 @@ defmodule ExConversionTest do
             %9 = "ex.list_head"(%5) : (!ex.dyn) -> !ex.dyn
             %10 = "ex.list_tail"(%5) : (!ex.dyn) -> !ex.dyn
             %11 = "ex.term_eq"(%7, %2) : (!ex.dyn, !ex.dyn) -> i64
-            %12 = "ex.string_printable"(%2) : (!ex.dyn) -> i64
-            %13 = "ex.binary_quote"(%2) : (!ex.dyn) -> !ex.dyn
-            %14 = "ex.int_to_hex"(%2) : (!ex.dyn) -> !ex.dyn
-            "ex.return"(%12) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
+            %12 = "ex.term_eq_loose"(%7, %2) : (!ex.dyn, !ex.dyn) -> i64
+            %13 = "ex.string_printable"(%2) : (!ex.dyn) -> i64
+            %14 = "ex.binary_quote"(%2) : (!ex.dyn) -> !ex.dyn
+            %15 = "ex.int_to_hex"(%2) : (!ex.dyn) -> !ex.dyn
+            "ex.return"(%13) {operandSegmentSizes = array<i32: 1>} : (i64) -> ()
           }) {sym_name = "main"} : () -> ()
         }
         """,
@@ -655,6 +656,7 @@ defmodule ExConversionTest do
     assert rendered =~ "ex.term.list_head"
     assert rendered =~ "ex.term.list_tail"
     assert rendered =~ "ex.term.eq"
+    assert rendered =~ "ex.term.eq_loose"
     assert rendered =~ "ex.term.string_printable"
     assert rendered =~ "ex.term.binary_quote"
     assert rendered =~ "ex.term.int_to_hex"

--- a/test/wasm_term_abi_test.exs
+++ b/test/wasm_term_abi_test.exs
@@ -30,6 +30,8 @@ defmodule WasmTermABITest do
   test "declares term signatures" do
     assert TermABI.entry("ex.term.list_cons").params == [:i64, :i64]
     assert TermABI.entry("ex.term.list_cons").result == :i64
+    assert TermABI.entry("ex.term.eq_loose").params == [:i64, :i64]
+    assert TermABI.entry("ex.term.eq_loose").result == :i64
     assert TermABI.entry("ex.term.map_put").params == [:i64, :i64, :i64]
     assert TermABI.entry("ex.term.map_fetch").params == [:i64, :i64]
     assert TermABI.entry("ex.term.map_fetch").result == :i64


### PR DESCRIPTION
## Summary

- add `ex.term_eq_loose` to the Ex dialect
- lower it to the `ex.term.eq_loose` runtime symbol
- expose the same signature through the Wasm term ABI

## Why

Batata needs BEAM-compatible loose equality for `:lists.keyfind/3`, including recursive numeric comparison such as `1 == 1.0`. Beaver owns the portable IR and import contract; the concrete runtime implementation remains in Batata.

## Validation

- `mix format --check-formatted`
- `mix test test/ex_conversion_test.exs test/wasm_term_abi_test.exs` (32 tests)
