### PR TITLE
Fix loose equality intrinsic arity

### DIFF
--- a/lib/beaver/mlir/conversion/ex.ex
+++ b/lib/beaver/mlir/conversion/ex.ex
@@ -1527,6 +1527,7 @@ defmodule Beaver.MLIR.Conversion.Ex do
               "ex.term.tuple_get",
               "ex.term.list_get",
               "ex.term.eq",
+              "ex.term.eq_loose",
               "ex.term.binary_get",
               "ex.term.binary_slice",
               "ex.term.binary_utf8_get",

--- a/test/ex_conversion_test.exs
+++ b/test/ex_conversion_test.exs
@@ -657,6 +657,10 @@ defmodule ExConversionTest do
     assert rendered =~ "ex.term.list_tail"
     assert rendered =~ "ex.term.eq"
     assert rendered =~ "ex.term.eq_loose"
+
+    assert rendered =~
+             ~s|function_type = (i64, i64) -> i64, sym_name = "ex.term.eq_loose"|
+
     assert rendered =~ "ex.term.string_printable"
     assert rendered =~ "ex.term.binary_quote"
     assert rendered =~ "ex.term.int_to_hex"


### PR DESCRIPTION
## Summary

- declare `ex.term.eq_loose` with its actual two-argument runtime ABI
- cover the intrinsic declaration so future verifier regressions fail locally

This is a follow-up to #647. The loose equality operation lowered correctly,
but its generated `func.func` declaration inherited the one-argument default,
so any real call failed MLIR verification.

## Test plan

- `mix test test/beaver/mlir/ex_conversion_test.exs`
